### PR TITLE
fix(Java): local service test

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/JavaLibrary.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/JavaLibrary.java
@@ -52,8 +52,8 @@ public class JavaLibrary extends CodegenSubject {
     public final String packageName;
     /** Public POJOs will go here. */
     public final String modelPackageName;
-    protected final ToDafnyLibrary toDafnyLibrary;
-    protected final ToNativeLibrary toNativeLibrary;
+    public final ToDafnyLibrary toDafnyLibrary;
+    public final ToNativeLibrary toNativeLibrary;
 
     public JavaLibrary(Model model, ServiceShape serviceShape, AwsSdkVersion sdkVersion) {
         super(model, serviceShape, initDafny(model, serviceShape, sdkVersion), initNative(model, serviceShape, sdkVersion), sdkVersion);

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/ToDafnyLibrary.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/ToDafnyLibrary.java
@@ -232,7 +232,7 @@ public class ToDafnyLibrary extends ToDafny {
     // that can be in other namespaces.
     // This override simplifies their lookup.
     @Override
-    protected MethodReference conversionMethodReference(Shape shape) {
+    public MethodReference conversionMethodReference(Shape shape) {
         ModelUtils.ResolvedShapeId resolvedShapeId = ModelUtils.resolveShape(shape.getId(),subject.model );
         Shape resolvedShape = subject.model.expectShape(resolvedShapeId.resolvedId());
         if (resolvedShape.isServiceShape() || resolvedShape.isResourceShape()) {


### PR DESCRIPTION
*Issue #, if available:* [[Polymorph][Java] Support the `--local-service-test` flag](https://sim.amazon.com/issues/CrypTool-5106)

*Description of Fixes:*
- Services & Resources MUST BE declared as interfaces
- Conversion Methods SHOULD BE looked up, as compared to assumed. 
  (Only fixed for ToDafny, not ToNative).

*Testing*: Smith-Dafny has 3 TestModels that use the code under change.
However, those tests have not been updated to cover the bugs addressed here.
The PR to ESDK-Dafny, particularly [`wrapped/TestMaterialProviders.java`](https://github.com/aws/private-aws-encryption-sdk-dafny-staging/pull/159/files#diff-a01308065565148ee0d54e367ec53490c24e66acfba6bfde169e2b609d4d60a5), 
is a better test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
