### PR TITLE
fix(Polymorph-Java): Dafny treats void methods in-correctly

### DIFF
--- a/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/smithyjava/generator/library/shims/NativeWrapper.java
+++ b/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/smithyjava/generator/library/shims/NativeWrapper.java
@@ -9,7 +9,6 @@ import com.squareup.javapoet.TypeSpec;
 
 import java.util.Set;
 
-import dafny.Tuple0;
 import software.amazon.polymorph.smithyjava.generator.library.JavaLibrary;
 import software.amazon.polymorph.smithyjava.generator.library.JavaLibrary.MethodSignature;
 import software.amazon.polymorph.utils.ModelUtils.ResolvedShapeId;


### PR DESCRIPTION
This closes https://sim.amazon.com/issues/CrypTool-5108.

Details: The Dafny Name Resolver already has `Tuple0` as the success type for a Smithy Unit.
We do not need this `if` statement;
`methodOutputTypeName` will correctly generate the signature for `void` methods.

*Issue #, if available:*

*Description of changes:*
Evidence: https://github.com/aws/private-aws-encryption-sdk-dafny-staging/commit/b964fd7820a499640145a479316940e597682cd0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
