### PR TITLE
fix: nomalize the line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize line endings to LF
+* text=auto


### PR DESCRIPTION
codegen/smithy-dafny-codegen-cli/gradlew.bat
has CRLF line endings.
For some git installs this means
that its line endings will be autoupdated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
