### PR TITLE
fix: Provide -compileSuffix to dafny when available

### DIFF
--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -29,6 +29,18 @@ PROJECT_RELATIVE_ROOT := $(dir $(lastword $(MAKEFILE_LIST)))
 # i.e. The specific library under consideration.
 LIBRARY_ROOT = $(PWD)
 
+# Later versions of Dafny no longer default to adding "_Compile"
+# to the names of modules when translating.
+# Our target language code still assumes it does,
+# so IF the /compileSuffix option is available in our verion of Dafny
+# we need to provide it.
+COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE := $(shell dafny /help | grep -q /compileSuffix; echo $$?)
+ifeq ($(COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE), 0)
+	COMPILE_SUFFIX_OPTION := -compileSuffix:1
+else
+	COMPILE_SUFFIX_OPTION :=
+endif
+
 STANDARD_LIBRARY_PATH := $(PROJECT_ROOT)/dafny-dependencies/StandardLibrary
 CODEGEN_CLI_ROOT := $(PROJECT_ROOT)/../codegen/smithy-dafny-codegen-cli
 GRADLEW := $(PROJECT_ROOT)/../codegen/gradlew
@@ -92,6 +104,7 @@ transpile_implementation:
 		-spillTargetCode:3 \
 		-compile:0 \
 		-optimizeErasableDatatypeWrapper:0 \
+		$(COMPILE_SUFFIX_OPTION) \
 		-quantifierSyntax:3 \
 		-unicodeChar:0 \
 		-functionSyntax:3 \
@@ -109,6 +122,7 @@ transpile_test:
 		-runAllTests:1 \
 		-compile:0 \
 		-optimizeErasableDatatypeWrapper:0 \
+		$(COMPILE_SUFFIX_OPTION) \
 		-quantifierSyntax:3 \
 		-unicodeChar:0 \
 		-functionSyntax:3 \


### PR DESCRIPTION
Same fix as https://github.com/aws/aws-cryptographic-material-providers-library-java/pull/58

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
