### PR TITLE
fix(.NET): validate that MemoryStream instances are backed by an array

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -234,7 +234,14 @@ public class TypeConversionCodegen {
 
     public TypeConverter generateBlobConverter(final BlobShape blobShape) {
         final TokenTree fromDafnyBody = Token.of("return new System.IO.MemoryStream(value.Elements);");
-        final TokenTree toDafnyBody = Token.of("return Dafny.Sequence<byte>.FromArray(value.ToArray());");
+        // enforce that MemoryStreams are backed by an array
+        final TokenTree toDafnyBody = Token.of("""
+                if (value.ToArray().Length == 0 && value.Length > 0)
+                {
+                    throw new System.ArgumentException("Fatal Error: MemoryStream instance not backed by an array!");
+                }
+                return Dafny.Sequence<byte>.FromArray(value.ToArray());
+                """);
         return buildConverterFromMethodBodies(blobShape, fromDafnyBody, toDafnyBody);
     }
 

--- a/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegenTest.java
+++ b/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegenTest.java
@@ -23,6 +23,7 @@ import software.amazon.polymorph.util.Tokenizer.ParseToken;
 import software.amazon.polymorph.utils.TokenTree;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.ModelAssembler;
+import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -171,31 +172,35 @@ public class TypeConversionCodegenTest {
         assertEquals(expectedShapeIds, actualShapeIds);
     }
 
-//    @Test
-//    public void testGenerateBlobConverter() {
-//        final ShapeId shapeId = ShapeId.from("smithy.api#Blob");
-//        final TypeConversionCodegen codegen = setupCodegen((_builder, _modelAssembler) -> {});
-//        final TypeConverter converter = codegen.generateBlobConverter(BlobShape.builder().id(shapeId).build());
-//        assertEquals(shapeId, converter.shapeId());
-//
-//        final String actualFromDafny = converter.fromDafny().toString();
-//        final String fromDafnyConverterName = DotNetNameResolver.typeConverterForShape(shapeId, FROM_DAFNY);
-//        final String expectedFromDafny = """
-//                public static System.IO.MemoryStream %s(Dafny.ISequence<byte> value) {
-//                    return new System.IO.MemoryStream(value.Elements);
-//                }
-//                """.formatted(fromDafnyConverterName);
-//        tokenizeAndAssertEqual(expectedFromDafny, actualFromDafny);
-//
-//        final String actualToDafny = converter.toDafny().toString();
-//        final String toDafnyConverterName = DotNetNameResolver.typeConverterForShape(shapeId, TO_DAFNY);
-//        final String expectedToDafny = """
-//                public static Dafny.ISequence<byte> %s(System.IO.MemoryStream value) {
-//                    return Dafny.Sequence<byte>.FromArray(value.ToArray());
-//                }
-//                """.formatted(toDafnyConverterName);
-//        tokenizeAndAssertEqual(expectedToDafny, actualToDafny);
-//    }
+    @Test
+    public void testGenerateBlobConverter() {
+        final ShapeId shapeId = ShapeId.from("smithy.api#Blob");
+        final TypeConversionCodegen codegen = setupCodegen((_builder, _modelAssembler) -> {});
+        final TypeConverter converter = codegen.generateBlobConverter(BlobShape.builder().id(shapeId).build());
+        assertEquals(shapeId, converter.shapeId());
+
+        final String actualFromDafny = converter.fromDafny().toString();
+        final String fromDafnyConverterName = DotNetNameResolver.typeConverterForShape(shapeId, FROM_DAFNY);
+        final String expectedFromDafny = """
+                public static System.IO.MemoryStream %s(Dafny.ISequence<byte> value) {
+                    return new System.IO.MemoryStream(value.Elements);
+                }
+                """.formatted(fromDafnyConverterName);
+        tokenizeAndAssertEqual(expectedFromDafny, actualFromDafny);
+
+        final String actualToDafny = converter.toDafny().toString();
+        final String toDafnyConverterName = DotNetNameResolver.typeConverterForShape(shapeId, TO_DAFNY);
+        final String expectedToDafny = """
+                public static Dafny.ISequence<byte> %s(System.IO.MemoryStream value) {
+                    if (value.ToArray().Length == 0 && value.Length > 0)
+                    {
+                        throw new System.ArgumentException("Fatal Error: MemoryStream instance not backed by an array!");
+                    }
+                    return Dafny.Sequence<byte>.FromArray(value.ToArray());
+                }
+                """.formatted(toDafnyConverterName);
+        tokenizeAndAssertEqual(expectedToDafny, actualToDafny);
+    }
 
 //    @Test
 //    public void testGenerateBooleanConverter() {


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* See https://github.com/aws/aws-encryption-sdk-dafny/pull/633 for more info. This PR addresses the issue in the codegen library itself, so the manual edit won't be lost. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
