### PR TITLE
Dafny only update history

### DIFF
--- a/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
+++ b/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
@@ -953,8 +953,11 @@ public class DafnyApiCodegen {
             // The abstract operations do not have a class with a `Modifies` property
             ? Token.of("%s(config)".formatted(nameResolver.modifiesInternalConfig()))
             // The class has a `Modifies` property
-            : Token.of("%s"
-                .formatted(nameResolver.mutableStateFunctionName()))
+            // The `- {History} is important for consumers
+            // otherwise if they use multiple APIs
+            // Dafny will assume that each API can modify _any_ other History.
+            : Token.of("%s - {%s}"
+                .formatted(nameResolver.mutableStateFunctionName(), nameResolver.callHistoryFieldName()))
         )
         .flatten();
     }


### PR DESCRIPTION
By removing all of `{History}` from the Dafny modifies clause
and then adding back _only_ the specific API history seq
we are implicitly saying "This API *only* modifies its history".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
