### PR TITLE
fix(Java): Operation.AsDafny.declareNativeInputAndCovert

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/ToNativeLibrary.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/ToNativeLibrary.java
@@ -259,7 +259,7 @@ public class ToNativeLibrary extends ToNative {
     // that can be in other namespaces.
     // This override simplifies their lookup.
     @Override
-    protected MethodReference conversionMethodReference(Shape shape) {
+    public MethodReference conversionMethodReference(Shape shape) {
         ModelUtils.ResolvedShapeId resolvedShapeId = ModelUtils.resolveShape(shape.toShapeId(), subject.model);
         Shape resolvedShape = subject.model.expectShape(resolvedShapeId.resolvedId());
         if (resolvedShape.isServiceShape() || resolvedShape.isResourceShape()) {


### PR DESCRIPTION
*Issue #, if available:*

While working on
`test-Java-Dependencies`,
I ran into this bug.

I was working on `test-Java-Dependencies` so I would have a Test Model
for the Error Improvements (SIM: [[Epic][Polymorph] Improve Error](https://sim.amazon.com/issues/CrypTool-5105)).

*Description of changes:*
- Do not assume the Input Shape is from this Namespace/Service.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
