### PR TITLE
feat: Compatibility with Dafny 4.4 and upcoming 4.5

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Populate Dafny versions list
       id: populate-dafny-versions-list
-      run: echo "dafny-versions-list=['4.1.0', '4.3.0']" >> $GITHUB_OUTPUT
+      run: echo "dafny-versions-list=['4.1.0', '4.4.0']" >> $GITHUB_OUTPUT
     outputs:
       dafny-version-list: ${{ steps.populate-dafny-versions-list.outputs.dafny-versions-list }}
         

--- a/.github/workflows/test_models_java_tests.yml
+++ b/.github/workflows/test_models_java_tests.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         dafny-version: [
           4.1.0,
-          4.3.0
+          4.4.0
         ]
         library: [
           TestModels/dafny-dependencies/StandardLibrary, # This stores current Polymorph dependencies that all TestModels depend on

--- a/.github/workflows/test_models_java_tests.yml
+++ b/.github/workflows/test_models_java_tests.yml
@@ -16,10 +16,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dafny-version: [
-          4.1.0,
-          4.4.0
-        ]
         library: [
           TestModels/dafny-dependencies/StandardLibrary, # This stores current Polymorph dependencies that all TestModels depend on
           # TestModels/Aggregate,

--- a/TestModels/.gitignore
+++ b/TestModels/.gitignore
@@ -12,6 +12,7 @@
 # Polymorph Generated Dafny
 **/Model/*Types.dfy
 **/Model/*TypesWrapped.dfy
+**/project.properties
 
 # Polymorph Generated .NET
 **/runtimes/net/Generated/*.cs

--- a/TestModels/Constraints/runtimes/java/build.gradle.kts
+++ b/TestModels/Constraints/runtimes/java/build.gradle.kts
@@ -10,6 +10,11 @@ plugins {
     `maven-publish`
 }
 
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+var dafnyVersion = props.getProperty("dafnyVersion")
+
 group = "simple"
 version = "1.0-SNAPSHOT"
 description = "Constraints"
@@ -33,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
 }

--- a/TestModels/Constraints/runtimes/java/build.gradle.kts
+++ b/TestModels/Constraints/runtimes/java/build.gradle.kts
@@ -1,5 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 
 tasks.wrapper {
     gradleVersion = "7.6"

--- a/TestModels/Errors/runtimes/java/build.gradle.kts
+++ b/TestModels/Errors/runtimes/java/build.gradle.kts
@@ -1,5 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 
 tasks.wrapper {
     gradleVersion = "7.6"
@@ -9,6 +12,11 @@ plugins {
     `java-library`
     `maven-publish`
 }
+
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "simple"
 version = "1.0-SNAPSHOT"
@@ -33,7 +41,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
 }

--- a/TestModels/Extendable/runtimes/java/build.gradle.kts
+++ b/TestModels/Extendable/runtimes/java/build.gradle.kts
@@ -1,5 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 
 tasks.wrapper {
     gradleVersion = "7.6"
@@ -9,6 +12,11 @@ plugins {
     `java-library`
     `maven-publish`
 }
+
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "simple.extendable.resources"
 version = "1.0-SNAPSHOT"
@@ -33,7 +41,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
 }

--- a/TestModels/LocalService/runtimes/java/build.gradle.kts
+++ b/TestModels/LocalService/runtimes/java/build.gradle.kts
@@ -1,5 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 
 tasks.wrapper {
     gradleVersion = "7.6"
@@ -9,6 +12,11 @@ plugins {
     `java-library`
     `maven-publish`
 }
+
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "simple"
 version = "1.0-SNAPSHOT"
@@ -33,7 +41,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
 }

--- a/TestModels/MultipleModels/runtimes/java/build.gradle.kts
+++ b/TestModels/MultipleModels/runtimes/java/build.gradle.kts
@@ -1,5 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 
 tasks.wrapper {
     gradleVersion = "7.6"
@@ -9,6 +12,11 @@ plugins {
     `java-library`
     `maven-publish`
 }
+
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "simple.multiplemodels"
 version = "1.0-SNAPSHOT"
@@ -33,7 +41,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
 }

--- a/TestModels/Resource/runtimes/java/build.gradle.kts
+++ b/TestModels/Resource/runtimes/java/build.gradle.kts
@@ -1,5 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 
 tasks.wrapper {
     gradleVersion = "7.6"
@@ -9,6 +12,11 @@ plugins {
     `java-library`
     `maven-publish`
 }
+
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "simple.resources"
 version = "1.0-SNAPSHOT"
@@ -33,7 +41,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
 }

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -206,6 +206,7 @@ _polymorph:
 	cd $(CODEGEN_CLI_ROOT); \
 	$(GRADLEW) run --args="\
 	$(DAFNY_VERSION_OPTION) \
+	--properties-file $(LIBRARY_ROOT)/project.properties \
 	$(OUTPUT_DAFNY) \
 	$(OUTPUT_DOTNET) \
 	$(OUTPUT_JAVA) \
@@ -220,6 +221,7 @@ _polymorph_wrapped:
 	cd $(CODEGEN_CLI_ROOT); \
 	$(GRADLEW) run --args="\
 	$(DAFNY_VERSION_OPTION) \
+	--properties-file $(LIBRARY_ROOT)/project.properties \
 	$(OUTPUT_DAFNY_WRAPPED) \
 	$(OUTPUT_DOTNET_WRAPPED) \
 	$(OUTPUT_JAVA_WRAPPED) \

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -268,6 +268,7 @@ _polymorph_code_gen: _polymorph_dependencies
 # Generates dafny code for all namespaces in this project
 .PHONY: polymorph_dafny
 polymorph_dafny:
+	$(MAKE) -C $(STANDARD_LIBRARY_PATH) polymorph_dafny
 	for service in $(PROJECT_SERVICES) ; do \
 		export service_deps_var=SERVICE_DEPS_$${service} ; \
 		export namespace_var=SERVICE_NAMESPACE_$${service} ; \

--- a/TestModels/aws-sdks/ddb/runtimes/java/build.gradle.kts
+++ b/TestModels/aws-sdks/ddb/runtimes/java/build.gradle.kts
@@ -1,5 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 import java.net.URI
 import javax.annotation.Nullable
 
@@ -7,6 +10,11 @@ plugins {
     `java-library`
     `maven-publish`
 }
+
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
 version = "1.0-SNAPSHOT"
@@ -54,7 +62,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))

--- a/TestModels/aws-sdks/ddb/runtimes/java/src/main/java/software/amazon/cryptography/services/dynamodb/internaldafny/__default.java
+++ b/TestModels/aws-sdks/ddb/runtimes/java/src/main/java/software/amazon/cryptography/services/dynamodb/internaldafny/__default.java
@@ -4,7 +4,7 @@ package software.amazon.cryptography.services.dynamodb.internaldafny;
 
 import software.amazon.cryptography.services.dynamodb.internaldafny.types.IDynamoDBClient;
 import software.amazon.cryptography.services.dynamodb.internaldafny.types.Error;
-import StandardLibrary_mInterop_Compile.WrappersInterop;
+import StandardLibraryInterop_Compile.WrappersInterop;
 import Wrappers_Compile.Option;
 import Wrappers_Compile.Result;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;

--- a/TestModels/aws-sdks/kms/runtimes/java/build.gradle.kts
+++ b/TestModels/aws-sdks/kms/runtimes/java/build.gradle.kts
@@ -1,5 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 import java.net.URI
 import javax.annotation.Nullable
 import org.gradle.api.tasks.wrapper.Wrapper
@@ -8,6 +11,11 @@ plugins {
     `java-library`
     `maven-publish`
 }
+
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
 version = "1.0-SNAPSHOT"
@@ -55,7 +63,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
     /*implementation("com.amazonaws:aws-java-sdk-kms:1.12.417")*/

--- a/TestModels/aws-sdks/kms/runtimes/java/src/main/java/software/amazon/cryptography/services/kms/internal/__default.java
+++ b/TestModels/aws-sdks/kms/runtimes/java/src/main/java/software/amazon/cryptography/services/kms/internal/__default.java
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.kms.KmsClientBuilder;
 
 import software.amazon.cryptography.services.kms.internaldafny.types.Error;
 import software.amazon.cryptography.services.kms.internaldafny.types.IKMSClient;
-import StandardLibrary_mInterop_Compile.WrappersInterop;
+import StandardLibraryInterop_Compile.WrappersInterop;
 import Wrappers_Compile.Option;
 import Wrappers_Compile.Result;
 

--- a/TestModels/dafny-dependencies/StandardLibrary/Makefile
+++ b/TestModels/dafny-dependencies/StandardLibrary/Makefile
@@ -19,8 +19,17 @@ else
 	RESET        := ""
 endif
 
+# Overriding this target just to generate the project.properties file
 polymorph_dafny :
-	echo "Skipping polymorph_dafny for StandardLibrary"
+	@: $(if ${CODEGEN_CLI_ROOT},,$(error You must pass the path CODEGEN_CLI_ROOT: CODEGEN_CLI_ROOT=/path/to/smithy-dafny/codegen/smithy-dafny-codegen-cli));
+	cd $(CODEGEN_CLI_ROOT); \
+	$(GRADLEW) run --args="\
+	$(DAFNY_VERSION_OPTION) \
+	--properties-file $(STANDARD_LIBRARY_PATH)/project.properties \
+	--model $(STANDARD_LIBRARY_PATH)/Model \
+	--namespace aws.polymorph \
+	--dependent-model $(STANDARD_LIBRARY_PATH)/../Model \
+	";
 
 polymorph_net :
 	echo "Skipping polymorph_net for StandardLibrary"

--- a/TestModels/dafny-dependencies/StandardLibrary/Model/stdlib.smithy
+++ b/TestModels/dafny-dependencies/StandardLibrary/Model/stdlib.smithy
@@ -1,0 +1,11 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+namespace aws.polymorph
+
+// Dummy service just to keep polymorph happy.
+service StandardLibrary {
+  version: "2021-11-01",
+  resources: [],
+  operations: [],
+  errors: [],
+}

--- a/TestModels/dafny-dependencies/StandardLibrary/runtimes/java/build.gradle.kts
+++ b/TestModels/dafny-dependencies/StandardLibrary/runtimes/java/build.gradle.kts
@@ -8,6 +8,11 @@ plugins {
     `maven-publish`
 }
 
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+var dafnyVersion = props.getProperty("dafnyVersion")
+
 group = "software.amazon.cryptography"
 version = "1.0-SNAPSHOT"
 description = "StandardLibrary"

--- a/TestModels/dafny-dependencies/StandardLibrary/runtimes/java/build.gradle.kts
+++ b/TestModels/dafny-dependencies/StandardLibrary/runtimes/java/build.gradle.kts
@@ -1,5 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
 import java.net.URI
 import javax.annotation.Nullable
 

--- a/TestModels/dafny-dependencies/StandardLibrary/runtimes/java/build.gradle.kts
+++ b/TestModels/dafny-dependencies/StandardLibrary/runtimes/java/build.gradle.kts
@@ -53,7 +53,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
 }
 publishing {

--- a/TestModels/dafny-dependencies/StandardLibrary/src/StandardLibrary.dfy
+++ b/TestModels/dafny-dependencies/StandardLibrary/src/StandardLibrary.dfy
@@ -244,7 +244,7 @@ module StandardLibrary {
     assert LexicographicLessOrEqualAux(a, a, less, |a|);
   }
 
-  lemma LexIsAntisymmetric<T>(a: seq<T>, b: seq<T>, less: (T, T) -> bool)
+  lemma LexIsAntisymmetric<T(!new)>(a: seq<T>, b: seq<T>, less: (T, T) -> bool)
     requires Trich: Trichotomous(less)
     requires LexicographicLessOrEqual(a, b, less)
     requires LexicographicLessOrEqual(b, a, less)
@@ -287,7 +287,7 @@ module StandardLibrary {
     }
   }
 
-  lemma LexIsTransitive<T>(a: seq<T>, b: seq<T>, c: seq<T>, less: (T, T) -> bool)
+  lemma LexIsTransitive<T(!new)>(a: seq<T>, b: seq<T>, c: seq<T>, less: (T, T) -> bool)
     requires Transitive(less)
     requires LexicographicLessOrEqual(a, b, less)
     requires LexicographicLessOrEqual(b, c, less)
@@ -299,7 +299,7 @@ module StandardLibrary {
     assert LexicographicLessOrEqualAux(a, c, less, k);
   }
 
-  lemma LexIsTotal<T>(a: seq<T>, b: seq<T>, less: (T, T) -> bool)
+  lemma LexIsTotal<T(!new)>(a: seq<T>, b: seq<T>, less: (T, T) -> bool)
     requires Trich: Trichotomous(less)
     ensures LexicographicLessOrEqual(a, b, less) || LexicographicLessOrEqual(b, a, less)
   {
@@ -375,7 +375,7 @@ module StandardLibrary {
     forall z :: z in s ==> LexicographicLessOrEqual(a, z, less)
   }
 
-  lemma ThereIsAMinimum<T>(s: set<seq<T>>, less: (T, T) -> bool)
+  lemma ThereIsAMinimum<T(!new)>(s: set<seq<T>>, less: (T, T) -> bool)
     requires s != {}
     requires Trichotomous(less) && Transitive(less)
     ensures exists a :: IsMinimum(a, s, less)
@@ -383,7 +383,7 @@ module StandardLibrary {
     var a := FindMinimum(s, less);
   }
 
-  lemma MinimumIsUnique<T>(a: seq<T>, b: seq<T>, s: set<seq<T>>, less: (T, T) -> bool)
+  lemma MinimumIsUnique<T(!new)>(a: seq<T>, b: seq<T>, s: set<seq<T>>, less: (T, T) -> bool)
     requires IsMinimum(a, s, less) && IsMinimum(b, s, less)
     requires Trichotomous(less)
     ensures a == b
@@ -391,7 +391,7 @@ module StandardLibrary {
     LexIsAntisymmetric(a, b, less);
   }
 
-  lemma FindMinimum<T>(s: set<seq<T>>, less: (T, T) -> bool) returns (a: seq<T>)
+  lemma FindMinimum<T(!new)>(s: set<seq<T>>, less: (T, T) -> bool) returns (a: seq<T>)
     requires s != {}
     requires Trichotomous(less) && Transitive(less)
     ensures IsMinimum(a, s, less)

--- a/TestModels/dafny-dependencies/StandardLibrary/src/UTF8.dfy
+++ b/TestModels/dafny-dependencies/StandardLibrary/src/UTF8.dfy
@@ -200,6 +200,8 @@ module {:extern "UTF8"} UTF8 {
         lo := lo + 3;
       } else if 4 <= |r| && Uses4Bytes(r) {
         lo := lo + 4;
+      } else {
+        assert false;
       }
     }
     calc {

--- a/TestModels/dafny-dependencies/StandardLibrary/src/UTF8.dfy
+++ b/TestModels/dafny-dependencies/StandardLibrary/src/UTF8.dfy
@@ -155,6 +155,16 @@ module {:extern "UTF8"} UTF8 {
         false
   }
 
+  lemma ValidUTF8SeqCases(s: seq<uint8>)
+    requires ValidUTF8Seq(s)
+    ensures
+      || 0 == |s|
+      || (1 <= |s| && Uses1Byte(s))
+      || (2 <= |s| && Uses2Bytes(s))
+      || (3 <= |s| && Uses3Bytes(s))
+      || (4 <= |s| && Uses4Bytes(s))
+  {}
+
   lemma ValidUTF8Embed(a: seq<uint8>, b: seq<uint8>, c: seq<uint8>, lo: nat, hi: nat)
     requires lo <= hi <= |b|
     ensures ValidUTF8Range(b, lo, hi) == ValidUTF8Range(a + b + c, |a| + lo, |a| + hi)
@@ -201,6 +211,7 @@ module {:extern "UTF8"} UTF8 {
       } else if 4 <= |r| && Uses4Bytes(r) {
         lo := lo + 4;
       } else {
+        ValidUTF8SeqCases(r);
         assert false;
       }
     }

--- a/TestModels/dafny-dependencies/StandardLibrary/src/WrappersInterop.dfy
+++ b/TestModels/dafny-dependencies/StandardLibrary/src/WrappersInterop.dfy
@@ -23,7 +23,7 @@ include "../../libraries/src/Wrappers.dfy"
 // See also DafnyApiCodegen.generateResultOfClientHelperFunctions(),
 // which solves the same problem by emitting similar helper methods for each client type.
 //
-module StandardLibrary.Interop {
+module StandardLibraryInterop {
 
   import opened Wrappers
 

--- a/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
+++ b/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
@@ -76,6 +76,7 @@ public class CodegenCli {
                 .withAwsSdkStyle(cliArguments.awsSdkStyle)
                 .withLocalServiceTest(cliArguments.localServiceTest)
                 .withDafnyVersion(cliArguments.dafnyVersion);
+        cliArguments.propertiesFile.ifPresent(engineBuilder::withPropertiesFile);
         cliArguments.javaAwsSdkVersion.ifPresent(engineBuilder::withJavaAwsSdkVersion);
         cliArguments.includeDafnyFile.ifPresent(engineBuilder::withIncludeDafnyFile);
         final CodegenEngine engine = engineBuilder.build();
@@ -127,6 +128,11 @@ public class CodegenCli {
             .hasArg()
             .build())
           .addOption(Option.builder()
+            .longOpt("properties-file")
+            .desc("Path to generate the project.properties file at")
+            .hasArg()
+            .build())
+          .addOption(Option.builder()
             .longOpt("aws-sdk")
             .desc("<optional> generate AWS SDK-style API and shims")
             .build())
@@ -160,6 +166,7 @@ public class CodegenCli {
             Optional<Path> outputDafnyDir,
             Optional<AwsSdkVersion> javaAwsSdkVersion,
             DafnyVersion dafnyVersion,
+            Optional<Path> propertiesFile,
             Optional<Path> includeDafnyFile,
             boolean awsSdkStyle,
             boolean localServiceTest
@@ -226,6 +233,9 @@ public class CodegenCli {
                 throw ex;
             }
 
+            Optional<Path> propertiesFile = Optional.ofNullable(commandLine.getOptionValue("properties-file"))
+                    .map(Paths::get);
+
             Optional<Path> includeDafnyFile = Optional.empty();
             if (outputDafnyDir.isPresent()) {
                 includeDafnyFile = Optional.of(Paths.get(commandLine.getOptionValue("include-dafny")));
@@ -234,7 +244,7 @@ public class CodegenCli {
             return Optional.of(new CliArguments(
                     modelPath, dependentModelPaths, namespace,
                     outputDotnetDir, outputJavaDir, outputDafnyDir,
-                    javaAwsSdkVersion, dafnyVersion, includeDafnyFile, awsSdkStyle,
+                    javaAwsSdkVersion, dafnyVersion, propertiesFile, includeDafnyFile, awsSdkStyle,
                     localServiceTest
             ));
         }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -30,6 +30,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.utils.IoUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -122,6 +123,11 @@ public class CodegenEngine {
         }
 
         if (propertiesFile.isPresent()) {
+            File propertiesFileAsFile = propertiesFile.get().toFile();
+            if (propertiesFileAsFile.exists()) {
+                throw new IllegalStateException("project.properties file already exists: " + propertiesFileAsFile);
+            }
+
             final String propertiesTemplate = IoUtils.readUtf8Resource(
                     this.getClass(), "/templates/project.properties.template");
             // Drop the pre-release suffix, if any.
@@ -134,7 +140,7 @@ public class CodegenEngine {
             ).unparse();
             final String propertiesText = propertiesTemplate
                     .replace("%DAFNY_VERSION%", dafnyVersionString);
-            IOUtils.writeToFile(propertiesText, propertiesFile.get().toFile());
+            IOUtils.writeToFile(propertiesText, propertiesFileAsFile);
         }
     }
 
@@ -324,10 +330,11 @@ public class CodegenEngine {
         }
 
         /**
-         * Sets the Dafny version for which generated code should be compatible.
-         * This is used to ensure both Dafny source compatibility
-         * and compatibility with the Dafny compiler and runtime internals,
-         * which shim code generation currently depends on.
+         * Sets the path to generate a project.properties file at.
+         * This will contain a dafnyVersion property that can be used to
+         * select the correct version of the Dafny runtime in target language
+         * project configurations, amonst other potential uses.
+         * The properties file may contain other metadata in the future.
          */
         public Builder withPropertiesFile(final Path propertiesFile) {
             this.propertiesFile = propertiesFile;

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -127,6 +127,8 @@ public class CodegenEngine {
             // Drop the pre-release suffix, if any.
             // This means with the current Dafny pre-release naming convention,
             // we'll grab the most recent full release of a Dafny runtime.
+            // This mapping may need to change in the future.
+            // Ideally this would be handled by the Dafny CLI itself.
             String dafnyVersionString = new DafnyVersion(
                     dafnyVersion.getMajor(), dafnyVersion.getMinor(), dafnyVersion.getPatch()
             ).unparse();

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -122,26 +122,23 @@ public class CodegenEngine {
             }
         }
 
-        if (propertiesFile.isPresent()) {
-            File propertiesFileAsFile = propertiesFile.get().toFile();
-            if (propertiesFileAsFile.exists()) {
-                throw new IllegalStateException("project.properties file already exists: " + propertiesFileAsFile);
-            }
+        propertiesFile.ifPresent(this::generateProjectPropertiesFile);
+    }
 
-            final String propertiesTemplate = IoUtils.readUtf8Resource(
-                    this.getClass(), "/templates/project.properties.template");
-            // Drop the pre-release suffix, if any.
-            // This means with the current Dafny pre-release naming convention,
-            // we'll grab the most recent full release of a Dafny runtime.
-            // This mapping may need to change in the future.
-            // Ideally this would be handled by the Dafny CLI itself.
-            String dafnyVersionString = new DafnyVersion(
-                    dafnyVersion.getMajor(), dafnyVersion.getMinor(), dafnyVersion.getPatch()
-            ).unparse();
-            final String propertiesText = propertiesTemplate
-                    .replace("%DAFNY_VERSION%", dafnyVersionString);
-            IOUtils.writeToFile(propertiesText, propertiesFileAsFile);
-        }
+    private void generateProjectPropertiesFile(final Path outputPath) {
+        final String propertiesTemplate = IoUtils.readUtf8Resource(
+                this.getClass(), "/templates/project.properties.template");
+        // Drop the pre-release suffix, if any.
+        // This means with the current Dafny pre-release naming convention,
+        // we'll grab the most recent full release of a Dafny runtime.
+        // This mapping may need to change in the future.
+        // Ideally this would be handled by the Dafny CLI itself.
+        String dafnyVersionString = new DafnyVersion(
+                dafnyVersion.getMajor(), dafnyVersion.getMinor(), dafnyVersion.getPatch()
+        ).unparse();
+        final String propertiesText = propertiesTemplate
+                .replace("%DAFNY_VERSION%", dafnyVersionString);
+        IOUtils.writeToFile(propertiesText, outputPath.toFile());
     }
 
     private void generateDafny(final Path outputDir) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyVersion.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyVersion.java
@@ -80,6 +80,22 @@ public class DafnyVersion implements Comparable<DafnyVersion> {
         return value;
     }
 
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getPatch() {
+        return patch;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -118,6 +134,20 @@ public class DafnyVersion implements Comparable<DafnyVersion> {
         }
 
         return SUFFIX_COMPARATOR.compare(this.suffix, other.suffix);
+    }
+
+    public String unparse() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(major);
+        builder.append('.');
+        builder.append(minor);
+        builder.append('.');
+        builder.append(patch);
+        if (suffix != null) {
+            builder.append('-');
+            builder.append(suffix);
+        }
+        return builder.toString();
     }
 
     @Override

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/smithy/dafny/codegen/DafnyClientCodegenPlugin.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/smithy/dafny/codegen/DafnyClientCodegenPlugin.java
@@ -40,6 +40,7 @@ public final class DafnyClientCodegenPlugin implements SmithyBuildPlugin {
             final Path dir = Paths.get("runtimes", lang.name().toLowerCase(), "Generated");
             outputDirs.put(lang, manifest.resolvePath(dir));
         });
+        final Path propertiesFile = manifest.resolvePath(Paths.get("project.properties"));
 
         // TODO remove when Java is properly supported
         if (settings.targetLanguages.contains(TargetLanguage.JAVA)) {
@@ -50,6 +51,8 @@ public final class DafnyClientCodegenPlugin implements SmithyBuildPlugin {
                 .withServiceModel(model)
                 // TODO generate code based on service closure, not namespace
                 .withNamespace(settings.serviceId.getNamespace())
+                .withDafnyVersion(settings.dafnyVersion)
+                .withPropertiesFile(propertiesFile)
                 .withTargetLangOutputDirs(outputDirs)
                 .withAwsSdkStyle(true)  // this plugin only generates AWS SDK-style code
                 .withIncludeDafnyFile(settings.includeDafnyFile)

--- a/codegen/smithy-dafny-codegen/src/main/resources/templates/project.properties.template
+++ b/codegen/smithy-dafny-codegen/src/main/resources/templates/project.properties.template
@@ -1,0 +1,3 @@
+# This file stores the top level dafny version information.
+# All elements of the project need to agree on this version.
+dafnyVersion=%DAFNY_VERSION%


### PR DESCRIPTION
*Description of changes:*

* Add `--properties-file` option to spit out a `project.properties` file in the style of https://github.com/aws/aws-cryptographic-material-providers-library/blob/main/project.properties, and modify all the test module Gradle build files to pick the right Java runtime version using it.
* Address one case of verification regression
* Clean up the CI to remove a duplicative case of testing on multiple Dafny versions
* Refactor WrappersInterop module name to avoid a translation change in 4.4

Manually verified this makes CI pass on the latest Dafny nightly too: https://github.com/smithy-lang/smithy-dafny/actions/runs/7671133054

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
