### PR TITLE
chore: wrap empty tupple for native wrappers that return void

### DIFF
--- a/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydotnet/nativeWrapper/NativeWrapperCodegen.java
+++ b/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydotnet/nativeWrapper/NativeWrapperCodegen.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.utils.StringUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -54,6 +55,7 @@ public class NativeWrapperCodegen {
                     """;
     protected static final List<String> UNCONDITIONAL_IMPORTS = List.of(
             "System",
+            "_System",
             "Wrappers_Compile"
     );
 
@@ -225,8 +227,11 @@ public class NativeWrapperCodegen {
                 .map(shapeId -> "%s(%s)".formatted(
                         qualifiedTypeConverter(shapeId, TO_DAFNY),
                         NATIVE_OUTPUT));
+        final String outputType = operationShape.getOutput()
+                .map(nameResolver::dafnyTypeForShape)
+                .orElse(nameResolver.dafnyTypeForUnit()).replace("_System._I", "");
         final TokenTree returnSuccess = TokenTree.of("return %s.create_Success(%s);".formatted(
-                concreteDafnyOutput, successConversion.orElse("null")));
+                concreteDafnyOutput, successConversion.orElse("%s.create()".formatted(outputType))));
 
         return TokenTree.of("try").append(
                 TokenTree.of(nativeCall, isNativeOutputNull, validateNativeOutput, returnSuccess)

--- a/smithy-polymorph/src/test/java/software/amazon/polymorph/smithydotnet/nativeWrapper/NativeWrapperCodegenTestConstants.java
+++ b/smithy-polymorph/src/test/java/software/amazon/polymorph/smithydotnet/nativeWrapper/NativeWrapperCodegenTestConstants.java
@@ -114,7 +114,7 @@ class NativeWrapperCodegenTestConstants {
                             return Wrappers_Compile.Result<
                                 _System._ITuple0,
                                 Dafny.Test.Foobar.Types._IError
-                            >.create_Success();
+                            >.create_Success(Tuple0.create());
                         }
                         %s
                     }
@@ -137,7 +137,7 @@ class NativeWrapperCodegenTestConstants {
                             return Wrappers_Compile.Result<
                                 _System._ITuple0,
                                 Dafny.Test.Foobar.Types._IError
-                            >.create_Success();
+                            >.create_Success(Tuple0.create());
                         }
                         %s
                     }
@@ -189,6 +189,7 @@ class NativeWrapperCodegenTestConstants {
                     // ReSharper disable SuggestVarOrType_SimpleTypes
                                 
                     using System;
+                    using _System;
                     using Wrappers_Compile;
                     """;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The underlying implementation that the Native Wrappers wrap sometimes may return void; the Native Wrapper returns a 
`Wrappers_Compile._IResult<_System._ITuple0, *._IError>` when the underlying implementation returns void; instead of returning and empty Success it should return an empty type of what the native wrapper is supposed to return.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
