### PR TITLE
test: general gradle build

### DIFF
--- a/.github/workflows/smithy-polymorph.yml
+++ b/.github/workflows/smithy-polymorph.yml
@@ -27,3 +27,9 @@ jobs:
         with:
           arguments: :smithy-dafny-codegen:test
           build-root-directory: codegen
+
+      - name: Execute codegen build
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+          build-root-directory: codegen


### PR DESCRIPTION
*Issue #, if available:* Follow up from https://github.com/awslabs/smithy-dafny/pull/216

*Description of changes:* Test `gradle -p codegen build` from root

As follow up, we SHOULD make this check required.
Though, since its already part of the gradle-build workflow, it may already be required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
