### PR TITLE
feat: Generate AWS region code for Java KMS

### DIFF
--- a/smithy-polymorph/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/ShimV1.java
+++ b/smithy-polymorph/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/ShimV1.java
@@ -26,7 +26,6 @@ import static software.amazon.polymorph.smithyjava.nameresolver.Constants.DAFNY_
 import static software.amazon.polymorph.smithyjava.nameresolver.Constants.DAFNY_TUPLE0_CLASS_NAME;
 import static software.amazon.polymorph.smithyjava.nameresolver.Constants.SMITHY_API_UNIT;
 
-
 /**
  * Generates an AWS SDK Shim for the AWS SKD for Java V1
  * exposing an AWS Service's operations to Dafny Generated Java.
@@ -57,7 +56,11 @@ public class ShimV1 extends Generator {
                 .addField(
                         subject.nativeNameResolver.classNameForService(subject.serviceShape),
                         "_impl", Modifier.PRIVATE, Modifier.FINAL)
+                .addField(
+                        ClassName.get(String.class),
+                        "region", Modifier.PRIVATE, Modifier.FINAL)
                 .addMethod(constructor())
+                .addMethod(region())
                 .addMethods(
                         subject.serviceShape.getAllOperations()
                                 .stream()
@@ -74,9 +77,24 @@ public class ShimV1 extends Generator {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(
                         subject.nativeNameResolver.classNameForService(subject.serviceShape),
-                        "impl")
-                .addStatement("_impl = impl")
+                        "impl",
+                        Modifier.FINAL)
+                .addParameter(
+                        ClassName.get(String.class),
+                        "region",
+                        Modifier.FINAL)
+                .addStatement("this._impl = impl")
+                .addStatement("this.region = region")
                 .build();
+    }
+
+    MethodSpec region() {
+        return MethodSpec
+            .methodBuilder("region")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ClassName.get(String.class))
+            .addStatement("return this.region")
+            .build();
     }
 
     Optional<MethodSpec> operation(final ShapeId operationShapeId) {


### PR DESCRIPTION
*Issue #, if available:* https://issues.amazon.com/issues/CrypTool-4890

*Description of changes:* Generates region code for storing AWS region within the shimmed client. See [PR](https://github.com/aws/private-aws-encryption-sdk-dafny-staging/pull/54) for generated code. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
