### PR TITLE
feat(Java): Always Generate in Order

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/Generator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/Generator.java
@@ -65,7 +65,7 @@ public abstract class Generator {
     public abstract Set<JavaFile> javaFiles();
 
     protected List<OperationShape> getOperationsForTarget() {
-        return subject.serviceShape.getOperations().stream().sequential()
+        return subject.serviceShape.getOperations().stream().sorted()
                 .map(shapeId -> subject.model.expectShape(shapeId, OperationShape.class))
                 .collect(Collectors.toList());
     }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/ToNative.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/ToNative.java
@@ -203,7 +203,7 @@ public abstract class ToNative extends Generator {
                     "Unnamed enums not supported. ShapeId: %s".formatted(shapeId));
         }
 
-        enumTrait.getValues().stream().sequential()
+        enumTrait.getValues().stream()
                 .map(EnumDefinition::getName)
                 .map(maybeName -> maybeName.orElseThrow(
                         () -> new IllegalArgumentException(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v1/ShimV1.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v1/ShimV1.java
@@ -74,7 +74,7 @@ public class ShimV1 extends Generator {
                 .addMethod(impl())
                 .addMethods(
                         subject.serviceShape.getAllOperations()
-                                .stream()
+                                .stream().sorted()
                                 .map(this::operation)
                                 .filter(Optional::isPresent)
                                 .map(Optional::get)
@@ -152,7 +152,7 @@ public class ShimV1 extends Generator {
                             DAFNY_RESULT_CLASS_NAME);
         }
 
-        operationShape.getErrors().forEach(shapeId ->
+        operationShape.getErrors().stream().sorted().forEach(shapeId ->
                 builder
                         .nextControlFlow("catch ($T ex)", subject.nativeNameResolver.typeForShape(shapeId))
                         .addStatement("return $T.create_Failure(ToDafny.Error(ex))",

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v1/ToDafnyAwsV1.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v1/ToDafnyAwsV1.java
@@ -93,21 +93,21 @@ public class ToDafnyAwsV1 extends ToDafny {
 
     TypeSpec toDafny() {
         List<OperationShape> operations = subject.serviceShape
-                .getOperations().stream()
+                .getOperations().stream().sorted()
                 .map(shapeId -> subject.model.expectShape(shapeId, OperationShape.class))
                 .toList();
         LinkedHashSet<ShapeId> operationOutputs = operations.stream()
-                .map(OperationShape::getOutputShape)
+                .map(OperationShape::getOutputShape).sorted()
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         LinkedHashSet<ShapeId> operationInputs = operations.stream()
-                .map(OperationShape::getInputShape)
+                .map(OperationShape::getInputShape).sorted()
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         LinkedHashSet<ShapeId> serviceErrors = operations.stream()
                 .map(OperationShape::getErrors)
-                .flatMap(Collection::stream)
+                .flatMap(Collection::stream).sorted()
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         ModelUtils.streamServiceErrors(subject.model, subject.serviceShape)
-                .map(Shape::toShapeId)
+                .map(Shape::toShapeId).sorted()
                 .forEachOrdered(serviceErrors::add);
 
         LinkedHashSet<ShapeId> operationStructures = new LinkedHashSet<>();
@@ -133,18 +133,18 @@ public class ToDafnyAwsV1 extends ToDafny {
 
         final List<MethodSpec> convertOutputs = operationOutputs.stream()
                 .map(this::generateConvertResponseV1).toList();
-        final List<MethodSpec> convertAllRelevant = allRelevantShapeIds.stream()
+        final List<MethodSpec> convertAllRelevant = allRelevantShapeIds.stream().sorted()
                 .map(this::generateConvert).filter(Objects::nonNull).toList();
-        final List<MethodSpec> convertServiceErrors = serviceErrors.stream()
+        final List<MethodSpec> convertServiceErrors = serviceErrors.stream().sorted()
                 .map(this::modeledError).collect(Collectors.toList());
         convertServiceErrors.add(generateConvertOpaqueError());
         // For enums, we generate overloaded methods,
         // one to convert instances of the Enum
         final List<MethodSpec> convertEnumEnum = enumShapeIds
-                .stream().map(this::generateConvertEnumEnum).toList();
+                .stream().sorted().map(this::generateConvertEnumEnum).toList();
         // The other to convert String representatives of the enum
         final List<MethodSpec> convertEnumString = enumShapeIds
-                .stream().map(this::generateConvertEnumString).toList();
+                .stream().sorted().map(this::generateConvertEnumString).toList();
 
         return TypeSpec
                 .classBuilder(className(subject.serviceShape.toShapeId()))

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v1/ToNativeAwsV1.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v1/ToNativeAwsV1.java
@@ -91,21 +91,21 @@ public class ToNativeAwsV1 extends ToNative {
 
     TypeSpec toNative() {
         List<OperationShape> operations = subject.serviceShape
-                .getOperations().stream()
+                .getOperations().stream().sorted()
                 .map(shapeId -> subject.model.expectShape(shapeId, OperationShape.class))
                 .toList();
         LinkedHashSet<ShapeId> operationOutputs = operations.stream()
-                .map(OperationShape::getOutputShape)
+                .map(OperationShape::getOutputShape).sorted()
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         LinkedHashSet<ShapeId> operationInputs = operations.stream()
-                .map(OperationShape::getInputShape)
+                .map(OperationShape::getInputShape).sorted()
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         LinkedHashSet<ShapeId> serviceErrors = operations.stream()
                 .map(OperationShape::getErrors)
-                .flatMap(Collection::stream)
+                .flatMap(Collection::stream).sorted()
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         ModelUtils.streamServiceErrors(subject.model, subject.serviceShape)
-                .map(Shape::toShapeId)
+                .map(Shape::toShapeId).sorted()
                 .forEachOrdered(serviceErrors::add);
 
         LinkedHashSet<ShapeId> operationStructures = new LinkedHashSet<>();
@@ -122,9 +122,9 @@ public class ToNativeAwsV1 extends ToNative {
 
         final List<MethodSpec> convertOutputs = operationOutputs.stream()
                 .map(this::generateConvertResponseV1).toList();
-        final List<MethodSpec> convertAllRelevant = allRelevantShapeIds.stream()
+        final List<MethodSpec> convertAllRelevant = allRelevantShapeIds.stream().sorted()
                 .map(this::generateConvert).filter(Objects::nonNull).toList();
-        final List<MethodSpec> convertServiceErrors = serviceErrors.stream()
+        final List<MethodSpec> convertServiceErrors = serviceErrors.stream().sorted()
                 .map(this::modeledError).collect(Collectors.toList());
 
         return TypeSpec
@@ -190,7 +190,7 @@ public class ToNativeAwsV1 extends ToNative {
         builder.addStatement("$T $L = new $T()", nativeClassName, VAR_OUTPUT, nativeClassName);
 
         // For each member
-        structureShape.members()
+        structureShape.members().stream().sorted()
                 .forEach(member -> {
                     // if optional, check if present
                     if (member.isOptional()) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ShimV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ShimV2.java
@@ -74,7 +74,7 @@ public class ShimV2 extends Generator {
                 .addMethod(region())
                 .addMethods(
                         subject.serviceShape.getAllOperations()
-                                .stream()
+                                .stream().sorted()
                                 .map(this::operation)
                                 .filter(Optional::isPresent)
                                 .map(Optional::get)
@@ -152,7 +152,7 @@ public class ShimV2 extends Generator {
                             DAFNY_RESULT_CLASS_NAME);
         }
 
-        operationShape.getErrors().forEach(shapeId -> {
+        operationShape.getErrors().stream().sorted().forEach(shapeId -> {
             TypeName typeForShape = subject.nativeNameResolver.typeForShape(shapeId);
 
             // InvalidEndpointException was removed in SDK V2

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
@@ -101,16 +101,16 @@ public class ToDafnyAwsV2 extends ToDafny {
 
     TypeSpec toDafny() {
         List<OperationShape> operations = subject.serviceShape
-                .getOperations().stream()
+                .getOperations().stream().sorted()
                 .map(shapeId -> subject.model.expectShape(shapeId, OperationShape.class))
                 .toList();
         LinkedHashSet<ShapeId> operationStructures = operations.stream()
-                .map(OperationShape::getInputShape)
+                .map(OperationShape::getInputShape).sorted()
                 .collect(Collectors.toCollection(LinkedHashSet::new));
-        operations.stream().map(OperationShape::getOutputShape)
+        operations.stream().map(OperationShape::getOutputShape).sorted()
                 .forEachOrdered(operationStructures::add);
         LinkedHashSet<ShapeId> serviceErrors = ModelUtils.streamServiceErrors(subject.model, subject.serviceShape)
-                .map(Shape::toShapeId)
+                .map(Shape::toShapeId).sorted()
                 // InvalidEndpointException does not exist in SDK V2
                 .filter(structureShapeId -> !structureShapeId.toString().contains("com.amazonaws.dynamodb#InvalidEndpointException"))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
@@ -129,17 +129,17 @@ public class ToDafnyAwsV2 extends ToDafny {
         });
         allRelevantShapeIds.removeAll(enumShapeIds);
 
-        final List<MethodSpec> convertAllRelevant = allRelevantShapeIds.stream()
+        final List<MethodSpec> convertAllRelevant = allRelevantShapeIds.stream().sorted()
                 .map(this::generateConvert).filter(Objects::nonNull).toList();
-        final List<MethodSpec> convertServiceErrors = serviceErrors.stream()
+        final List<MethodSpec> convertServiceErrors = serviceErrors.stream().sorted()
                 .map(this::modeledError).toList();
         // For enums, we generate overloaded methods,
         // one to convert instances of the Enum
         final List<MethodSpec> convertEnumEnum = enumShapeIds
-                .stream().map(this::generateConvertEnumEnum).toList();
+                .stream().sorted().map(this::generateConvertEnumEnum).toList();
         // The other to convert String representatives of the enum
         final List<MethodSpec> convertEnumString = enumShapeIds
-                .stream().map(this::generateConvertEnumString).toList();
+                .stream().sorted().map(this::generateConvertEnumString).toList();
 
         return TypeSpec
                 .classBuilder(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/JavaLibrary.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/JavaLibrary.java
@@ -2,7 +2,6 @@ package software.amazon.polymorph.smithyjava.generator.library;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.MethodSpec;
 
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -138,7 +137,7 @@ public class JavaLibrary extends CodegenSubject {
         return this.model.getStructureShapes().stream()
                 .filter(shape -> shape.hasTrait(ErrorTrait.class))
                 .filter(shape -> ModelUtils.isInServiceNamespace(shape.getId(), this.serviceShape))
-                .toList();
+                .sorted().toList();
     }
 
     public List<StructureShape> getStructuresInServiceNamespace() {
@@ -158,43 +157,43 @@ public class JavaLibrary extends CodegenSubject {
                     return !targetShape.hasTrait(ReferenceTrait.class);
                 })
                 .filter(shape -> ModelUtils.isInServiceNamespace(shape.getId(), this.serviceShape))
-                .toList();
+                .sorted().toList();
     }
 
     public List<ResourceShape> getResourcesInServiceNamespace() {
         return this.model.getResourceShapes().stream()
                 .filter(shape -> ModelUtils.isInServiceNamespace(shape.getId(), this.serviceShape))
-                .toList();
+                .sorted().toList();
     }
 
     public List<StringShape> getEnumsInServiceNamespace() {
         return this.model.getStringShapesWithTrait(EnumTrait.class).stream()
                 .filter(shape -> ModelUtils.isInServiceNamespace(shape.getId(), this.serviceShape))
-                .toList();
+                .sorted().toList();
     }
 
     public List<UnionShape> getUnionsInServiceNamespace() {
-        return this.model.getUnionShapes().stream().sequential()
+        return this.model.getUnionShapes().stream()
                 .filter(shape -> ModelUtils.isInServiceNamespace(shape.getId(), this.serviceShape))
-                .collect(Collectors.toList());
+                .sorted().toList();
     }
 
     public List<ListShape> getListsInServiceNamespace() {
-        return this.model.getListShapes().stream().sequential()
+        return this.model.getListShapes().stream()
                 .filter(shape -> ModelUtils.isInServiceNamespace(shape.getId(), this.serviceShape))
-                .collect(Collectors.toList());
+                .sorted().toList();
     }
 
     public List<SetShape> getSetsInServiceNamespace() {
-        return this.model.getSetShapes().stream().sequential()
+        return this.model.getSetShapes().stream()
                 .filter(shape -> ModelUtils.isInServiceNamespace(shape.getId(), this.serviceShape))
-                .collect(Collectors.toList());
+                .sorted().toList();
     }
 
     public List<MapShape> getMapsInServiceNamespace() {
-        return this.model.getMapShapes().stream().sequential()
+        return this.model.getMapShapes().stream()
                 .filter(shape -> ModelUtils.isInServiceNamespace(shape.getId(), this.serviceShape))
-                .collect(Collectors.toList());
+                .sorted().toList();
     }
 
     public CodeBlock wrapWithShim(ShapeId referentId, CodeBlock referentVariable) throws ExpectationNotMetException {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/shims/ResourceShim.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/shims/ResourceShim.java
@@ -181,7 +181,7 @@ public class ResourceShim extends ShimLibrary {
     }
 
     protected List<OperationShape> getOperationsForTarget() {
-        return targetShape.getOperations().stream().sequential()
+        return targetShape.getOperations().stream().sorted()
                 .map(shapeId -> subject.model.expectShape(shapeId, OperationShape.class))
                 .collect(Collectors.toList());
     }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/shims/ServiceShim.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/shims/ServiceShim.java
@@ -63,7 +63,7 @@ public class ServiceShim extends ShimLibrary {
                 .addMethod(dafnyConstructor());
 
         spec.addMethods(getOperationsForTarget()
-                .stream().sequential().map(this::operation).collect(Collectors.toList()));
+                .stream().map(this::operation).collect(Collectors.toList()));
         spec.addMethod(impl());
         return spec.build();
     }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/shims/TestServiceShim.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/library/shims/TestServiceShim.java
@@ -58,7 +58,7 @@ public class TestServiceShim extends ServiceShim {
         // Add public static method for creating a builder
         spec.addMethod(builderSpecs.builderMethod());
 
-        spec.addMethods(getOperationsForTarget().stream().sequential()
+        spec.addMethods(getOperationsForTarget().stream()
                 .map(shape -> Operation.AsDafny.operation(shape, this.subject, this))
                 .collect(Collectors.toList()));
         return spec.build();


### PR DESCRIPTION
*Issue #, if available:* ["The output MUST be deterministic."](https://github.com/awslabs/smithy-dafny/pull/231#pullrequestreview-1400919211)

*Description of changes:*
- Whenever we stream shapes from the Smithy Model, unless otherwise noted, Sort them by their ShapeID
- Exceptions to the above:
-- Enum Names
-- Members of a Structure or Union, which should remain in the order defined in the Smithy Model

*Evidence*:
https://github.com/aws/private-aws-encryption-sdk-dafny-staging/pull/196
There, you can see that all:
- The Operations of a Service or Resource are generated in Alphabetical Order
Inside Conversion Classes:
- All the Structures in Conversion Class are generated in Alphabetical Order
- They are followed by all the Errors, in Alphabetical Order
- Which are followed by all the Enums, in Alphabetical Order
- followed by all the Unions, in Alphabetical Order
- followed by all the Lists, in Alphabetical Order
- followed by all the Sets, in Alphabetical Order
- followed by all the Maps, in Alphabetical Order
- followed by all the Resources, in Alphabetical Order


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
