### PR TITLE
fix(CFN): Repo Rename violates access policy

### DIFF
--- a/cfn/ci.yaml
+++ b/cfn/ci.yaml
@@ -13,7 +13,7 @@ Parameters:
   GitHubRepo:
     Type: String
     Description: GitHub Repo that invokes CI
-    Default: awslabs/polymorph
+    Default: awslabs/smithy-dafny
 
 Resources:
   DDBDafnyTestTable:


### PR DESCRIPTION
*Issue #, if available:* GitHub Workflows cannot access our IAM CI roles due to repo rename.

*Description of changes:* `fix(CFN): Repo Rename violates access policy`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
