### PR TITLE
feat(smithydotnet): add dependency error from localservice trait

### DIFF
--- a/TestModels/Dependencies/Model/Dependencies.smithy
+++ b/TestModels/Dependencies/Model/Dependencies.smithy
@@ -15,7 +15,8 @@ use simple.extendable.resources#SimpleExtendableResources
     SimpleConstraints,
     SimpleExtendableResources,
     // for reference on why this is commented out and next steps see:  https://sim.amazon.com/issues/CrypTool-5231
-    //SimpleErrors
+// TODO: Uncomment out as part of https://sim.amazon.com/issues/CrypTool-5231
+//use simple.errors#SimpleErrors
   ]
 )
 service SimpleDependencies {

--- a/TestModels/Dependencies/Model/Dependencies.smithy
+++ b/TestModels/Dependencies/Model/Dependencies.smithy
@@ -5,6 +5,7 @@ namespace simple.dependencies
 use simple.resources#SimpleResources
 use simple.constraints#SimpleConstraints
 use simple.extendable.resources#SimpleExtendableResources
+//use simple.errors#SimpleErrors
 
 @aws.polymorph#localService(
   sdkId: "SimpleDependencies",
@@ -13,6 +14,7 @@ use simple.extendable.resources#SimpleExtendableResources
     SimpleResources,
     SimpleConstraints,
     SimpleExtendableResources,
+    //SimpleErrors
   ]
 )
 service SimpleDependencies {

--- a/TestModels/Dependencies/Model/Dependencies.smithy
+++ b/TestModels/Dependencies/Model/Dependencies.smithy
@@ -5,6 +5,7 @@ namespace simple.dependencies
 use simple.resources#SimpleResources
 use simple.constraints#SimpleConstraints
 use simple.extendable.resources#SimpleExtendableResources
+// TODO: Uncomment out as part of https://sim.amazon.com/issues/CrypTool-5231
 //use simple.errors#SimpleErrors
 
 @aws.polymorph#localService(

--- a/TestModels/Dependencies/Model/Dependencies.smithy
+++ b/TestModels/Dependencies/Model/Dependencies.smithy
@@ -5,7 +5,6 @@ namespace simple.dependencies
 use simple.resources#SimpleResources
 use simple.constraints#SimpleConstraints
 use simple.extendable.resources#SimpleExtendableResources
-use simple.errors#SimpleErrors
 
 @aws.polymorph#localService(
   sdkId: "SimpleDependencies",
@@ -14,7 +13,6 @@ use simple.errors#SimpleErrors
     SimpleResources,
     SimpleConstraints,
     SimpleExtendableResources,
-    SimpleErrors
   ]
 )
 service SimpleDependencies {

--- a/TestModels/Dependencies/Model/Dependencies.smithy
+++ b/TestModels/Dependencies/Model/Dependencies.smithy
@@ -15,9 +15,8 @@ use simple.extendable.resources#SimpleExtendableResources
     SimpleResources,
     SimpleConstraints,
     SimpleExtendableResources,
-    // for reference on why this is commented out and next steps see:  https://sim.amazon.com/issues/CrypTool-5231
-// TODO: Uncomment out as part of https://sim.amazon.com/issues/CrypTool-5231
-//use simple.errors#SimpleErrors
+    // TODO: Uncomment out as part of https://sim.amazon.com/issues/CrypTool-5231
+    // SimpleErrors
   ]
 )
 service SimpleDependencies {

--- a/TestModels/Dependencies/Model/Dependencies.smithy
+++ b/TestModels/Dependencies/Model/Dependencies.smithy
@@ -14,6 +14,7 @@ use simple.extendable.resources#SimpleExtendableResources
     SimpleResources,
     SimpleConstraints,
     SimpleExtendableResources,
+    // for reference on why this is commented out and next steps see:  https://sim.amazon.com/issues/CrypTool-5231
     //SimpleErrors
   ]
 )

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -948,7 +948,7 @@ public class TypeConversionCodegen {
             Set<String> dependentNamespaces = ModelUtils.findAllDependentNamespaces(
                 new HashSet<ShapeId>(Collections.singleton(localServiceTrait.getConfigId())), model);
 
-            if (!localServiceTrait.getDependencies().isEmpty()) {
+            if (localServiceTrait.getDependencies() != null) {
                 localServiceTrait.getDependencies().stream()
                         .map(model::expectShape)
                         .map(Shape::asServiceShape)

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -948,6 +948,17 @@ public class TypeConversionCodegen {
             Set<String> dependentNamespaces = ModelUtils.findAllDependentNamespaces(
                 new HashSet<ShapeId>(Collections.singleton(localServiceTrait.getConfigId())), model);
 
+            if (!localServiceTrait.getDependencies().isEmpty()) {
+                localServiceTrait.getDependencies().stream()
+                        .map(model::expectShape)
+                        .map(Shape::asServiceShape)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .forEach( serviceShape ->
+                                dependentNamespaces.add(serviceShape.getId().getNamespace())
+                        );
+            }
+
             if (dependentNamespaces.size() > 0) {
                 Set<TokenTree> cases = new HashSet<>();
                 for (String dependentNamespace : dependentNamespaces) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
localService in smithy can have dependencies in order to properly model all errors the service or dependent services can throw.

Here we go through the localServiceTrait and check if we have dependencies and add the appropriate namespace to the set so the errors can be correctly written. This prevents valid errors from dependencies convert to Default Opaque objects loosing the stack error message

SIM to track work of adding back unused modeled dependency: https://sim.amazon.com/issues/CrypTool-5231

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
