### PR TITLE
feat: Repair OpaqueError

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/ServiceCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/ServiceCodegen.java
@@ -257,7 +257,7 @@ public class ServiceCodegen {
           public readonly object obj;
           public OpaqueError(Exception ex) : base("OpaqueError:", ex) { this.obj = ex; }
           public OpaqueError() : base("Unknown Unexpected Error") { }
-          public OpaqueError(object obj) : base("Opaque obj is not an Exception.") { this.obj = obj;}
+          public OpaqueError(object obj) : base(obj is Exception ? "OpaqueError:" : "Opaque obj is not an Exception.", obj as Exception) { this.obj = obj;}
         }
           """
         ).namespaced(Token.of(nameResolver.namespaceForService()));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

OpaqueError has two constructors :
      OpaqueError(Exception ex) : base("OpaqueError:", ex) { this.obj = ex; }
      OpaqueError(object obj) : base("Opaque obj is not an Exception.") { this.obj = obj;}

Unfortunately, overloading is resolved at compile time, so if you have an Exception currently cast to an Object, you get the second one, and therefore lose all the information in the original Exception.
Even more unfortunately, the thing that turns an extern's Error_Opaque into an OpaqueError does exactly that : casts the original Exception to an Object before use.

The solution is to change the second constructor to behave differently if the Object is really an Exception

OpaqueError(object obj)
  : base(obj is Exception ? "OpaqueError:" : "Opaque obj is not an Exception.", obj as Exception)
{ this.obj = obj;}

"obj as Exception" is either an Exception, in which case we get back the context, or null, which is exactly the old behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
