### PR TITLE
fix(CI): distinct names for GHW Jobs

### DIFF
--- a/.github/workflows/smithy-dafny-conversion.yml
+++ b/.github/workflows/smithy-dafny-conversion.yml
@@ -7,7 +7,7 @@ on:
       - main-1.x
 
 jobs:
-  gradle-build:
+  gradle-build-smithy-dafny:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/smithy-polymorph.yml
+++ b/.github/workflows/smithy-polymorph.yml
@@ -7,7 +7,7 @@ on:
       - main-1.x
 
 jobs:
-  gradle-build:
+  gradle-build-smithy-dafny:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
GitHub's branch protection model can enforce
Status Checks to on branches.

These status checks are named by the Job in
the GitHub workflow.

As such, it is best to have distinct names
for the jobs in the GitHub workflows.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
