### PR TITLE
chore: update unions in typeconversion

### DIFF
--- a/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -563,6 +563,8 @@ public class TypeConversionCodegen {
                     String createSuffixUnMod = defNames.size() == 1
                             ? ""
                             : dafnyMemberName;
+                    // TODO come back and revisit how we generate Unions - we should use the names
+                    // defined in the smithy model 
                     if (StringUtils.equals(memberShape.getId().getName(), "AttributeValue") ||
                         StringUtils.equals(memberShape.getContainer().getName(), "Materials")) {
                         createSuffixUnMod = "_%s".formatted(propertyName);


### PR DESCRIPTION
*Description of changes:*
we currently model the Union of materials like, 
```
union Materials {
  encryptionMaterials: EncryptionMaterials,
  decryptionMaterials: DecryptionMaterials,
  hierarchicalMaterials: HierarchicalMaterials,
}
```
When generating this union converter polymorph gets confused between when to use encryptionMaterials and EncryptionMaterials. Poly uses `classPropertyForStructureMember` to get the appropriate name of the member; however it capitalizes it before returning the value. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
