### PR TITLE
fix(Dafny & Net): Respect Union Shape member names from Smithy

### DIFF
--- a/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
+++ b/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
@@ -287,9 +287,7 @@ public class DafnyApiCodegen {
         final String name = memberShape.getMemberName();
         final String wrappedType = nameResolver.baseTypeForShape(memberShape.getTarget());
 
-        return TokenTree.of(
-          "| %s(%s: %s)".formatted(name, wrappedType.replace(".", ""), wrappedType)
-        );
+        return TokenTree.of("| %s(%s: %s)".formatted(name, name, wrappedType));
     }
 
     private TokenTree generateStructureTypeParameter(final MemberShape memberShape) {

--- a/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydotnet/DotNetNameResolver.java
+++ b/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydotnet/DotNetNameResolver.java
@@ -879,15 +879,7 @@ public class DotNetNameResolver {
     }
     /** Return the DotNet Type for a Union Member */
     public String unionMemberName(final MemberShape memberShape) {
-        if (ModelUtils.isInServiceNamespace(memberShape.getTarget(), serviceShape)) {
             String[] qualifiedName = classPropertyTypeForStructureMember(memberShape).split("[.]");
             return "_%s".formatted(dafnyCompilesExtra_(qualifiedName[qualifiedName.length - 1]));
-        } else {
-            final String name = dafnyConcreteTypeForUnionMember(memberShape)
-                    // TODO Hack to remove Dafny "namespace"
-                    .replace("Dafny.", "")
-                    .replace(".", "");
-            return "_%s".formatted(name);
-        }
     }
 }

--- a/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -29,6 +29,7 @@ import static software.amazon.polymorph.smithydotnet.DotNetNameResolver.TYPE_CON
 import static software.amazon.polymorph.smithydotnet.DotNetNameResolver.typeConverterForShape;
 import static software.amazon.polymorph.smithydotnet.TypeConversionDirection.FROM_DAFNY;
 import static software.amazon.polymorph.smithydotnet.TypeConversionDirection.TO_DAFNY;
+import static software.amazon.polymorph.utils.DafnyNameResolverHelpers.dafnyCompilesExtra_;
 import static software.amazon.polymorph.utils.DafnyNameResolverHelpers.dafnyExternNamespaceForShapeId;
 
 /**
@@ -463,19 +464,17 @@ public class TypeConversionCodegen {
                 .stream()
                 .map(memberShape -> {
                     final String propertyName = nameResolver.classPropertyForStructureMember(memberShape);
-                    final String propertyType = nameResolver.classPropertyTypeForStructureMember(memberShape);
-                    final String dafnyMemberName = nameResolver.unionMemberName(memberShape);
                     final String memberFromDafnyConverterName = typeConverterForShape(
                             memberShape.getId(), FROM_DAFNY);
                     return TokenTree
                         .of("if (value.is_%s)".formatted(propertyName))
                         .append(TokenTree
                             .of(
-                                "converted.%s = %s(concrete.dtor%s);"
+                                "converted.%s = %s(concrete.dtor_%s);"
                                     .formatted(
                                         propertyName,
                                         memberFromDafnyConverterName,
-                                        dafnyMemberName
+                                        dafnyCompilesExtra_(memberShape.getMemberName())
                                     ),
                                 "return converted;"
                             )


### PR DESCRIPTION
*Issue #, if available:* Respect Union Shape member names from Smithy

*Description of changes:*
See https://github.com/aws/private-aws-encryption-sdk-dafny-staging/pull/49
for generated C# and Dafny.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
