### PR TITLE
fix: union names are only the member names

### DIFF
--- a/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydotnet/DotNetNameResolver.java
+++ b/smithy-polymorph/src/main/java/software/amazon/polymorph/smithydotnet/DotNetNameResolver.java
@@ -934,15 +934,6 @@ public class DotNetNameResolver {
     }
     /** Return the DotNet Type for a Union Member */
     public String unionMemberName(final MemberShape memberShape) {
-        if (ModelUtils.isInServiceNamespace(memberShape.getTarget(), serviceShape)) {
-            String[] qualifiedName = classPropertyTypeForStructureMember(memberShape).split("[.]");
-            return "_%s".formatted(dafnyCompilesExtra_(qualifiedName[qualifiedName.length - 1]));
-        } else {
-            final String name = dafnyConcreteTypeForUnionMember(memberShape)
-                    // TODO Hack to remove Dafny "namespace"
-                    .replace("Dafny.", "")
-                    .replace(".", "");
-            return "_%s".formatted(name);
-        }
+        return "_%s".formatted(dafnyCompilesExtra_(memberShape.getMemberName()));
     }
 }


### PR DESCRIPTION
I think that we updated how unions get created.
Somehow the .NET and the Dafny identifications
got mixed up. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
