### PR TITLE
fix: Incorrect Dafny version check for Java type descriptors changes

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Populate Dafny versions list
       id: populate-dafny-versions-list
-      run: echo "dafny-versions-list=['4.1.0', '4.3.0']" >> $GITHUB_OUTPUT
+      run: echo "dafny-versions-list=['4.1.0', '4.2.0', '4.3.0']" >> $GITHUB_OUTPUT
     outputs:
       dafny-version-list: ${{ steps.populate-dafny-versions-list.outputs.dafny-versions-list }}
         

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Populate Dafny versions list
       id: populate-dafny-versions-list
-      run: echo "dafny-versions-list=['4.1.0', '4.2.0', '4.3.0', '4.4.0']" >> $GITHUB_OUTPUT
+      run: echo "dafny-versions-list=['4.1.0', '4.2.0', '4.4.0']" >> $GITHUB_OUTPUT
     outputs:
       dafny-version-list: ${{ steps.populate-dafny-versions-list.outputs.dafny-versions-list }}
         

--- a/.github/workflows/test_models_dafny_verification.yml
+++ b/.github/workflows/test_models_dafny_verification.yml
@@ -60,8 +60,10 @@ jobs:
             dafny-version: 4.4.0
             os: ubuntu-latest
         exclude:
-          # This model tickles a tricky Dafny verification regression to be fixed in 4.4
+          # This model tickles a tricky Dafny verification regression fixed in 4.4
           # https://github.com/dafny-lang/dafny/pull/4800
+          - dafny-version: 4.2.0
+            library: TestModels/Extendable
           - dafny-version: 4.3.0
             library: TestModels/Extendable
     runs-on: ${{ matrix.os }}

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Dafny.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Dafny.java
@@ -98,7 +98,7 @@ public class Dafny extends NameResolver {
     }
 
     //  Dafnys greater than or equal to this will need Type Descriptors for constructing datatypes  
-    private static final DafnyVersion NEEDS_TYPE_DESCRIPTORS_WHEN_CONSTRUCTING_DATATYPES = new DafnyVersion(4, 2, 0);
+    private static final DafnyVersion NEEDS_TYPE_DESCRIPTORS_WHEN_CONSTRUCTING_DATATYPES = new DafnyVersion(4, 3, 0);
 
     /**
      * @return Whether the given Dafny version requires type descriptor values when instantiating datatype constructors.


### PR DESCRIPTION
*Description of changes:*
A previous change accounts for changes in how Dafny uses TypeDescriptors when translating to Java, but a typo makes it apply from Dafny 4.2 and up when it should apply on 4.3 and up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
