### PR TITLE
feat(smithydotnet): add dependency error from localservice trait

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -947,6 +947,18 @@ public class TypeConversionCodegen {
 
             Set<String> dependentNamespaces = ModelUtils.findAllDependentNamespaces(
                 new HashSet<ShapeId>(Collections.singleton(localServiceTrait.getConfigId())), model);
+            
+            if (!localServiceTrait.getDependencies().isEmpty()) {
+                localServiceTrait.getDependencies().stream()
+                        .map(model::expectShape)
+                        .map(Shape::asServiceShape)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .forEach(serviceShape ->
+                                dependentNamespaces.add(serviceShape.getId().getNamespace()
+                        );
+            
+            }
 
             if (dependentNamespaces.size() > 0) {
                 Set<TokenTree> cases = new HashSet<>();

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -948,7 +948,7 @@ public class TypeConversionCodegen {
             Set<String> dependentNamespaces = ModelUtils.findAllDependentNamespaces(
                 new HashSet<ShapeId>(Collections.singleton(localServiceTrait.getConfigId())), model);
             
-            if (!localServiceTrait.getDependencies().isEmpty()) {
+            if (localServiceTrait.getDependencies() != null) {
                 localServiceTrait.getDependencies().stream()
                         .map(model::expectShape)
                         .map(Shape::asServiceShape)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
localService in smithy can have dependencies in order to properly model all errors the service or dependent services can throw. 

Here we go through the localServiceTrait and check if we have dependencies and add the appropriate namespace to the set so the errors can be correctly written. This prevents valid errors from dependencies convert to Default Opaque objects loosing the stack error message

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
