### PR TITLE
fix(conversion): publish

### DIFF
--- a/smithy-dafny-conversion/build.gradle.kts
+++ b/smithy-dafny-conversion/build.gradle.kts
@@ -19,6 +19,20 @@ java {
     }
 }
 
+var caUrl: URI? = null
+@Nullable
+val caUrlStr: String? = System.getenv("CODEARTIFACT_URL_JAVA_CONVERSION")
+if (!caUrlStr.isNullOrBlank()) {
+    caUrl = URI.create(caUrlStr)
+}
+
+var caPassword: String? = null
+@Nullable
+val caPasswordString: String? = System.getenv("CODEARTIFACT_AUTH_TOKEN")
+if (!caPasswordString.isNullOrBlank()) {
+    caPassword = caPasswordString
+}
+
 repositories {
     mavenCentral()
     mavenLocal()
@@ -59,20 +73,6 @@ publishing {
             maybeCodeArtifact(this@Build_gradle, this)
         }
     }
-}
-
-var caUrl: URI? = null
-@Nullable
-val caUrlStr: String? = System.getenv("CODEARTIFACT_URL_JAVA_CONVERSION")
-if (!caUrlStr.isNullOrBlank()) {
-    caUrl = URI.create(caUrlStr)
-}
-
-var caPassword: String? = null
-@Nullable
-val caPasswordString: String? = System.getenv("CODEARTIFACT_AUTH_TOKEN")
-if (!caPasswordString.isNullOrBlank()) {
-    caPassword = caPasswordString
 }
 
 fun maybeCodeArtifact(buildGradle: Build_gradle, repositoryHandler: RepositoryHandler) {


### PR DESCRIPTION
*Issue #, if available:*
While trying to publish to CA,
I discovered that we cannot bury environmental variable parsing;
that MUST occur before they are ever referenced in task registration. 

*Description of changes:*
Reading environment variables MUST occur before
registering any tasks that use them.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
