### PR TITLE
ci: add GHA workflow for smithy-dotnet tests

### DIFF
--- a/.github/workflows/smithy-dotnet.yml
+++ b/.github/workflows/smithy-dotnet.yml
@@ -1,0 +1,18 @@
+name: smithy-dotnet workflows
+
+on: ['pull_request', 'push']
+
+jobs:
+  gradle-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: corretto
+          java-version: 16
+      - name: Execute tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: test
+          build-root-directory: smithy-dotnet


### PR DESCRIPTION
*Description of changes:* Adds a GitHub Actions workflow to run `smithy-dotnet` unit tests on every branch and PR commit.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
