### PR TITLE
feat: repair type deduction for AttributeValue

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -637,7 +637,7 @@ public class TypeConversionCodegen {
                             .of("if (value.Is%sSet)".formatted(propertyName));
                         } else if (listTypes.contains(propertyName)) {
                             checkIfValuePresent = TokenTree
-                            .of("if (!value.%s.Any())".formatted(propertyName));
+                            .of("if (value.%s.Any())".formatted(propertyName));
                         } else if ("NULL".equals(propertyName)) {
                             checkIfValuePresent =  TokenTree
                             .of("if (value.%s == true)".formatted(propertyName));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Given an AttributeValue, what is its underlying type?
Of course, the dotnet SDK won't let us check most attributes for IsSet, so we have to make some guesses.
For example, for Sets, we check to see if the set has any members. If it does, then that's probably the type.
Unfortunately, the generated code was wrong, and instead of Any it produced !Any. 
The code to convert an AttributeValue started

        if (value.S != null)  return "S";
        if (value.N != null)  return "N";
        if (value.B != null)  return "B";
        if (!value.SS.Any())

and so any AttributeValue that is not of type S, N or B would always be recognized as SS; because SS would not have any members. Unless it actually was an SS, then it's type would be unknown.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
