### PR TITLE
feat: support Smithy 2.0

### DIFF
--- a/.github/workflows/test_models_dafny_verification.yml
+++ b/.github/workflows/test_models_dafny_verification.yml
@@ -49,7 +49,7 @@ jobs:
           # TestModels/SimpleTypes/SimpleByte,
           TestModels/SimpleTypes/SimpleDouble,          
           TestModels/SimpleTypes/SimpleEnum,
-          # TestModels/SimpleTypes/SimpleEnumV2,
+          TestModels/SimpleTypes/SimpleEnumV2,
           # TestModels/SimpleTypes/SimpleFloat,
           TestModels/SimpleTypes/SimpleInteger,
           TestModels/SimpleTypes/SimpleLong,

--- a/.github/workflows/test_models_net_tests.yml
+++ b/.github/workflows/test_models_net_tests.yml
@@ -49,7 +49,7 @@ jobs:
           # TestModels/SimpleTypes/SimpleByte,
           TestModels/SimpleTypes/SimpleDouble,          
           TestModels/SimpleTypes/SimpleEnum,
-          # TestModels/SimpleTypes/SimpleEnumV2,
+          TestModels/SimpleTypes/SimpleEnumV2,
           # TestModels/SimpleTypes/SimpleFloat,
           TestModels/SimpleTypes/SimpleInteger,
           TestModels/SimpleTypes/SimpleLong,

--- a/TestModels/SimpleTypes/SimpleEnum/README.md
+++ b/TestModels/SimpleTypes/SimpleEnum/README.md
@@ -1,11 +1,12 @@
 # SimpleEnum
 
