### PR TITLE
fix(dafny-java-conversion): ByteBuffer maybe read-only

### DIFF
--- a/dafny-java-conversion/src/main/java/software/amazon/dafny/conversion/ToDafny.java
+++ b/dafny-java-conversion/src/main/java/software/amazon/dafny/conversion/ToDafny.java
@@ -47,7 +47,7 @@ public class ToDafny {
                 final int limit) {
             byte[] rawArray = new byte[limit - start];
             byteBuffer.position(start);
-            byteBuffer.get(rawArray, start, limit);
+            byteBuffer.get(rawArray, 0, limit);
             return ByteSequence(rawArray);
         }
 


### PR DESCRIPTION
*Issue #, if available:* 
A `java.nio.ByteBuffer` maybe read-only.
In which case, `byteBuffer.array()` will throw a `ReadOnlyBufferException`.
To work around this, we should not use `array()`, 
but `ByteBuffer`'s "Relative bulk get method."

Which introduces a new challenge,
as the ByteBuffer's position may not be at the start!

*Description of changes:*
- Refactor our `ByteSequence` methods to avoid `ReadOnlyBufferException`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
