### PR TITLE
feat: DafnyUtf8BytesTrait trait list support

### DIFF
--- a/TestModels/Constraints/Model/Constraints.smithy
+++ b/TestModels/Constraints/Model/Constraints.smithy
@@ -122,6 +122,8 @@ structure GetConstraintsInput {
   LessThanTen: LessThanTen,
   MyUniqueList: MyUniqueList,
   MyComplexUniqueList: MyComplexUniqueList,
+  MyUtf8Bytes: Utf8Bytes,
+  MyListOfUtf8Bytes: ListOfUtf8Bytes,
 }
 
 structure GetConstraintsOutput {
@@ -143,4 +145,14 @@ structure GetConstraintsOutput {
   LessThanTen: LessThanTen,
   MyUniqueList: MyUniqueList,
   MyComplexUniqueList: MyComplexUniqueList,
+  MyUtf8Bytes: Utf8Bytes,
+  MyListOfUtf8Bytes: ListOfUtf8Bytes,
+}
+
+// See Comment in traits.smithy
+@aws.polymorph#dafnyUtf8Bytes
+string Utf8Bytes
+
+list ListOfUtf8Bytes {
+  member: Utf8Bytes
 }

--- a/TestModels/Constraints/src/SimpleConstraintsImpl.dfy
+++ b/TestModels/Constraints/src/SimpleConstraintsImpl.dfy
@@ -31,7 +31,9 @@ module SimpleConstraintsImpl refines AbstractSimpleConstraintsOperations  {
       GreaterThanOne := input.GreaterThanOne,
       LessThanTen := input.LessThanTen,
       MyUniqueList := input.MyUniqueList,
-      MyComplexUniqueList := input.MyComplexUniqueList
+      MyComplexUniqueList := input.MyComplexUniqueList,
+      MyUtf8Bytes := input.MyUtf8Bytes,
+      MyListOfUtf8Bytes := input.MyListOfUtf8Bytes
     );
 
     return Success(res);

--- a/TestModels/Constraints/test/Helpers.dfy
+++ b/TestModels/Constraints/test/Helpers.dfy
@@ -7,6 +7,12 @@ module Helpers {
     import opened SimpleConstraintsTypes
     import opened Wrappers
 
+    // UTF-8 encoded "aws-kms"
+    const PROVIDER_ID: UTF8.ValidUTF8Bytes :=
+      var s := [0x61, 0x77, 0x73, 0x2D, 0x6B, 0x6D, 0x73];
+      assert UTF8.ValidUTF8Range(s, 0, 7);
+      s
+
     // Example for overriding GetConstraintInputTemplate with an invalid input
     // 
     // method TestGetConstraintWithInvalidMyString(client: ISimpleConstraintsClient)
@@ -98,7 +104,9 @@ module Helpers {
         GreaterThanOne := Some(greaterThanOne),
         LessThanTen := Some(lessThanTen),
         MyUniqueList := Some(myUniqueList),
-        MyComplexUniqueList := Some(myComplexUniqueList)
+        MyComplexUniqueList := Some(myComplexUniqueList),
+        MyUtf8Bytes := Some(PROVIDER_ID),
+        MyListOfUtf8Bytes := Some([PROVIDER_ID, PROVIDER_ID])
       );
 
       return input;

--- a/smithy-polymorph/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Dafny.java
+++ b/smithy-polymorph/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Dafny.java
@@ -252,7 +252,12 @@ public class Dafny extends NameResolver {
                     new MethodReference(ClassName.get(Tuple0.class), "_typeDescriptor").asNormalReference());
         }
         if (shape.getType().getCategory().equals(ShapeType.Category.SIMPLE) && !shape.hasTrait(EnumTrait.class)) {
-            @Nullable CodeBlock typeDescriptor = TYPE_DESCRIPTOR_BY_SHAPE_TYPE.get(shape.getType());
+            @Nullable CodeBlock typeDescriptor =
+              shape.hasTrait(DafnyUtf8BytesTrait.class)
+                // A Dafny UTF8 Bytes are basically a blob.
+                // They are a sequence of uint8 in Dafny, this makes them the same as a Blob.
+                ? TYPE_DESCRIPTOR_BY_SHAPE_TYPE.get(ShapeType.BLOB)
+                : TYPE_DESCRIPTOR_BY_SHAPE_TYPE.get(shape.getType());
             if (Objects.nonNull(typeDescriptor)) {
                 return CodeBlock.of("$L", typeDescriptor);
             }


### PR DESCRIPTION
The @DafnyUtf8BytesTrait is used to support strings. This trait can be used in a list.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