-This project implements the smithy type [enum](https://smithy.io/2.0/spec/simple-types.html#blob) and the associated operations in `dafny`. This is then transpiled to a target runtime, and each tests are executed - either as CI actions or manually.
+This project implements strings attached with the Smithy trait [@enum](https://smithy.io/2.0/spec/constraint-traits.html#enum-trait) and the associated operations in `dafny`. This is then transpiled to a target runtime, and each tests are executed - either as CI actions or manually.
 
 ## Build
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
+make polymorph_dafny
 make polymorph_net
 ```
 

--- a/TestModels/SimpleTypes/SimpleEnumV2/Makefile
+++ b/TestModels/SimpleTypes/SimpleEnumV2/Makefile
@@ -2,97 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CORES=2
-DAFNY_ROOT := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-# Note: This build target fails. This project does not support code generation for Smithy 2.0 models.
-polymorph_dafny :
-	cd ../../../codegen/smithy-dafny-codegen-cli;\
-	./gradlew run --args="\
-	--output-dafny \
-	--include-dafny $(DAFNY_ROOT)/../../dafny-dependencies/StandardLibrary/src/Index.dfy \
-	--model $(DAFNY_ROOT)/Model \
-	--dependent-model $(DAFNY_ROOT)/../../dafny-dependencies/Model \
-	--namespace simple.types.enumv2"; \
-	./gradlew run --args="\
-	--output-dafny \
-	--output-local-service-test $(DAFNY_ROOT)/Model \
-	--include-dafny $(DAFNY_ROOT)/../../dafny-dependencies/StandardLibrary/src/Index.dfy \
-	--model $(DAFNY_ROOT)/Model \
-	--dependent-model $(DAFNY_ROOT)/../../dafny-dependencies/Model \
-	--namespace simple.types.enumv2"; \
+include ../../SharedMakefile.mk
 
-# Note: This build target fails. This project does not support code generation for Smithy 2.0 models.
-polymorph_net :
-	cd ../../../codegen/smithy-dafny-codegen-cli;\
-	./gradlew run --args="\
-	--output-dafny \
-	--include-dafny $(DAFNY_ROOT)/../../dafny-dependencies/StandardLibrary/src/Index.dfy \
-	--output-dotnet $(DAFNY_ROOT)/runtimes/net/Generated/ \
-	--model $(DAFNY_ROOT)/Model \
-	--dependent-model $(DAFNY_ROOT)/../../dafny-dependencies/Model \
-	--namespace simple.types.enumv2"; \
-	./gradlew run --args="\
-	--output-dafny \
-	--output-local-service-test $(DAFNY_ROOT)/Model \
-	--include-dafny $(DAFNY_ROOT)/../../dafny-dependencies/StandardLibrary/src/Index.dfy \
-	--output-dotnet $(DAFNY_ROOT)/runtimes/net/Generated/Wrapped \
-	--model $(DAFNY_ROOT)/Model \
-	--dependent-model $(DAFNY_ROOT)/../../dafny-dependencies/Model \
-	--namespace simple.types.enumv2"; \
+NAMESPACE=simple.types.enumV2
 
-# Note: Any build targets below this line have not been tested; they depend on the first two targets, which fail.
-verify:
-	dafny \
-		-vcsCores:$(CORES) \
-		-compile:0 \
-		-definiteAssignment:3 \
-		-verificationLogger:csv \
-		-timeLimit:300 \
-		-trace \
-		`find . -name '*.dfy'`
-
-dafny-reportgenerator:
-	dafny-reportgenerator \
-		summarize-csv-results \
-		--max-resource-count 10000000 \
-		TestResults/*.csv
-
-transpile_net: | transpile_implementation_net transpile_test_net transpile_net_dependencies
-
-transpile_implementation_net:
-	dafny \
-		-vcsCores:$(CORES) \
-		-compileTarget:cs \
-		-spillTargetCode:3 \
-		-runAllTests:1 \
-		-compile:0 \
-		-optimizeErasableDatatypeWrapper:0 \
-		-useRuntimeLib \
-		-out runtimes/net/ImplementationFromDafny \
-		./src/Index.dfy \
-		-library:../../dafny-dependencies/StandardLibrary/src/Index.dfy \
-
-
-transpile_test_net:
-	dafny \
-		-vcsCores:$(CORES) \
-		-compileTarget:cs \
-		-spillTargetCode:3 \
-		-runAllTests:1 \
-		-compile:0 \
-		-optimizeErasableDatatypeWrapper:0 \
-		-useRuntimeLib \
-		-out runtimes/net/tests/TestsFromDafny \
-		`find ./test -name '*.dfy'` \
-		-library:src/Index.dfy
-
-	$(MAKE) -C ../../dafny-dependencies/StandardLibrary transpile_implementation_net \
-
-test_net:
-	dotnet run \
-		--project runtimes/net/tests/ \
-		--framework net6.0
-
-setup_net:
-	dotnet restore runtimes/net/
-	
+# This project has no dependencies 
+# DEPENDENT-MODELS:= 
+# LIBRARIES :=

--- a/TestModels/SimpleTypes/SimpleEnumV2/Model/SimpleEnumV2.smithy
+++ b/TestModels/SimpleTypes/SimpleEnumV2/Model/SimpleEnumV2.smithy
@@ -21,11 +21,11 @@ operation GetEnumV2 {
 }
 
 structure GetEnumV2Input {
-  value: Enum
+  value: SimpleEnum
 }
 
 structure GetEnumV2Output {
-  value: Enum
+  value: SimpleEnum
 }
 
 // This is a smithy V2 Enum

--- a/TestModels/SimpleTypes/SimpleEnumV2/Model/SimpleEnumV2.smithy
+++ b/TestModels/SimpleTypes/SimpleEnumV2/Model/SimpleEnumV2.smithy
@@ -1,6 +1,6 @@
 $version: "2"
 
-namespace simple.types.enumv2
+namespace simple.types.enumV2
 
 @aws.polymorph#localService(
   sdkId: "SimpleEnumV2",
@@ -9,7 +9,12 @@ namespace simple.types.enumv2
 service SimpleTypesEnumV2 {
   version: "2021-11-01",
   resources: [],
-  operations: [ GetEnumV2 ],
+  operations: [
+    GetEnumV2,
+    GetEnumV2FirstKnownValueTest,
+    GetEnumV2SecondKnownValueTest,
+    GetEnumV2ThirdKnownValueTest,
+  ],
   errors: [],
 }
 
@@ -20,16 +25,31 @@ operation GetEnumV2 {
   output: GetEnumV2Output,
 }
 
+operation GetEnumV2FirstKnownValueTest {
+  input: GetEnumV2Input,
+  output: GetEnumV2Output,
+}
+
+operation GetEnumV2SecondKnownValueTest {
+  input: GetEnumV2Input,
+  output: GetEnumV2Output,
+}
+
+operation GetEnumV2ThirdKnownValueTest {
+  input: GetEnumV2Input,
+  output: GetEnumV2Output,
+}
+
 structure GetEnumV2Input {
-  value: SimpleEnum
+  value: SimpleEnumV2Shape
 }
 
 structure GetEnumV2Output {
-  value: SimpleEnum
+  value: SimpleEnumV2Shape
 }
 
 // This is a smithy V2 Enum
-enum SimpleEnum {
+enum SimpleEnumV2Shape {
     FIRST = "0x0014"
     SECOND = "0x0046"
     THIRD = "0x0078"

--- a/TestModels/SimpleTypes/SimpleEnumV2/README.md
+++ b/TestModels/SimpleTypes/SimpleEnumV2/README.md
@@ -1,9 +1,30 @@
 # SimpleEnumV2
 
-This project will implement the Smithy 2.0 type [enum](https://smithy.io/2.0/spec/simple-types.html#enum) and the associated operations in `dafny`.
+This project implements the Smithy 2.0 type [enum](https://smithy.io/2.0/spec/simple-types.html#enum) and the associated operations in `dafny`. This is then transpiled to a target runtime, and each tests are executed - either as CI actions or manually.
 
-## Status
+## Build
+### .NET
+1. Generate the Wrappers using `polymorph`
+```
+make polymorph_dafny
+make polymorph_net
+```
 
-This project does not build. The `software.amazon.polymorph` project does not support Smithy version 2.0 models.
+2. Transpile the tests (and implementation) to the target runtime.
+```
+make transpile_net
+```
 
-Once the project adds Smithy 2.0 support, these files should be extended to allow building EnumV2.
+3. Generate the executable in the .NET and execute the tests
+```
+make test_net
+```
+
+## Development
+1. To add another target runtime support, edit the `Makefile` and add the appropriate recipe to generate the `polymorph` wrappers, and dafny transpilation.
+2. Provide any glue code between dafny and target runtime if required.
+3. Build, execute, and test in the target runtime.
+
+*Example*
+
+`--output-dotnet <PATH>` in the `gradlew run` is used to generate the polymorph wrappers. Similarly `--compileTarget:<RUNTIME>` flags is used in dafny recipe to transpile to C#.

--- a/TestModels/SimpleTypes/SimpleEnumV2/runtimes/net/Extern/WrappedSimpleEnumService.cs
+++ b/TestModels/SimpleTypes/SimpleEnumV2/runtimes/net/Extern/WrappedSimpleEnumService.cs
@@ -1,0 +1,15 @@
+using Wrappers_Compile;
+using Simple.Types.EnumV2;
+using Simple.Types.EnumV2.Wrapped;
+using TypeConversion = Simple.Types.EnumV2.TypeConversion ;
+namespace Dafny.Simple.Types.EnumV2.Wrapped
+{
+    public partial class __default {
+        public static _IResult<Types.ISimpleTypesEnumV2Client, Types._IError> WrappedSimpleEnumV2(Types._ISimpleEnumV2Config config) {
+            var wrappedConfig = TypeConversion.FromDafny_N6_simple__N5_types__N6_enumV2__S18_SimpleEnumV2Config(config);
+            var impl = new SimpleEnumV2(wrappedConfig);
+            var wrappedClient = new SimpleTypesEnumV2Shim(impl);
+            return Result<Types.ISimpleTypesEnumV2Client, Types._IError>.create_Success(wrappedClient);
+        }
+    }
+}

--- a/TestModels/SimpleTypes/SimpleEnumV2/runtimes/net/SimpleEnumV2.csproj
+++ b/TestModels/SimpleTypes/SimpleEnumV2/runtimes/net/SimpleEnumV2.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DafnyRuntime" Version="3.10.0.41215" />
+    <PackageReference Include="DafnyRuntime" Version="4.0.0.50303"/>
     <!--
       System.Collections.Immutable can be removed once dafny.msbuild is updated with
       https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned

--- a/TestModels/SimpleTypes/SimpleEnumV2/runtimes/net/SimpleEnumV2.csproj
+++ b/TestModels/SimpleTypes/SimpleEnumV2/runtimes/net/SimpleEnumV2.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>SimpleEnumV2</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DafnyRuntime" Version="3.10.0.41215" />
+    <!--
+      System.Collections.Immutable can be removed once dafny.msbuild is updated with
+      https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned
+    -->
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <!-- Work around for dafny-lang/dafny/issues/1951; remove once resolved -->
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+
+    <Compile Include="Extern/**/*.cs" />
+    <Compile Include="Generated/**/*.cs" />
+    <Compile Include="ImplementationFromDafny.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../../dafny-dependencies/StandardLibrary/runtimes/net/STD.csproj" />
+    <!-- TODO: This is here because Dotnet Enum builder assumes the AWS SDK will be included.
+               (It generates classes that unambigiously extend the "ConstantClass" constructor, which is defined in
+               the AWS SDK.) -->
+    <PackageReference Include="AWSSDK.Core" Version="3.7.9.2" />
+  </ItemGroup>
+
+
+</Project>

--- a/TestModels/SimpleTypes/SimpleEnumV2/runtimes/net/tests/SimpleEnumTest.csproj
+++ b/TestModels/SimpleTypes/SimpleEnumV2/runtimes/net/tests/SimpleEnumTest.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>SimpleEnumV2Test</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
+    <OutputType>Exe</OutputType>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      System.Collections.Immutable can be removed once dafny.msbuild is updated with
+      https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned
+    -->
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <!-- Work around for dafny-lang/dafny/issues/1951; remove once resolved -->
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+
+    <ProjectReference Include="../SimpleEnumV2.csproj" />
+    <Compile Include="../Extern/**" />
+    <Compile Include="../Generated/**" />
+    <Compile Include="TestsFromDafny.cs" />
+  </ItemGroup>
+
+  <!-- <ItemGroup>
+    <None Include="..\icon.png" Pack="true" PackagePath="" />
+    <None Include="..\README.md" Pack="true" PackagePath="" />
+  </ItemGroup> -->
+
+</Project>

--- a/TestModels/SimpleTypes/SimpleEnumV2/runtimes/net/tests/SimpleEnumTest.csproj
+++ b/TestModels/SimpleTypes/SimpleEnumV2/runtimes/net/tests/SimpleEnumTest.csproj
@@ -25,9 +25,4 @@
     <Compile Include="TestsFromDafny.cs" />
   </ItemGroup>
 
-  <!-- <ItemGroup>
-    <None Include="..\icon.png" Pack="true" PackagePath="" />
-    <None Include="..\README.md" Pack="true" PackagePath="" />
-  </ItemGroup> -->
-
 </Project>

--- a/TestModels/SimpleTypes/SimpleEnumV2/src/Index.dfy
+++ b/TestModels/SimpleTypes/SimpleEnumV2/src/Index.dfy
@@ -1,0 +1,30 @@
+include "SimpleEnumImpl.dfy"
+
+module {:extern "Dafny.Simple.Types.EnumV2" } SimpleEnumV2 refines AbstractSimpleTypesEnumV2Service {
+    import Operations = SimpleEnumV2Impl
+
+ function method DefaultSimpleEnumV2Config(): SimpleEnumV2Config {
+    SimpleEnumV2Config
+ }
+
+ method SimpleEnumV2(config: SimpleEnumV2Config)
+ returns (res: Result<SimpleEnumV2Client, Error>) {
+    var client := new SimpleEnumV2Client(Operations.Config);
+    return Success(client);
+ }
+
+ class SimpleEnumV2Client... {
+   predicate ValidState()
+   {
+     && Operations.ValidInternalConfig?(config)
+     && Modifies == Operations.ModifiesInternalConfig(config) + {History}
+   }
+
+   constructor(config: Operations.InternalConfig)
+   {
+     this.config := config;
+     History := new ISimpleTypesEnumV2ClientCallHistory();
+     Modifies := Operations.ModifiesInternalConfig(config) + {History};
+   }
+ }
+}

--- a/TestModels/SimpleTypes/SimpleEnumV2/src/SimpleEnumImpl.dfy
+++ b/TestModels/SimpleTypes/SimpleEnumV2/src/SimpleEnumImpl.dfy
@@ -1,12 +1,10 @@
 include "../Model/SimpleTypesEnumV2Types.dfy"
 
-module SimpleEnumV2Impl refines AbstractSimpleTypesEnumV2Operations  {
+module SimpleEnumV2Impl refines AbstractSimpleTypesEnumV2Operations {
   datatype Config = Config
   type InternalConfig = Config
-  predicate ValidInternalConfig?(config: InternalConfig)
-  {true}
-  function ModifiesInternalConfig(config: InternalConfig) : set<object>
-  {{}}
+  predicate ValidInternalConfig?(config: InternalConfig) { true }
+  function ModifiesInternalConfig(config: InternalConfig): set<object> { {} }
   predicate GetEnumV2EnsuresPublicly(input: GetEnumV2Input, output: Result<GetEnumV2Output, Error>) {
     true
   }
@@ -19,49 +17,53 @@ module SimpleEnumV2Impl refines AbstractSimpleTypesEnumV2Operations  {
   predicate GetEnumV2ThirdKnownValueTestEnsuresPublicly(input: GetEnumV2Input, output: Result<GetEnumV2Output, Error>) {
     true
   }
-  method GetEnumV2 ( config: InternalConfig,  input: GetEnumV2Input )
-  returns (output: Result<GetEnumV2Output, Error>) {
+  method GetEnumV2(config: InternalConfig, input: GetEnumV2Input)
+    returns (output: Result<GetEnumV2Output, Error>)
+  {
     var res := GetEnumV2Output(value := input.value);
     return Success(res);
   }
 
   // Known value tests. See "Known value test" in TestModels' README.
-  method GetEnumV2FirstKnownValueTest ( config: InternalConfig,  input: GetEnumV2Input )
-  returns (output: Result<GetEnumV2Output, Error>) {
+  method GetEnumV2FirstKnownValueTest(config: InternalConfig, input: GetEnumV2Input)
+    returns (output: Result<GetEnumV2Output, Error>)
+  {
     expect input.value.Some?;
     expect input.value.value == FIRST;
 
     var res := GetEnumV2Output(value := input.value);
 
     expect res.value.Some?;
-    expect res.value.value == FIRST; 
+    expect res.value.value == FIRST;
 
     return Success(res);
   }
 
-  method GetEnumV2SecondKnownValueTest ( config: InternalConfig,  input: GetEnumV2Input )
-  returns (output: Result<GetEnumV2Output, Error>) {
+  method GetEnumV2SecondKnownValueTest(config: InternalConfig, input: GetEnumV2Input)
+    returns (output: Result<GetEnumV2Output, Error>)
+  {
     expect input.value.Some?;
     expect input.value.value == SECOND;
 
     var res := GetEnumV2Output(value := input.value);
 
     expect res.value.Some?;
-    expect res.value.value == SECOND; 
-    
+    expect res.value.value == SECOND;
+
     return Success(res);
   }
 
-  method GetEnumV2ThirdKnownValueTest ( config: InternalConfig,  input: GetEnumV2Input )
-  returns (output: Result<GetEnumV2Output, Error>) {
+  method GetEnumV2ThirdKnownValueTest(config: InternalConfig, input: GetEnumV2Input)
+    returns (output: Result<GetEnumV2Output, Error>)
+  {
     expect input.value.Some?;
     expect input.value.value == THIRD;
 
     var res := GetEnumV2Output(value := input.value);
 
     expect res.value.Some?;
-    expect res.value.value == THIRD; 
-    
+    expect res.value.value == THIRD;
+
     return Success(res);
   }
 }

--- a/TestModels/SimpleTypes/SimpleEnumV2/src/SimpleEnumImpl.dfy
+++ b/TestModels/SimpleTypes/SimpleEnumV2/src/SimpleEnumImpl.dfy
@@ -1,0 +1,67 @@
+include "../Model/SimpleTypesEnumV2Types.dfy"
+
+module SimpleEnumV2Impl refines AbstractSimpleTypesEnumV2Operations  {
+  datatype Config = Config
+  type InternalConfig = Config
+  predicate ValidInternalConfig?(config: InternalConfig)
+  {true}
+  function ModifiesInternalConfig(config: InternalConfig) : set<object>
+  {{}}
+  predicate GetEnumV2EnsuresPublicly(input: GetEnumV2Input, output: Result<GetEnumV2Output, Error>) {
+    true
+  }
+  predicate GetEnumV2FirstKnownValueTestEnsuresPublicly(input: GetEnumV2Input, output: Result<GetEnumV2Output, Error>) {
+    true
+  }
+  predicate GetEnumV2SecondKnownValueTestEnsuresPublicly(input: GetEnumV2Input, output: Result<GetEnumV2Output, Error>) {
+    true
+  }
+  predicate GetEnumV2ThirdKnownValueTestEnsuresPublicly(input: GetEnumV2Input, output: Result<GetEnumV2Output, Error>) {
+    true
+  }
+  method GetEnumV2 ( config: InternalConfig,  input: GetEnumV2Input )
+  returns (output: Result<GetEnumV2Output, Error>) {
+    var res := GetEnumV2Output(value := input.value);
+    return Success(res);
+  }
+
+  // Known value tests. See "Known value test" in TestModels' README.
+  method GetEnumV2FirstKnownValueTest ( config: InternalConfig,  input: GetEnumV2Input )
+  returns (output: Result<GetEnumV2Output, Error>) {
+    expect input.value.Some?;
+    expect input.value.value == FIRST;
+
+    var res := GetEnumV2Output(value := input.value);
+
+    expect res.value.Some?;
+    expect res.value.value == FIRST; 
+
+    return Success(res);
+  }
+
+  method GetEnumV2SecondKnownValueTest ( config: InternalConfig,  input: GetEnumV2Input )
+  returns (output: Result<GetEnumV2Output, Error>) {
+    expect input.value.Some?;
+    expect input.value.value == SECOND;
+
+    var res := GetEnumV2Output(value := input.value);
+
+    expect res.value.Some?;
+    expect res.value.value == SECOND; 
+    
+    return Success(res);
+  }
+
+  method GetEnumV2ThirdKnownValueTest ( config: InternalConfig,  input: GetEnumV2Input )
+  returns (output: Result<GetEnumV2Output, Error>) {
+    expect input.value.Some?;
+    expect input.value.value == THIRD;
+
+    var res := GetEnumV2Output(value := input.value);
+
+    expect res.value.Some?;
+    expect res.value.value == THIRD; 
+    
+    return Success(res);
+  }
+}

--- a/TestModels/SimpleTypes/SimpleEnumV2/src/WrappedSimpleEnumImpl.dfy
+++ b/TestModels/SimpleTypes/SimpleEnumV2/src/WrappedSimpleEnumImpl.dfy
@@ -1,0 +1,8 @@
+include "../Model/SimpleTypesEnumV2TypesWrapped.dfy"
+
+module {:extern "Dafny.Simple.Types.EnumV2.Wrapped"} WrappedSimpleTypesEnumV2Service refines WrappedAbstractSimpleTypesEnumV2Service {
+    import WrappedService = SimpleEnumV2
+    function method WrappedDefaultSimpleEnumV2Config(): SimpleEnumV2Config {
+        SimpleEnumV2Config
+    }
+}

--- a/TestModels/SimpleTypes/SimpleEnumV2/test/SimpleEnumImplTest.dfy
+++ b/TestModels/SimpleTypes/SimpleEnumV2/test/SimpleEnumImplTest.dfy
@@ -19,14 +19,13 @@ module  SimpleEnumV2ImplTest {
       ensures client.ValidState()
     {
         var convertedEnumInput := SimpleEnumV2.Types.GetEnumV2Input(value := Some(THIRD));
-        
+
         expect convertedEnumInput.value.value == THIRD;
 
         var ret := client.GetEnumV2(convertedEnumInput);
-        
+
         expect ret.Success?;
         expect ret.value.value.UnwrapOr(FIRST) == THIRD;
-        print ret;
     }
 
     method TestGetEnumFirstKnownValueTest(client: ISimpleTypesEnumV2Client)
@@ -35,14 +34,13 @@ module  SimpleEnumV2ImplTest {
       ensures client.ValidState()
     {
         var convertedEnumInput := SimpleEnumV2.Types.GetEnumV2Input(value := Some(FIRST));
-        
+
         expect convertedEnumInput.value.value == FIRST;
 
         var ret := client.GetEnumV2FirstKnownValueTest(convertedEnumInput);
-        
+
         expect ret.Success?;
         expect ret.value.value.UnwrapOr(THIRD) == FIRST;
-        print ret;
     }
 
     method TestGetEnumSecondKnownValueTest(client: ISimpleTypesEnumV2Client)
@@ -51,14 +49,13 @@ module  SimpleEnumV2ImplTest {
       ensures client.ValidState()
     {
         var convertedEnumInput := SimpleEnumV2.Types.GetEnumV2Input(value := Some(SECOND));
-        
+
         expect convertedEnumInput.value.value == SECOND;
 
         var ret := client.GetEnumV2SecondKnownValueTest(convertedEnumInput);
-        
+
         expect ret.Success?;
         expect ret.value.value.UnwrapOr(THIRD) == SECOND;
-        print ret;
     }
 
     method TestGetEnumThirdKnownValueTest(client: ISimpleTypesEnumV2Client)
@@ -67,13 +64,12 @@ module  SimpleEnumV2ImplTest {
       ensures client.ValidState()
     {
         var convertedEnumInput := SimpleEnumV2.Types.GetEnumV2Input(value := Some(THIRD));
-        
+
         expect convertedEnumInput.value.value == THIRD;
 
         var ret := client.GetEnumV2ThirdKnownValueTest(convertedEnumInput);
-        
+
         expect ret.Success?;
         expect ret.value.value.UnwrapOr(FIRST) == THIRD;
-        print ret;
     }
 }

--- a/TestModels/SimpleTypes/SimpleEnumV2/test/SimpleEnumImplTest.dfy
+++ b/TestModels/SimpleTypes/SimpleEnumV2/test/SimpleEnumImplTest.dfy
@@ -1,0 +1,79 @@
+include "../src/Index.dfy"
+
+module  SimpleEnumV2ImplTest {
+    import SimpleEnumV2
+    import StandardLibrary.UInt
+    import opened SimpleTypesEnumV2Types
+    import opened Wrappers
+    method{:test} GetEnum(){
+        var client :- expect SimpleEnumV2.SimpleEnumV2();
+        TestGetEnum(client);
+        TestGetEnumFirstKnownValueTest(client);
+        TestGetEnumSecondKnownValueTest(client);
+        TestGetEnumThirdKnownValueTest(client);
+    }
+
+    method TestGetEnum(client: ISimpleTypesEnumV2Client)
+      requires client.ValidState()
+      modifies client.Modifies
+      ensures client.ValidState()
+    {
+        var convertedEnumInput := SimpleEnumV2.Types.GetEnumV2Input(value := Some(THIRD));
+        
+        expect convertedEnumInput.value.value == THIRD;
+
+        var ret := client.GetEnumV2(convertedEnumInput);
+        
+        expect ret.Success?;
+        expect ret.value.value.UnwrapOr(FIRST) == THIRD;
+        print ret;
+    }
+
+    method TestGetEnumFirstKnownValueTest(client: ISimpleTypesEnumV2Client)
+      requires client.ValidState()
+      modifies client.Modifies
+      ensures client.ValidState()
+    {
+        var convertedEnumInput := SimpleEnumV2.Types.GetEnumV2Input(value := Some(FIRST));
+        
+        expect convertedEnumInput.value.value == FIRST;
+
+        var ret := client.GetEnumV2FirstKnownValueTest(convertedEnumInput);
+        
+        expect ret.Success?;
+        expect ret.value.value.UnwrapOr(THIRD) == FIRST;
+        print ret;
+    }
+
+    method TestGetEnumSecondKnownValueTest(client: ISimpleTypesEnumV2Client)
+      requires client.ValidState()
+      modifies client.Modifies
+      ensures client.ValidState()
+    {
+        var convertedEnumInput := SimpleEnumV2.Types.GetEnumV2Input(value := Some(SECOND));
+        
+        expect convertedEnumInput.value.value == SECOND;
+
+        var ret := client.GetEnumV2SecondKnownValueTest(convertedEnumInput);
+        
+        expect ret.Success?;
+        expect ret.value.value.UnwrapOr(THIRD) == SECOND;
+        print ret;
+    }
+
+    method TestGetEnumThirdKnownValueTest(client: ISimpleTypesEnumV2Client)
+      requires client.ValidState()
+      modifies client.Modifies
+      ensures client.ValidState()
+    {
+        var convertedEnumInput := SimpleEnumV2.Types.GetEnumV2Input(value := Some(THIRD));
+        
+        expect convertedEnumInput.value.value == THIRD;
+
+        var ret := client.GetEnumV2ThirdKnownValueTest(convertedEnumInput);
+        
+        expect ret.Success?;
+        expect ret.value.value.UnwrapOr(FIRST) == THIRD;
+        print ret;
+    }
+}

--- a/TestModels/SimpleTypes/SimpleEnumV2/test/WrappedSimpleEnumTest.dfy
+++ b/TestModels/SimpleTypes/SimpleEnumV2/test/WrappedSimpleEnumTest.dfy
@@ -1,0 +1,15 @@
+include "../src/WrappedSimpleEnumImpl.dfy"
+include "SimpleEnumImplTest.dfy"
+
+module WrappedSimpleTypesEnumTest {
+    import WrappedSimpleTypesEnumV2Service
+    import SimpleEnumV2ImplTest
+    import opened Wrappers
+    method{:test} GetEnum() {
+        var client :- expect WrappedSimpleTypesEnumV2Service.WrappedSimpleEnumV2();
+        SimpleEnumV2ImplTest.TestGetEnum(client);
+        SimpleEnumV2ImplTest.TestGetEnumFirstKnownValueTest(client);
+        SimpleEnumV2ImplTest.TestGetEnumSecondKnownValueTest(client);
+        SimpleEnumV2ImplTest.TestGetEnumThirdKnownValueTest(client);
+    }
+}

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
@@ -84,8 +84,13 @@ public class DafnyApiCodegen {
               // Sort by shape ID for deterministic generated code
               .collect(Collectors.toCollection(TreeSet::new))
               .stream()
-              .map(this::generateCodeForShape)
-              .flatMap(Optional::stream)
+              .flatMap(shape -> {
+                  final Optional<TokenTree> tokens = generateCodeForShape(shape);
+                  if (tokens.isEmpty()) {
+                      LOGGER.info("No code generated for shape {}", shape.getId().toString());
+                  }
+                  return tokens.stream();
+              })
             )
           .lineSeparated();
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
@@ -238,6 +238,7 @@ public class DafnyApiCodegen {
                     yield generateStringTypeDefinition(shapeId);
                 }
             }
+            case ENUM -> generateEnumTypeDefinition(shapeId);
             case INTEGER, LONG -> generateNumericTypeDefinition(shapeId);
             case DOUBLE -> generateDoubleTypeDefinition(shapeId);
             case LIST -> generateListTypeDefinition(shapeId);

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyNameResolver.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyNameResolver.java
@@ -67,7 +67,7 @@ public record DafnyNameResolver(
         }
 
         return switch (shape.getType()) {
-            case BLOB, BOOLEAN, STRING,
+            case BLOB, BOOLEAN, STRING, ENUM,
                     // currently unused in model and unsupported in StandardLibrary.UInt
                     // BYTE, SHORT
                     INTEGER, LONG, DOUBLE,

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/DotNetNameResolver.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/DotNetNameResolver.java
@@ -266,6 +266,12 @@ public class DotNetNameResolver {
                 : "string";
     }
 
+    protected String baseTypeForEnum(final EnumShape enumShape) {
+        final ShapeId shapeId = enumShape.getId();
+        final String namespace = namespaceForShapeId(shapeId);
+        return "%s.%s".formatted(namespace, classForEnum(shapeId));
+    }
+
     protected String baseTypeForList(final ListShape listShape) {
         if (StringUtils.equals(baseTypeForMember(listShape.getMember()),
                 AwsSdkDotNetNameResolver.DDB_ATTRIBUTE_VALUE_MODEL_NAMESPACE)) {
@@ -560,7 +566,7 @@ public class DotNetNameResolver {
         return switch (shape.getType()) {
             case BLOB, DOUBLE -> "Dafny.ISequence<byte>";
             case BOOLEAN -> "bool";
-            case STRING -> dafnyTypeForString(shape.asStringShape().get());
+            case STRING, ENUM -> dafnyTypeForString(shape.asStringShape().get());
             case INTEGER -> "int";
             case LONG -> "long";
             // TODO create/use better timestamp type in Dafny libraries

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/DotNetNameResolver.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/DotNetNameResolver.java
@@ -567,7 +567,8 @@ public class DotNetNameResolver {
         return switch (shape.getType()) {
             case BLOB, DOUBLE -> "Dafny.ISequence<byte>";
             case BOOLEAN -> "bool";
-            case STRING, ENUM -> dafnyTypeForString(shape.asStringShape().get());
+            case STRING -> dafnyTypeForString(shape.asStringShape().get());
+            case ENUM -> dafnyTypeForEnum(shape.getId(), false);
             case INTEGER -> "int";
             case LONG -> "long";
             // TODO create/use better timestamp type in Dafny libraries

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/DotNetNameResolver.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/DotNetNameResolver.java
@@ -414,6 +414,7 @@ public class DotNetNameResolver {
             }
 
             case STRING -> baseTypeForString(shape.asStringShape().get());
+            case ENUM -> baseTypeForEnum(shape.asEnumShape().get());
             case LIST -> baseTypeForList(shape.asListShape().get());
             case MAP -> baseTypeForMap(shape.asMapShape().get());
             case STRUCTURE -> baseTypeForStructure(shape.asStructureShape().get());

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/ServiceCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/ServiceCodegen.java
@@ -4,6 +4,7 @@
 package software.amazon.polymorph.smithydotnet;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Streams;
 import software.amazon.polymorph.smithydotnet.nativeWrapper.NativeWrapperCodegen;
 import software.amazon.polymorph.traits.ExtendableTrait;
 import software.amazon.polymorph.traits.PositionalTrait;
@@ -115,8 +116,7 @@ public class ServiceCodegen {
                 });
 
         // Enums (both string shapes as in Smithy IDL 1.0, and enum shapes as in 2.0)
-        model.getShapesWithTrait(EnumTrait.class)
-                .stream()
+        Streams.concat(model.getEnumShapes().stream(), model.getStringShapesWithTrait(EnumTrait.class).stream())
                 .map(Shape::getId)
                 .filter(enumShapeId -> ModelUtils.isInServiceNamespace(enumShapeId, serviceShape))
                 .forEach(enumShapeId -> {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/ServiceCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/ServiceCodegen.java
@@ -496,8 +496,8 @@ public class ServiceCodegen {
      * @return a class containing constants for the enum members
      */
     public TokenTree generateEnumClass(final ShapeId shapeId) {
-        final StringShape stringShape = model.expectShape(shapeId, StringShape.class);
-        final EnumTrait enumTrait = getAndValidateEnumTrait(stringShape);
+        final Shape shape = model.expectShape(shapeId);
+        final EnumTrait enumTrait = getAndValidateEnumTrait(shape);
 
         final String enumClassName = nameResolver.classForEnum(shapeId);
         final String enumValueTypeName = enumTrait.hasNames() ? enumClassName : "string";

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/ServiceCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/ServiceCodegen.java
@@ -114,8 +114,8 @@ public class ServiceCodegen {
                     codeByPath.put(structureClassPath, structureCode.prepend(prelude));
                 });
 
-        // Enums
-        model.getStringShapesWithTrait(EnumTrait.class)
+        // Enums (both string shapes as in Smithy IDL 1.0, and enum shapes as in 2.0)
+        model.getShapesWithTrait(EnumTrait.class)
                 .stream()
                 .map(Shape::getId)
                 .filter(enumShapeId -> ModelUtils.isInServiceNamespace(enumShapeId, serviceShape))
@@ -476,9 +476,9 @@ public class ServiceCodegen {
                 .orElse(Token.of("void"));
     }
 
-    private EnumTrait getAndValidateEnumTrait(final StringShape stringShape) {
-        final EnumTrait enumTrait = stringShape.getTrait(EnumTrait.class)
-                .orElseThrow(() -> new IllegalStateException("EnumTrait absent on provided string shape"));
+    private EnumTrait getAndValidateEnumTrait(final Shape shape) {
+        final EnumTrait enumTrait = shape.getTrait(EnumTrait.class)
+                .orElseThrow(() -> new IllegalStateException("EnumTrait absent on provided shape"));
         if (enumTrait.hasNames() && hasInvalidEnumNames(enumTrait)) {
             throw new IllegalStateException("Enum definition names must be uppercase alphanumeric and begin with a letter");
         }
@@ -495,11 +495,11 @@ public class ServiceCodegen {
      *
      * @return a class containing constants for the enum members
      */
-    public TokenTree generateEnumClass(final ShapeId stringShapeId) {
-        final StringShape stringShape = model.expectShape(stringShapeId, StringShape.class);
+    public TokenTree generateEnumClass(final ShapeId shapeId) {
+        final StringShape stringShape = model.expectShape(shapeId, StringShape.class);
         final EnumTrait enumTrait = getAndValidateEnumTrait(stringShape);
 
-        final String enumClassName = nameResolver.classForEnum(stringShapeId);
+        final String enumClassName = nameResolver.classForEnum(shapeId);
         final String enumValueTypeName = enumTrait.hasNames() ? enumClassName : "string";
         final TokenTree namedEnumValues = enumTrait.hasNames()
                 ? generateNamedEnumValues(enumTrait, enumClassName)

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -33,7 +33,9 @@ import software.amazon.polymorph.utils.TokenTree;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.*;
 import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.EnumValueTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.synthetic.SyntheticEnumTrait;
 import software.amazon.smithy.utils.StringUtils;
 
 import static software.amazon.polymorph.smithydotnet.DotNetNameResolver.TYPE_CONVERSION_CLASS_NAME;
@@ -174,12 +176,10 @@ public class TypeConversionCodegen {
                 .map(unionShape -> unionShape.getId())
                 .collect(Collectors.toSet());
 
-        // TODO add smithy v2 Enums
         // Collect enum shapes
-        final Set<ShapeId> enumShapes = model.getStringShapes().stream()
-                .filter(stringShape -> isInServiceNamespace(stringShape.getId()))
-                .filter(stringShape -> stringShape.hasTrait(EnumTrait.class))
-                .map(stringShape -> stringShape.getId())
+        final Set<ShapeId> enumShapes = model.getShapesWithTrait(EnumTrait.class).stream()
+                .map(Shape::getId)
+                .filter(this::isInServiceNamespace)
                 .collect(Collectors.toSet());
 
         // Collect all specific error structures
@@ -210,6 +210,7 @@ public class TypeConversionCodegen {
             case BLOB -> generateBlobConverter(shape.asBlobShape().get());
             case BOOLEAN -> generateBooleanConverter(shape.asBooleanShape().get());
             case STRING -> generateStringConverter(shape.asStringShape().get());
+            case ENUM -> generateEnumConverter(shape.asEnumShape().get());
             case INTEGER -> generateIntegerConverter(shape.asIntegerShape().get());
             case LONG -> generateLongConverter(shape.asLongShape().get());
             case DOUBLE -> generateDoubleConverter(shape.asDoubleShape().get());
@@ -790,21 +791,27 @@ public class TypeConversionCodegen {
      * Smithy-defined name (the {@link EnumDefNames#defName}) and the Dafny-compiler-generated name (the
      * {@link EnumDefNames#dafnyName}).
      */
-    private static record EnumDefNames(String defName, String dafnyName) {}
+    private record EnumDefNames(String defName, String dafnyName) {}
+
+    public TypeConverter generateEnumConverter(final EnumShape enumShape) {
+        return generateEnumConverter(enumShape, enumShape.expectTrait(SyntheticEnumTrait.class));
+    }
 
     /**
-     * This should not be called directly, instead call
-     * {@link TypeConversionCodegen#generateStringConverter(StringShape)}.
+     * This should not be called directly, instead call either
+     * {@link TypeConversionCodegen#generateStringConverter(StringShape)} (for @enums)
+     * or
+     * {@link TypeConversionCodegen#generateEnumConverter(EnumShape)} (for Smithy 2.0 enums).
      */
-    private TypeConverter generateEnumConverter(final StringShape stringShape, final EnumTrait enumTrait) {
+    private TypeConverter generateEnumConverter(final Shape shape, final EnumTrait enumTrait) {
         assert enumTrait.hasNames();
         //noinspection OptionalGetWithoutIsPresent
         final List<EnumDefNames> defNames = enumTrait.getValues().stream()
                 .map(enumDefinition -> enumDefinition.getName().get())
                 .map(name -> new EnumDefNames(name, DotNetNameResolver.dafnyCompiledNameForEnumDefinitionName(name)))
                 .toList();
-        final String enumClass = nameResolver.baseTypeForShape(stringShape.getId());
-        final String dafnyEnumConcreteType = nameResolver.dafnyConcreteTypeForEnum(stringShape.getId());
+        final String enumClass = nameResolver.baseTypeForShape(shape.getId());
+        final String dafnyEnumConcreteType = nameResolver.dafnyConcreteTypeForEnum(shape.getId());
         final Token throwInvalidEnumValue = Token.of("\nthrow new System.ArgumentException(\"Invalid %s value\");"
                 .formatted(enumClass));
 
@@ -827,7 +834,7 @@ public class TypeConversionCodegen {
                 .lineSeparated()
                 .append(throwInvalidEnumValue);
 
-        return buildConverterFromMethodBodies(stringShape, fromDafnyBody, toDafnyBody);
+        return buildConverterFromMethodBodies(shape, fromDafnyBody, toDafnyBody);
     }
 
     /**

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/ToDafny.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/ToDafny.java
@@ -203,7 +203,7 @@ public abstract class ToDafny extends Generator {
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
-    protected MethodSpec modeledEnum(StringShape shape) {
+    protected MethodSpec modeledEnum(Shape shape) {
         final ShapeId shapeId = shape.getId();
         String methodName = capitalize(shapeId.getName());
         final EnumTrait enumTrait = shape.getTrait(EnumTrait.class).orElseThrow(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/ToNative.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/ToNative.java
@@ -179,7 +179,7 @@ public abstract class ToNative extends Generator {
         return builder.build();
     }
 
-    protected MethodSpec modeledEnum(StringShape shape) {
+    protected MethodSpec modeledEnum(Shape shape) {
         final ClassName returnType = subject.nativeNameResolver.classForEnum(shape);
         MethodSpec.Builder method = modeledEnumCommon(shape, returnType);
         // No Enum value matched, throw an Exception
@@ -192,7 +192,7 @@ public abstract class ToNative extends Generator {
 
     /** @return MethodSpec.Builder with an If-Return for every known enum value.*/
     protected final MethodSpec.Builder modeledEnumCommon(
-            StringShape shape, ClassName returnType
+            Shape shape, ClassName returnType
     ) {
         final ShapeId shapeId = shape.getId();
         final String methodName = capitalize(shapeId.getName());

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
@@ -333,7 +333,7 @@ public class ToDafnyAwsV2 extends ToDafny {
      */
     @Override
     @SuppressWarnings("OptionalGetWithoutIsPresent")
-    protected MethodSpec modeledEnum(StringShape shape) {
+    protected MethodSpec modeledEnum(Shape shape) {
         final ShapeId shapeId = shape.getId();
         String methodName = capitalize(shapeId.getName());
         final EnumTrait enumTrait = shape.getTrait(EnumTrait.class).orElseThrow(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/JavaLibrary.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/JavaLibrary.java
@@ -1,5 +1,6 @@
 package software.amazon.polymorph.smithyjava.generator.library;
 
+import com.google.common.collect.Streams;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 
@@ -9,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +45,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.EnumValueTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.TraitDefinition;
 
@@ -171,8 +174,14 @@ public class JavaLibrary extends CodegenSubject {
                 .sorted().toList();
     }
 
-    public List<StringShape> getEnumsInServiceNamespace() {
-        return this.model.getStringShapesWithTrait(EnumTrait.class).stream()
+    public List<Shape> getEnumsInServiceNamespace() {
+        final Stream<Shape> enumShapes = Streams.concat(
+                // @enum string
+                this.model.getStringShapesWithTrait(EnumTrait.class).stream(),
+                // Smithy 2.0 enum shapes
+                this.model.getEnumShapes().stream()
+        );
+        return enumShapes
                 .filter(shape -> ModelUtils.isInServiceNamespace(shape.getId(), this.serviceShape))
                 .sorted().toList();
     }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/ModelCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/ModelCodegen.java
@@ -8,7 +8,8 @@ import software.amazon.polymorph.smithyjava.modeled.ModeledStructure;
 import software.amazon.polymorph.smithyjava.modeled.ModeledUnion;
 import software.amazon.polymorph.smithyjava.unmodeled.CollectionOfErrors;
 import software.amazon.polymorph.smithyjava.unmodeled.OpaqueError;
-import software.amazon.smithy.model.shapes.StringShape;
+
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 
@@ -74,8 +75,8 @@ class ModelCodegen extends Generator {
         return ModeledStructure.javaFile(modelPackageName, shape, subject);
     }
 
-    JavaFile modeledEnum(StringShape stringShape) {
-        return ModeledEnum.javaFile(modelPackageName, stringShape);
+    JavaFile modeledEnum(Shape shape) {
+        return ModeledEnum.javaFile(modelPackageName, shape);
     }
 
     JavaFile modeledUnion(UnionShape shape) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/modeled/ModeledEnum.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/modeled/ModeledEnum.java
@@ -7,7 +7,7 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
 
 import software.amazon.polymorph.traits.JavaDocTrait;
-import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
 
@@ -20,7 +20,7 @@ public class ModeledEnum {
     static final String TO_STRING_METHOD_NAME = "toString";
     static final FieldSpec ENUM_VALUE_FIELD = FieldSpec.builder(String.class, VALUE_VAR, PRIVATE, FINAL).build();
 
-    public static JavaFile javaFile(String packageName, StringShape shape) {
+    public static JavaFile javaFile(String packageName, Shape shape) {
         ClassName className = ClassName.get(packageName, shape.getId().getName());
         TypeSpec.Builder enumSpec = TypeSpec.enumBuilder(className);
         enumSpec.addModifiers(PUBLIC);

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Native.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Native.java
@@ -173,6 +173,7 @@ public class Native extends NameResolver{
     }
 
     public ClassName classForStringOrEnum(final Shape shape) {
+        // This case must be first because shape can be an @enum string, or a Smithy 2.0 enum
         if (shape.hasTrait(EnumTrait.class)) {
             if (AwsSdkNameResolverHelpers.isInAwsSdkNamespace(shape.getId())) {
                 return switch (awsSdkVersion) {
@@ -182,7 +183,12 @@ public class Native extends NameResolver{
             }
             return classForEnum(shape);
         }
-        return classForString();
+
+        if (shape.getType().isShapeType(ShapeType.STRING)) {
+            return classForString();
+        }
+
+        throw new IllegalArgumentException("Shape was neither string nor enum");
     }
 
     public ClassName classForEnum(final Shape shape) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Native.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Native.java
@@ -31,7 +31,6 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
-import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.BoxTrait;
 import software.amazon.smithy.model.traits.EnumTrait;
 
@@ -148,7 +147,7 @@ public class Native extends NameResolver{
             }
             // For supported simple shapes, just map to native types
             case BLOB, TIMESTAMP, BIG_DECIMAL, BIG_INTEGER -> NATIVE_TYPES_BY_SIMPLE_SHAPE_TYPE.get(shape.getType());
-            case STRING -> classForStringOrEnum(shape.asStringShape().get());
+            case STRING, ENUM -> classForStringOrEnum(shape);
             case LIST -> ParameterizedTypeName.get(
                     ClassName.get(List.class),
                     typeForShape(shape.asListShape().get().getMember().getTarget())
@@ -173,7 +172,7 @@ public class Native extends NameResolver{
         };
     }
 
-    public ClassName classForStringOrEnum(final StringShape shape) {
+    public ClassName classForStringOrEnum(final Shape shape) {
         if (shape.hasTrait(EnumTrait.class)) {
             if (AwsSdkNameResolverHelpers.isInAwsSdkNamespace(shape.getId())) {
                 return switch (awsSdkVersion) {

--- a/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithydotnet/DotNetNameResolverTest.java
+++ b/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithydotnet/DotNetNameResolverTest.java
@@ -13,8 +13,10 @@ import software.amazon.polymorph.util.TestModel;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.loader.ModelAssembler;
+import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -23,7 +25,9 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.UnitTypeTrait;
 
+import java.util.EnumSet;
 import java.util.function.BiConsumer;
 
 import static org.junit.Assert.assertEquals;
@@ -102,6 +106,21 @@ public class DotNetNameResolverTest {
         final DotNetNameResolver nameResolver = setupNameResolver(
                 (builder, modelAssembler) -> modelAssembler.addShape(enumStringShape));
         assertEquals("test.foobar.internaldafny.types._IEnumString", nameResolver.dafnyTypeForShape(enumStringShape.getId()));
+    }
+
+    @Test
+    public void testDafnyTypeForEnumV2() {
+        final MemberShape memberShape = MemberShape.builder()
+                .id(ShapeId.fromParts(SERVICE_NAMESPACE, "EnumShape", "FOO"))
+                .target(UnitTypeTrait.UNIT)
+                .build();
+        final EnumShape enumShape = EnumShape.builder()
+                .id(ShapeId.fromParts(SERVICE_NAMESPACE, "EnumShape"))
+                .addMember(memberShape)
+                .build();
+        final DotNetNameResolver nameResolver = setupNameResolver(
+                (builder, modelAssembler) -> modelAssembler.addShape(enumShape));
+        assertEquals("Dafny.Test.Foobar.Types._IEnumShape", nameResolver.dafnyTypeForShape(enumShape.getId()));
     }
 
     @Test

--- a/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithydotnet/DotNetNameResolverTest.java
+++ b/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithydotnet/DotNetNameResolverTest.java
@@ -120,7 +120,7 @@ public class DotNetNameResolverTest {
                 .build();
         final DotNetNameResolver nameResolver = setupNameResolver(
                 (builder, modelAssembler) -> modelAssembler.addShape(enumShape));
-        assertEquals("Dafny.Test.Foobar.Types._IEnumShape", nameResolver.dafnyTypeForShape(enumShape.getId()));
+        assertEquals("test.foobar.internaldafny.types._IEnumShape", nameResolver.dafnyTypeForShape(enumShape.getId()));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:* #105

*Description of changes:* Implements Smithy 2.0 support. Concretely, this updates Smithy dependencies to the latest version (1.28.1 as of this writing) which can read Smithy IDL 2.0 models.

Most of smithy-dafny's code generation logic is unchanged because the underlying Smithy semantic model has not undergone any breaking changes. The exception is that supporting Smithy 2.0's new `enum` shape (as opposed to `@enum`-attached `string` shapes) requires changes to shape discovery and generated symbol names. Thankfully the Smithy tooling attaches `SyntheticEnumTrait (extends EnumTrait)` to each Smithy 2.0 `enum` shape, so that the codegen logic can inspect `enum` shapes just like the old `@enum string` shapes.

Notes for reviewers:

* The `SimpleEnumV2` test model is mostly copied from the `SimpleEnum` test model, with names changed to include "V2". I'd recommend only skimming over these files.
* The most important changes are those made in the codegen logic. In particular, I'm less familiar with the Java codegen structure, so I'd appreciate extra attention to it (cc @texastony). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
