### PR TITLE
fix(Java): Constraint Trait validation should not assume Required

### DIFF
--- a/smithy-polymorph/src/main/java/software/amazon/polymorph/smithyjava/BuildMethod.java
+++ b/smithy-polymorph/src/main/java/software/amazon/polymorph/smithyjava/BuildMethod.java
@@ -77,6 +77,9 @@ public class BuildMethod {
         return buildMethod.build();
     }
 
+    static CodeBlock fieldNonNull(FieldSpec field) {
+        return CodeBlock.of("$T.nonNull(this.$L())", Objects.class, field.name);
+    }
 
     public static CodeBlock requiredCheck(FieldSpec field) {
         return CodeBlock.builder()
@@ -92,7 +95,7 @@ public class BuildMethod {
     static CodeBlock rangeMinCheck(PolymorphFieldSpec polyField, RangeTrait trait) {
         String min = ConstrainTraitUtils.RangeTraitUtils.minAsShapeType(polyField.getTargetShape(), trait);
         return CodeBlock.builder()
-                .beginControlFlow("if (this.$L() < $L)", polyField.name, min)
+                .beginControlFlow("if ($L && this.$L() < $L)", fieldNonNull(polyField.fieldSpec), polyField.name, min)
                 .addStatement(
                         "throw new $T($S)",
                         IllegalArgumentException.class,
@@ -103,7 +106,7 @@ public class BuildMethod {
     static CodeBlock rangeMaxCheck(PolymorphFieldSpec polyField, RangeTrait trait) {
         String max = ConstrainTraitUtils.RangeTraitUtils.maxAsShapeType(polyField.getTargetShape(), trait);
         return CodeBlock.builder()
-                .beginControlFlow("if (this.$L() > $L)", polyField.name, max)
+                .beginControlFlow("if ($L && this.$L() > $L)", fieldNonNull(polyField.fieldSpec), polyField.name, max)
                 .addStatement(
                         "throw new $T($S)",
                         IllegalArgumentException.class,
@@ -114,7 +117,9 @@ public class BuildMethod {
     static CodeBlock lengthMinCheck(PolymorphFieldSpec polyField, LengthTrait trait) {
         String min = ConstrainTraitUtils.LengthTraitUtils.min(trait);
         return CodeBlock.builder()
-                .beginControlFlow("if (this.$L().$L < $L)", polyField.name, polyField.getLengthMethod(), min)
+                .beginControlFlow("if ($L && this.$L().$L < $L)",
+                        fieldNonNull(polyField.fieldSpec),
+                        polyField.name, polyField.getLengthMethod(), min)
                 .addStatement(
                         "throw new $T($S)",
                         IllegalArgumentException.class,
@@ -125,7 +130,9 @@ public class BuildMethod {
     static CodeBlock lengthMaxCheck(PolymorphFieldSpec polyField, LengthTrait trait) {
         String max = ConstrainTraitUtils.LengthTraitUtils.max(trait);
         return CodeBlock.builder()
-                .beginControlFlow("if (this.$L().$L > $L)", polyField.name, polyField.getLengthMethod(), max)
+                .beginControlFlow("if ($L && this.$L().$L > $L)",
+                        fieldNonNull(polyField.fieldSpec),
+                        polyField.name, polyField.getLengthMethod(), max)
                 .addStatement(
                         "throw new $T($S)",
                         IllegalArgumentException.class,

--- a/smithy-polymorph/src/test/java/software/amazon/polymorph/smithyjava/generator/library/Constants.java
+++ b/smithy-polymorph/src/test/java/software/amazon/polymorph/smithyjava/generator/library/Constants.java
@@ -63,10 +63,10 @@ class Constants {
     static String RANGE_TRAIT_INTEGER_BUILD_METHOD_RETURN = "return new TestRangeMinMaxInteger(this);";
     static String RANGE_TRAIT_INTEGER_BUILD_EXPECTED = """
             %s {
-              if (this.zeroToTen() < 0) {
+              if (Objects.nonNull(this.zeroToTen()) && this.zeroToTen() < 0) {
                 throw new IllegalArgumentException("`zeroToTen` must be greater than or equal to 0");
               }
-              if (this.zeroToTen() > 10) {
+              if (Objects.nonNull(this.zeroToTen()) && this.zeroToTen() > 10) {
                 throw new IllegalArgumentException("`zeroToTen` must be less than or equal to 10.");
               }
               %s
@@ -79,10 +79,10 @@ class Constants {
     static String LENGTH_TRAIT_BLOB_BUILD_METHOD_RETURN = "return new TestLengthMinMaxBlob(this);";
     static String LENGTH_TRAIT_BLOB_BUILD_METHOD_EXPECTED = """
             %s {
-              if (this.key().remaining() < 256) {
+              if (Objects.nonNull(this.key()) && this.key().remaining() < 256) {
                 throw new IllegalArgumentException("The size of `key` must be greater than or equal to 256");
               }
-              if (this.key().remaining() > 256) {
+              if (Objects.nonNull(this.key()) && this.key().remaining() > 256) {
                 throw new IllegalArgumentException("The size of `key` must be less than or equal to 256");
               }
               %s


### PR DESCRIPTION
*Issue #, if available:* [CrypTool-4888](https://issues.amazon.com/issues/CrypTool-4888)
From https://issues.amazon.com/issues/CrypTool-4888:

>When Polymorph-Smithy's Java generates constraint trait validation,
([link to code](https://github.com/awslabs/polymorph/blob/f6e9290c14fd42531ca63cd47698ad5a968b3e02/smithy-polymorph/src/main/java/software/amazon/polymorph/smithyjava/BuildMethod.java#L80-L134)),
it assumes the field it is validating is set (is non-null).

>So far, this has not been an issue,
as our smithy shapes have always **required** shapes that have
constraint traits (like **range**, or **length**). 

>But it is valid for a Smithy Structure to have
constraint traits applied to members that are not required.


*Description of changes:*
The fix is simple: always check for null before a range or length check.

*Example Java*:
See https://github.com/aws/private-aws-encryption-sdk-dafny-staging/commit/3a1b7a82f494a2573fc786967827b26c05d2e30f

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
