### PR TITLE
feat: Generate impl accessor for library shims

### DIFF
--- a/smithy-polymorph/src/main/java/software/amazon/polymorph/smithyjava/generator/library/ShimLibrary.java
+++ b/smithy-polymorph/src/main/java/software/amazon/polymorph/smithyjava/generator/library/ShimLibrary.java
@@ -97,7 +97,8 @@ public class ShimLibrary extends Generator {
                 ))
                 // TODO: Handle Resources (serviceConstructor assumes this is a service)
                 .addMethod(serviceConstructor(builderSpecs))
-                .addMethod(builderSpecs.builderMethod());
+                .addMethod(builderSpecs.builderMethod())
+                .addMethod(impl());
         spec.addMethods(getOperationsForTarget()
                 .stream().sequential().map(this::operation).collect(Collectors.toList()));
         return spec.build();
@@ -270,6 +271,16 @@ public class ShimLibrary extends Generator {
         method.addCode(ifFailure());
         method.addStatement("this.$L = $L.dtor_value()", INTERFACE_FIELD, RESULT_VAR);
         return method.build();
+    }
+
+    MethodSpec impl() {
+        return MethodSpec
+            .methodBuilder("impl")
+            .addModifiers(Modifier.PROTECTED)
+            .returns(subject.dafnyNameResolver.typeForShape(
+                    targetShape.toShapeId()))
+            .addStatement("return this.$L", INTERFACE_FIELD)
+            .build();
     }
 
     // If it is known the Shape cannot have a positional trait,


### PR DESCRIPTION
*Issue #, if available:*

Issue raised in [[PR comment]](https://github.com/awslabs/polymorph/pull/82#issuecomment-1363066163): AwsCryptographyPrimitives was losing its `impl` method after running code generation off `main-1.x`. We probably wrote this manually but didn't track generating it.

*Description of changes:*

* Create `impl` generator in ShimLibrary class

*Testing:*

I pushed the current generated code for `main-1.x` and `shim-library-impl` to my ESDK-Dafny fork and diffed them.
Link to diff: https://github.com/lucasmcdonald3/private-aws-encryption-sdk-dafny-staging/pull/1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
