### PR TITLE
fix(Java-ToDafny): handling positional

### DIFF
--- a/smithy-polymorph/src/test/java/software/amazon/polymorph/smithyjava/generator/ToDafnyTest.java
+++ b/smithy-polymorph/src/test/java/software/amazon/polymorph/smithyjava/generator/ToDafnyTest.java
@@ -87,12 +87,14 @@ public class ToDafnyTest {
         StructureShape structureShape = model.expectShape(structureId, StructureShape.class);
         // if required
         MemberShape memberRequired = structureShape.getMember("name").get();
-        CodeBlock actualRequired = underTest.memberAssignment(memberRequired, CodeBlock.of("name"));
+        CodeBlock actualRequired = underTest.memberAssignment(
+                memberRequired, CodeBlock.of("name"), CodeBlock.of("nativeValue.getName()"));
         String expectedRequired = ToDafnyConstants.MEMBER_ASSIGNMENT_REQUIRED;
         tokenizeAndAssertEqual(expectedRequired, actualRequired.toString());
         // if optional
         MemberShape memberOptional = structureShape.getMember("message").get();
-        CodeBlock actualOptional = underTest.memberAssignment(memberOptional, CodeBlock.of("message"));
+        CodeBlock actualOptional = underTest.memberAssignment(
+                memberOptional, CodeBlock.of("message"), CodeBlock.of("nativeValue.getMessage()"));
         String expectedOptional = ToDafnyConstants.MEMBER_ASSIGNMENT_OPTIONAL;
         tokenizeAndAssertEqual(expectedOptional, actualOptional.toString());
     }


### PR DESCRIPTION
### Issue #, if available: [CrypTool-4856](https://issues.amazon.com/issues/CrypTool-4856)

### Description of changes:
Two issues are fixed:
1. Methods handling Positional Structures MUST take 
    the "onlyMember" as the input, not the structure.
3. Abstract ToDafny should not deal with Positional structures, 
    as only Crypto Tool Libraries use that trait, 
    and the trait is crutch that we SHOULD kill.

This is accomplished by:
- Breaking the logic for determining the conversion method of a field
   (`memberAssignment`)
   away from the logic for getting the field's value
   (`getMember`)
- Creating a method in `ToDafnyLibrary` to explicitly handle 
   structures with the positional trait

### Generated Java:
See https://github.com/aws/private-aws-encryption-sdk-dafny-staging/commit/a5a06e9f47fa58e00837b686d2720e86f7c0da80

### Unresolved Issue:
Oh, this has revealed another issue.
Constraint Traits are only validated by Builders. 
But we only use Builders for Structures.
So we, at this time, do not validate the only member of a positional structure
(unless the onlyMember is a Structure or Enum). 

Bother. 
I ~will~ created a [SIM to track this](https://issues.amazon.com/issues/CrypTool-4871), 
as it could be a bigger fix,
but may not block getting the Java done for Crypto Primitives.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
