### PR TITLE
fix(Java): track Primitive setting

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/BuildMethod.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/BuildMethod.java
@@ -47,7 +47,6 @@ public class BuildMethod {
         polyFieldSpecs.forEach(polyField -> {
             // Required Trait
             if (polyField.isRequired()) {
-                // TODO: CrypTool-4889: If primitive type, check isSet
                 buildMethod.addCode(requiredCheck(polyField.fieldSpec));
             }
 
@@ -82,18 +81,29 @@ public class BuildMethod {
     }
 
     static CodeBlock fieldNonNull(BuilderMemberSpec field) {
+        if (field.type.isPrimitive()) {
+            return CodeBlock.of("this.$L", isSetFieldName(field));
+        }
         return CodeBlock.of("$T.nonNull(this.$L())", Objects.class, field.name);
     }
 
+    static String isSetFieldName(BuilderMemberSpec field) {
+        return "_%sSet".formatted(field.name);
+    }
+
     public static CodeBlock requiredCheck(BuilderMemberSpec field) {
-        return CodeBlock.builder()
-                .beginControlFlow("if ($T.isNull(this.$L())) ", Objects.class, field.name)
-                .addStatement(
-                        "throw new $T($S)",
-                        IllegalArgumentException.class,
-                        "Missing value for required field `%s`".formatted(field.name))
-                .endControlFlow()
-                .build();
+        CodeBlock.Builder check = CodeBlock.builder();
+        if (field.type.isPrimitive()) {
+            check.beginControlFlow("if (!this.$L)", isSetFieldName(field));
+        } else {
+            check.beginControlFlow("if ($T.isNull(this.$L())) ", Objects.class, field.name);
+        }
+        return check.addStatement(
+          "throw new $T($S)",
+          IllegalArgumentException.class,
+          "Missing value for required field `%s`".formatted(field.name))
+          .endControlFlow()
+          .build();
     }
 
     static CodeBlock rangeMinCheck(PolymorphFieldSpec polyField, RangeTrait trait) {

--- a/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/library/Constants.java
+++ b/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/library/Constants.java
@@ -6,10 +6,10 @@ class Constants {
     static String RANGE_TRAIT_INTEGER_BUILD_METHOD_RETURN = "return new TestRangeMinMaxInteger(this);";
     static String RANGE_TRAIT_INTEGER_BUILD_EXPECTED = """
             %s {
-              if (Objects.nonNull(this.zeroToTen()) && this.zeroToTen() < 0) {
+              if (this._zeroToTenSet && this.zeroToTen() < 0) {
                 throw new IllegalArgumentException("`zeroToTen` must be greater than or equal to 0");
               }
-              if (Objects.nonNull(this.zeroToTen()) && this.zeroToTen() > 10) {
+              if (this._zeroToTenSet && this.zeroToTen() > 10) {
                 throw new IllegalArgumentException("`zeroToTen` must be less than or equal to 10.");
               }
               %s


### PR DESCRIPTION
*Issue #, if available:* [[Polymorph][Java] Required Shapes have un-intended default](https://taskei.amazon.dev/tasks/CrypTool-4889)

*Description of changes:*
Use Java Poet's TypeName class's `isPrimitive` to detect primitive types.
When working with a primitive member, 
generate an extra field `_%sSet` on the builder.
When building with a primitive member,
don't call `isNull`, but just check `_%sSet`. 

### Evidence:
- [Generated Changes in MPL](https://github.com/aws/private-aws-encryption-sdk-dafny-staging/pull/207/commits/56b89c6d2bf4319e2246f830cda5998352094748)
- [Generated Changes in AtomicPrimitives](https://github.com/aws/private-aws-encryption-sdk-dafny-staging/pull/207/commits/fc99cdf1a144daaaf5a2f42d64b13c7cd5c70b3f)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
