### PR TITLE
fix: catch aggregate exceptions from KMS

### DIFF
--- a/smithy-dotnet/src/main/java/software/amazon/polymorph/smithydotnet/AwsSdkShimCodegen.java
+++ b/smithy-dotnet/src/main/java/software/amazon/polymorph/smithydotnet/AwsSdkShimCodegen.java
@@ -108,6 +108,7 @@ public class AwsSdkShimCodegen {
 
         final TokenTree tryBody = TokenTree.of(assignSdkResponse, callImpl, returnResponse).lineSeparated();
         final TokenTree tryBlock = Token.of("try").append(tryBody.braced());
+        // TODO fix tests
         final String baseExceptionForService = nameResolver.baseExceptionForService();
         final TokenTree catchBlock = Token.of("""
                 catch (System.AggregateException ex) when (ex.InnerException is %s) {


### PR DESCRIPTION
*Description of changes:*
KMS Async API calls return `Task` objects. When you retrieve the `Result` field of a failed `Task`, you get an aggregate exception. So, we need to be a bit smarter in catching the KMS exception.

NOTE: this is affected by https://github.com/awslabs/polymorph/issues/7; it is currently not possible to generate KMS shims, so I was only able to get this to work by applying this diff to an older, working version of KMS shim generation (specifically 538c4e6). As far as I know this issue is tangential from the one above, so this change should stand alone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
