### PR TITLE
ci: update GHA workflow to use Java 17

### DIFF
--- a/.github/workflows/smithy-dotnet.yml
+++ b/.github/workflows/smithy-dotnet.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
-          java-version: '16'
+          java-version: '17'
       - name: Execute tests
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
*Description of changes:* This is a follow-up to #24 which bumps the target language version to Java 17. This does the same but for CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
