### PR TITLE
feat: Add support for automatically patching generated code

### DIFF
--- a/.github/not-grep.toml
+++ b/.github/not-grep.toml
@@ -7,7 +7,7 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 """
-"**/*.cs" = """
+"**/[!/obj/]*.cs" = """
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 """

--- a/.github/workflows/smithy-polymorph.yml
+++ b/.github/workflows/smithy-polymorph.yml
@@ -15,7 +15,16 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
-
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+      - name: Setup Dafny
+        uses: dafny-lang/setup-dafny-action@v1.7.0
+        with:
+          # Matching the hard-coded version for the "2023" edition for now
+          dafny-version: 4.1.0
+  
       - name: Execute smithy-dafny-codegen-cli tests
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/test_models_dafny_verification.yml
+++ b/.github/workflows/test_models_dafny_verification.yml
@@ -20,6 +20,7 @@ jobs:
           TestModels/dafny-dependencies/StandardLibrary, # This stores current Polymorph dependencies that all TestModels depend on
           TestModels/Aggregate,
           TestModels/AggregateReferences,
+          TestModels/CodegenPatches,
           TestModels/Constraints,
           TestModels/Constructor,
           TestModels/Dependencies,
@@ -67,6 +68,9 @@ jobs:
           - dafny-version: 4.3.0
             library: TestModels/Extendable
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
@@ -83,13 +87,11 @@ jobs:
           dafny-version: ${{ matrix.dafny-version }}
 
       - name: Generate Polymorph Wrapper Dafny code
-        shell: bash
         working-directory: ./${{ matrix.library }}
         run: |
           make polymorph_dafny DAFNY_VERSION_OPTION="--dafny-version $DAFNY_VERSION"
 
       - name: Verify ${{ matrix.library }} Dafny code
-        shell: bash
         working-directory: ./${{ matrix.library }}
         run: |
           # This works because `node` is installed by default on GHA runners
@@ -97,7 +99,6 @@ jobs:
           make verify CORES=$CORES
 
       - name: Check solver resource use
-        shell: bash
         working-directory: ./${{ matrix.library }}
         run: |
           make dafny-reportgenerator

--- a/.github/workflows/test_models_java_tests.yml
+++ b/.github/workflows/test_models_java_tests.yml
@@ -93,6 +93,11 @@ jobs:
           distribution: 'corretto'
           java-version: '17'
 
+      - name: Setup dependencies
+        working-directory: ./${{ matrix.library }}
+        run: |
+          make setup_prettier
+  
       - name: Generate Polymorph Dafny and Java code
         shell: bash
         working-directory: ./${{ matrix.library }}

--- a/.github/workflows/test_models_java_tests.yml
+++ b/.github/workflows/test_models_java_tests.yml
@@ -20,6 +20,7 @@ jobs:
           TestModels/dafny-dependencies/StandardLibrary, # This stores current Polymorph dependencies that all TestModels depend on
           # TestModels/Aggregate,
           # TestModels/AggregateReferences,
+          TestModels/CodegenPatches,
           TestModels/Constraints,
           # TestModels/Constructor,
           # TestModels/Dependencies,

--- a/.github/workflows/test_models_net_tests.yml
+++ b/.github/workflows/test_models_net_tests.yml
@@ -20,6 +20,7 @@ jobs:
           TestModels/dafny-dependencies/StandardLibrary, # This stores current Polymorph dependencies that all TestModels depend on
           TestModels/Aggregate,
           # TestModels/AggregateReferences,
+          TestModels/CodegenPatches,
           TestModels/Constraints,
           TestModels/Constructor,
           TestModels/Dependencies,

--- a/TestModels/CodegenPatches/Makefile
+++ b/TestModels/CodegenPatches/Makefile
@@ -1,0 +1,24 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+CORES=2
+
+include ../SharedMakefile.mk
+
+PROJECT_SERVICES := \
+	CodegenPatches
+
+SERVICE_NAMESPACE_CodegenPatches=simple.codegenpatches
+
+SERVICE_DEPS_CodegenPatches :=
+
+SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
+
+# This project has no dependencies 
+# DEPENDENT-MODELS:= 
+# LIBRARIES :=
+
+clean: _clean
+	rm -rf $(LIBRARY_ROOT)/runtimes/java/src/main/dafny-generated
+	rm -rf $(LIBRARY_ROOT)/runtimes/java/src/main/smithy-generated
+	rm -rf $(LIBRARY_ROOT)/runtimes/java/src/test/dafny-generated

--- a/TestModels/CodegenPatches/Model/CodegenPatches.smithy
+++ b/TestModels/CodegenPatches/Model/CodegenPatches.smithy
@@ -12,9 +12,15 @@ service CodegenPatches {
   operations: [
     GetString,
   ],
+  errors: [
+    CodegenPatchesError
+  ]
 }
 
 structure CodegenPatchesConfig {}
+
+@error("client")
+structure CodegenPatchesError {}
 
 operation GetString {
   input: GetStringInput,

--- a/TestModels/CodegenPatches/Model/CodegenPatches.smithy
+++ b/TestModels/CodegenPatches/Model/CodegenPatches.smithy
@@ -20,7 +20,10 @@ service CodegenPatches {
 structure CodegenPatchesConfig {}
 
 @error("client")
-structure CodegenPatchesError {}
+structure CodegenPatchesError {
+  @required
+  message: String
+}
 
 operation GetString {
   input: GetStringInput,

--- a/TestModels/CodegenPatches/Model/CodegenPatches.smithy
+++ b/TestModels/CodegenPatches/Model/CodegenPatches.smithy
@@ -1,0 +1,30 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+namespace simple.codegenpatches
+
+@aws.polymorph#localService(
+  sdkId: "CodegenPatches",
+  config: CodegenPatchesConfig
+)
+service CodegenPatches {
+  version: "2021-11-01",
+  resources: [],
+  operations: [
+    GetString,
+  ],
+}
+
+structure CodegenPatchesConfig {}
+
+operation GetString {
+  input: GetStringInput,
+  output: GetStringOutput,
+}
+
+structure GetStringInput {
+  value: String,
+}
+
+structure GetStringOutput {
+  value: String,
+}

--- a/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
+++ b/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
@@ -164,7 +164,7 @@ abstract module AbstractSimpleCodegenpatchesService
         defaultedInput := input.(value := Some("default"));
       }
       output := Operations.GetString(config, defaultedInput);
-      History.GetString := History.GetString + [DafnyCallEvent(defaultedInput, output)];
+      History.GetString := History.GetString + [DafnyCallEvent(input, output)];
       // END MANUAL EDIT
     }
 
@@ -179,6 +179,11 @@ abstract module AbstractSimpleCodegenpatchesOperations {
   predicate ValidInternalConfig?(config: InternalConfig)
   function ModifiesInternalConfig(config: InternalConfig): set<object>
   predicate GetStringEnsuresPublicly(input: GetStringInput , output: Result<GetStringOutput, Error>)
+  // BEGIN MANUAL EDIT
+  {
+    true
+  }
+  // END MANUAL EDIT
   // The private method to be refined by the library developer
 
 

--- a/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
+++ b/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
@@ -1,0 +1,195 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+include "../../dafny-dependencies/StandardLibrary/src/Index.dfy"
+module {:extern "simple.codegenpatches.internaldafny.types" } SimpleCodegenpatchesTypes
+{
+  import opened Wrappers
+  import opened StandardLibrary.UInt
+  import opened UTF8
+    // Generic helpers for verification of mock/unit tests.
+  datatype DafnyCallEvent<I, O> = DafnyCallEvent(input: I, output: O)
+
+  // Begin Generated Types
+
+  class ICodegenPatchesClientCallHistory {
+    ghost constructor() {
+      GetString := [];
+    }
+    ghost var GetString: seq<DafnyCallEvent<GetStringInput, Result<GetStringOutput, Error>>>
+  }
+  trait {:termination false} ICodegenPatchesClient
+  {
+    // Helper to define any additional modifies/reads clauses.
+    // If your operations need to mutate state,
+    // add it in your constructor function:
+    // Modifies := {your, fields, here, History};
+    // If you do not need to mutate anything:
+    // Modifies := {History};
+
+    ghost const Modifies: set<object>
+    // For an unassigned field defined in a trait,
+    // Dafny can only assign a value in the constructor.
+    // This means that for Dafny to reason about this value,
+    // it needs some way to know (an invariant),
+    // about the state of the object.
+    // This builds on the Valid/Repr paradigm
+    // To make this kind requires safe to add
+    // to methods called from unverified code,
+    // the predicate MUST NOT take any arguments.
+    // This means that the correctness of this requires
+    // MUST only be evaluated by the class itself.
+    // If you require any additional mutation,
+    // then you MUST ensure everything you need in ValidState.
+    // You MUST also ensure ValidState in your constructor.
+    predicate ValidState()
+      ensures ValidState() ==> History in Modifies
+    ghost const History: ICodegenPatchesClientCallHistory
+    predicate GetStringEnsuresPublicly(input: GetStringInput , output: Result<GetStringOutput, Error>)
+    // The public method to be called by library consumers
+    method GetString ( input: GetStringInput )
+      returns (output: Result<GetStringOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History} ,
+               History`GetString
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures GetStringEnsuresPublicly(input, output)
+      ensures History.GetString == old(History.GetString) + [DafnyCallEvent(input, output)]
+
+  }
+  datatype CodegenPatchesConfig = | CodegenPatchesConfig (
+
+                                  )
+  datatype GetStringInput = | GetStringInput (
+    nameonly value: Option<string> := Option.None
+  )
+  datatype GetStringOutput = | GetStringOutput (
+    nameonly value: Option<string> := Option.None
+  )
+  datatype Error =
+      // Local Error structures are listed here
+    | CodegenPatchesError (
+        nameonly message: string
+      )
+      // Any dependent models are listed here
+
+      // The Collection error is used to collect several errors together
+      // This is useful when composing OR logic.
+      // Consider the following method:
+      // 
+      // method FN<I, O>(n:I)
+      //   returns (res: Result<O, Types.Error>)
+      //   ensures A(I).Success? ==> res.Success?
+      //   ensures B(I).Success? ==> res.Success?
+      //   ensures A(I).Failure? && B(I).Failure? ==> res.Failure?
+      // 
+      // If either A || B is successful then FN is successful.
+      // And if A && B fail then FN will fail.
+      // But what information should FN transmit back to the caller?
+      // While it may be correct to hide these details from the caller,
+      // this can not be the globally correct option.
+      // Suppose that A and B can be blocked by different ACLs,
+      // and that their representation of I is only eventually consistent.
+      // How can the caller distinguish, at a minimum for logging,
+      // the difference between the four failure modes?
+    // || (!access(A(I)) && !access(B(I)))
+    // || (!exit(A(I)) && !exit(B(I)))
+    // || (!access(A(I)) && !exit(B(I)))
+    // || (!exit(A(I)) && !access(B(I)))
+    | CollectionOfErrors(list: seq<Error>, nameonly message: string)
+      // The Opaque error, used for native, extern, wrapped or unknown errors
+    | Opaque(obj: object)
+  type OpaqueError = e: Error | e.Opaque? witness *
+}
+abstract module AbstractSimpleCodegenpatchesService
+{
+  import opened Wrappers
+  import opened StandardLibrary.UInt
+  import opened UTF8
+  import opened Types = SimpleCodegenpatchesTypes
+  import Operations : AbstractSimpleCodegenpatchesOperations
+  function method DefaultCodegenPatchesConfig(): CodegenPatchesConfig
+  method CodegenPatches(config: CodegenPatchesConfig := DefaultCodegenPatchesConfig())
+    returns (res: Result<ICodegenPatchesClient, Error>)
+    ensures res.Success? ==>
+              && fresh(res.value)
+              && fresh(res.value.Modifies)
+              && fresh(res.value.History)
+              && res.value.ValidState()
+
+  // Helper function for the benefit of native code to create a Success(client) without referring to Dafny internals
+  function method CreateSuccessOfClient(client: ICodegenPatchesClient): Result<ICodegenPatchesClient, Error> {
+    Success(client)
+  } // Helper function for the benefit of native code to create a Failure(error) without referring to Dafny internals
+  function method CreateFailureOfError(error: Error): Result<ICodegenPatchesClient, Error> {
+    Failure(error)
+  }
+  class CodegenPatchesClient extends ICodegenPatchesClient
+  {
+    constructor(config: Operations.InternalConfig)
+      requires Operations.ValidInternalConfig?(config)
+      ensures
+        && ValidState()
+        && fresh(History)
+        && this.config == config
+    const config: Operations.InternalConfig
+    predicate ValidState()
+      ensures ValidState() ==>
+                && Operations.ValidInternalConfig?(config)
+                && History !in Operations.ModifiesInternalConfig(config)
+                && Modifies == Operations.ModifiesInternalConfig(config) + {History}
+    predicate GetStringEnsuresPublicly(input: GetStringInput , output: Result<GetStringOutput, Error>)
+    {Operations.GetStringEnsuresPublicly(input, output)}
+    // The public method to be called by library consumers
+    method GetString ( input: GetStringInput )
+      returns (output: Result<GetStringOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History} ,
+               History`GetString
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures GetStringEnsuresPublicly(input, output)
+      ensures History.GetString == old(History.GetString) + [DafnyCallEvent(input, output)]
+    {
+      // BEGIN MANUAL EDIT
+      var defaultedInput := input;
+      if input.value.None? {
+        defaultedInput := input.(value := Some("default"));
+      }
+      output := Operations.GetString(config, defaultedInput);
+      History.GetString := History.GetString + [DafnyCallEvent(defaultedInput, output)];
+      // END MANUAL EDIT
+    }
+
+  }
+}
+abstract module AbstractSimpleCodegenpatchesOperations {
+  import opened Wrappers
+  import opened StandardLibrary.UInt
+  import opened UTF8
+  import opened Types = SimpleCodegenpatchesTypes
+  type InternalConfig
+  predicate ValidInternalConfig?(config: InternalConfig)
+  function ModifiesInternalConfig(config: InternalConfig): set<object>
+  predicate GetStringEnsuresPublicly(input: GetStringInput , output: Result<GetStringOutput, Error>)
+  // The private method to be refined by the library developer
+
+
+  method GetString ( config: InternalConfig , input: GetStringInput )
+    returns (output: Result<GetStringOutput, Error>)
+    requires
+      && ValidInternalConfig?(config)
+    modifies ModifiesInternalConfig(config)
+    // Dafny will skip type parameters when generating a default decreases clause.
+    decreases ModifiesInternalConfig(config)
+    ensures
+      && ValidInternalConfig?(config)
+    ensures GetStringEnsuresPublicly(input, output)
+}

--- a/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypesWrapped.dfy
+++ b/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypesWrapped.dfy
@@ -1,0 +1,20 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+include "../../dafny-dependencies/StandardLibrary/src/Index.dfy"
+include "../src/Index.dfy"
+abstract module WrappedAbstractSimpleCodegenpatchesService {
+  import opened Wrappers
+  import opened StandardLibrary.UInt
+  import opened UTF8
+  import opened Types = SimpleCodegenpatchesTypes
+  import WrappedService : AbstractSimpleCodegenpatchesService
+  function method WrappedDefaultCodegenPatchesConfig(): CodegenPatchesConfig
+  method {:extern} WrappedCodegenPatches(config: CodegenPatchesConfig := WrappedDefaultCodegenPatchesConfig())
+    returns (res: Result<ICodegenPatchesClient, Error>)
+    ensures res.Success? ==>
+              && fresh(res.value)
+              && fresh(res.value.Modifies)
+              && fresh(res.value.History)
+              && res.value.ValidState()
+}

--- a/TestModels/CodegenPatches/README.md
+++ b/TestModels/CodegenPatches/README.md
@@ -1,0 +1,53 @@
+# CodegenPatches
+
+This project tests the feature of automatically applying patches to generated code.
+While obviously discouraged, this has been necessary in practice
+to account for Smithy model inaccuracies and features that aren't yet implemented
+in the core code generation logic.
+
+These files can be located at `<library-root>`/codegen-patches/<language>/dafny-<version>.patch;
+the patch file matching the generated language with the highest version less than the value of `--dafny-version`
+will be applied.
+
+The easiest way to create these patches is the following workflow
+(which requires that the generated code is checked in to git):
+
+1. Generate the code using a target like `make polymorph_dafny`.
+2. Apply the necessary manual edits (preferrably with marker comments to make them stand out better).
+3. Commit the generated code to git.
+4. Regenerate the code, passing the `--update-patch-files` option to the polymorph CLI.
+   With this repository's `SharedMakefile.mk`, you can define `UPDATE_PATCH_FILES_OPTION="--update-patch-files"`.
+   This will extract the necessary patch to modify the generated code to match what's checked in.
+
+## Build
+
+### All target runtimes
+1. Generate Dafny code using `polymorph`
+```
+make polymorph_dafny
+```
+
+### .NET
+1. Generate the Wrappers using `polymorph`
+```
+make polymorph_net
+```
+
+2. Transpile the tests (and implementation) to the target runtime.
+```
+make transpile_net
+```
+
+3. Generate the executable in the .NET and execute the tests
+```
+make test_net
+```
+
+## Development
+1. To add another target runtime support, edit the `Makefile` and add the appropriate recipe to generate the `polymorph` wrappers, and dafny transpilation.
+2. Provide any glue code between dafny and target runtime if required.
+3. Build, execute, and test in the target runtime.
+
+*Example*
+
+`--output-dotnet <PATH>` in the `gradlew run` is used to generate the polymorph wrappers. Similarly `--compileTarget:<RUNTIME>` flags is used in dafny recipe to transpile to C#.

--- a/TestModels/CodegenPatches/codegen-patches/dafny/dafny-4.2.0.patch
+++ b/TestModels/CodegenPatches/codegen-patches/dafny/dafny-4.2.0.patch
@@ -1,5 +1,5 @@
 diff --git b/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy a/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
-index 78cb9bf9..91bae887 100644
+index 78cb9bf9..491091be 100644
 --- b/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
 +++ a/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
 @@ -158,8 +158,14 @@ abstract module AbstractSimpleCodegenpatchesService
@@ -7,15 +7,26 @@ index 78cb9bf9..91bae887 100644
        ensures History.GetString == old(History.GetString) + [DafnyCallEvent(input, output)]
      {
 -      output := Operations.GetString(config, input);
--      History.GetString := History.GetString + [DafnyCallEvent(input, output)];
 +      // BEGIN MANUAL EDIT
 +      var defaultedInput := input;
 +      if input.value.None? {
 +        defaultedInput := input.(value := Some("default"));
 +      }
 +      output := Operations.GetString(config, defaultedInput);
-+      History.GetString := History.GetString + [DafnyCallEvent(defaultedInput, output)];
+       History.GetString := History.GetString + [DafnyCallEvent(input, output)];
 +      // END MANUAL EDIT
      }
  
    }
+@@ -173,6 +179,11 @@ abstract module AbstractSimpleCodegenpatchesOperations {
+   predicate ValidInternalConfig?(config: InternalConfig)
+   function ModifiesInternalConfig(config: InternalConfig): set<object>
+   predicate GetStringEnsuresPublicly(input: GetStringInput , output: Result<GetStringOutput, Error>)
++  // BEGIN MANUAL EDIT
++  {
++    true
++  }
++  // END MANUAL EDIT
+   // The private method to be refined by the library developer
+ 
+ 

--- a/TestModels/CodegenPatches/codegen-patches/dafny/dafny-4.2.0.patch
+++ b/TestModels/CodegenPatches/codegen-patches/dafny/dafny-4.2.0.patch
@@ -1,4 +1,5 @@
 diff --git b/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy a/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
+index 78cb9bf9..91bae887 100644
 --- b/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
 +++ a/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
 @@ -158,8 +158,14 @@ abstract module AbstractSimpleCodegenpatchesService

--- a/TestModels/CodegenPatches/codegen-patches/dafny/dafny-4.2.0.patch
+++ b/TestModels/CodegenPatches/codegen-patches/dafny/dafny-4.2.0.patch
@@ -1,0 +1,21 @@
+diff --git b/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy a/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
+index 78cb9bf9..91bae887 100644
+--- b/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
++++ a/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
+@@ -158,8 +158,14 @@ abstract module AbstractSimpleCodegenpatchesService
+       ensures GetStringEnsuresPublicly(input, output)
+       ensures History.GetString == old(History.GetString) + [DafnyCallEvent(input, output)]
+     {
+-      output := Operations.GetString(config, input);
+-      History.GetString := History.GetString + [DafnyCallEvent(input, output)];
++      // BEGIN MANUAL EDIT
++      var defaultedInput := input;
++      if input.value.None? {
++        defaultedInput := input.(value := Some("default"));
++      }
++      output := Operations.GetString(config, defaultedInput);
++      History.GetString := History.GetString + [DafnyCallEvent(defaultedInput, output)];
++      // END MANUAL EDIT
+     }
+ 
+   }

--- a/TestModels/CodegenPatches/codegen-patches/dafny/dafny-4.2.0.patch
+++ b/TestModels/CodegenPatches/codegen-patches/dafny/dafny-4.2.0.patch
@@ -1,5 +1,4 @@
 diff --git b/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy a/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
-index 78cb9bf9..91bae887 100644
 --- b/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
 +++ a/TestModels/CodegenPatches/Model/SimpleCodegenpatchesTypes.dfy
 @@ -158,8 +158,14 @@ abstract module AbstractSimpleCodegenpatchesService

--- a/TestModels/CodegenPatches/runtimes/java/build.gradle.kts
+++ b/TestModels/CodegenPatches/runtimes/java/build.gradle.kts
@@ -1,0 +1,67 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
+
+tasks.wrapper {
+    gradleVersion = "7.6"
+}
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+var dafnyVersion = props.getProperty("dafnyVersion")
+
+group = "simple"
+version = "1.0-SNAPSHOT"
+description = "CodegenPatches"
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(8))
+    sourceSets["main"].java {
+        srcDir("src/main/java")
+        srcDir("src/main/dafny-generated")
+        srcDir("src/main/smithy-generated")
+    }
+    sourceSets["test"].java {
+        srcDir("src/test/java")
+        srcDir("src/test/dafny-generated")
+    }
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+dependencies {
+    implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
+    implementation("software.amazon.smithy.dafny:conversion:0.1")
+    implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
+}
+
+publishing {
+    publications.create<MavenPublication>("maven") {
+        groupId = group as String?
+        artifactId = description
+        from(components["java"])
+    }
+    repositories { mavenLocal() }
+}
+
+tasks.withType<JavaCompile>() {
+    options.encoding = "UTF-8"
+}
+
+tasks {
+    register("runTests", JavaExec::class.java) {
+        mainClass.set("TestsFromDafny")
+        classpath = sourceSets["test"].runtimeClasspath
+    }
+}

--- a/TestModels/CodegenPatches/runtimes/java/src/main/java/Dafny/Simple/CodegenPatches/__default.java
+++ b/TestModels/CodegenPatches/runtimes/java/src/main/java/Dafny/Simple/CodegenPatches/__default.java
@@ -1,0 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package simple.codegenpatches.internaldafny;
+
+public class __default extends _ExternBase___default {
+}

--- a/TestModels/CodegenPatches/runtimes/java/src/test/java/simple/codegenpatches/internaldafny/wrapped/__default.java
+++ b/TestModels/CodegenPatches/runtimes/java/src/test/java/simple/codegenpatches/internaldafny/wrapped/__default.java
@@ -1,0 +1,21 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package simple.codegenpatches.internaldafny.wrapped;
+
+import simple.codegenpatches.CodegenPatches;
+import simple.codegenpatches.ToNative;
+import simple.codegenpatches.wrapped.TestCodegenPatches;
+
+import simple.codegenpatches.internaldafny.types.Error;
+import simple.codegenpatches.internaldafny.types.ICodegenPatchesClient;
+import simple.codegenpatches.internaldafny.types.CodegenPatchesConfig;
+import Wrappers_Compile.Result;
+
+public class __default extends _ExternBase___default {
+    public static Result<ICodegenPatchesClient, Error> WrappedCodegenPatches(CodegenPatchesConfig config) {
+        simple.codegenpatches.model.CodegenPatchesConfig wrappedConfig = ToNative.CodegenPatchesConfig(config);
+        simple.codegenpatches.CodegenPatches impl = CodegenPatches.builder().CodegenPatchesConfig(wrappedConfig).build();
+        TestCodegenPatches wrappedClient = TestCodegenPatches.builder().impl(impl).build();
+        return simple.codegenpatches.internaldafny.__default.CreateSuccessOfClient(wrappedClient);
+    }
+}

--- a/TestModels/CodegenPatches/runtimes/net/CodegenPatches.csproj
+++ b/TestModels/CodegenPatches/runtimes/net/CodegenPatches.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>CodegenPatches</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DafnyRuntime" Version="4.0.0.50303"/>
+    <!--
+      System.Collections.Immutable can be removed once dafny.msbuild is updated with
+      https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned
+    -->
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <!-- Work around for dafny-lang/dafny/issues/1951; remove once resolved -->
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+
+    <Compile Include="Extern/**/*.cs" />
+    <Compile Include="Generated/**/*.cs" />
+    <Compile Include="ImplementationFromDafny.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../dafny-dependencies/StandardLibrary/runtimes/net/STD.csproj" />
+  </ItemGroup>
+
+  <!--
+    TODO .NET assemblies are expected to have an ICON.
+    This MUST be replaced before launch.
+  -->
+  <!-- <ItemGroup>
+    <None Include="..\icon.png" Pack="true" PackagePath="" />
+    <None Include="..\README.md" Pack="true" PackagePath="" />
+  </ItemGroup> -->
+
+</Project>

--- a/TestModels/CodegenPatches/runtimes/net/Extern/WrappedSimpleCodegenPatchesService.cs
+++ b/TestModels/CodegenPatches/runtimes/net/Extern/WrappedSimpleCodegenPatchesService.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+using Wrappers_Compile;
+using Simple.Codegenpatches;
+using Simple.Codegenpatches.Wrapped;
+using TypeConversion = Simple.Codegenpatches.TypeConversion;
+namespace simple.codegenpatches.internaldafny.wrapped
+{
+    public partial class __default
+    {
+        public static _IResult<types.ICodegenPatchesClient, types._IError> WrappedCodegenPatches(types._ICodegenPatchesConfig config)
+        {
+            var wrappedConfig = TypeConversion.FromDafny_N6_simple__N14_codegenpatches__S20_CodegenPatchesConfig(config);
+            var impl = new CodegenPatches(wrappedConfig);
+            var wrappedClient = new CodegenPatchesShim(impl);
+            return Result<types.ICodegenPatchesClient, types._IError>.create_Success(wrappedClient);
+        }
+    }
+}

--- a/TestModels/CodegenPatches/runtimes/net/tests/CodegenPatchesTest.csproj
+++ b/TestModels/CodegenPatches/runtimes/net/tests/CodegenPatchesTest.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>CodegenPatchesTest</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
+    <OutputType>Exe</OutputType>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      System.Collections.Immutable can be removed once dafny.msbuild is updated with
+      https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned
+    -->
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <!-- Work around for dafny-lang/dafny/issues/1951; remove once resolved -->
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+
+    <ProjectReference Include="../CodegenPatches.csproj" />
+    <Compile Include="../Extern/**" />
+    <Compile Include="../Generated/**" />
+    <Compile Include="TestsFromDafny.cs" />
+  </ItemGroup>
+
+  <!-- <ItemGroup>
+    <None Include="..\icon.png" Pack="true" PackagePath="" />
+    <None Include="..\README.md" Pack="true" PackagePath="" />
+  </ItemGroup> -->
+
+</Project>

--- a/TestModels/CodegenPatches/src/CodegenPatchesImpl.dfy
+++ b/TestModels/CodegenPatches/src/CodegenPatchesImpl.dfy
@@ -9,9 +9,6 @@ module CodegenPatchesImpl refines AbstractSimpleCodegenpatchesOperations  {
   {true}
   function ModifiesInternalConfig(config: InternalConfig) : set<object>
   {{}}
-  predicate GetStringEnsuresPublicly(input: GetStringInput, output: Result<GetStringOutput, Error>) {
-    true
-  }
   method GetString ( config: InternalConfig,  input: GetStringInput )
     returns (output: Result<GetStringOutput, Error>)
   {  

--- a/TestModels/CodegenPatches/src/CodegenPatchesImpl.dfy
+++ b/TestModels/CodegenPatches/src/CodegenPatchesImpl.dfy
@@ -1,0 +1,22 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+include "../Model/SimpleCodegenpatchesTypes.dfy"
+
+module CodegenPatchesImpl refines AbstractSimpleCodegenpatchesOperations  {
+  datatype Config = Config
+  type InternalConfig = Config
+  predicate ValidInternalConfig?(config: InternalConfig)
+  {true}
+  function ModifiesInternalConfig(config: InternalConfig) : set<object>
+  {{}}
+  predicate GetStringEnsuresPublicly(input: GetStringInput, output: Result<GetStringOutput, Error>) {
+    true
+  }
+  method GetString ( config: InternalConfig,  input: GetStringInput )
+    returns (output: Result<GetStringOutput, Error>)
+  {  
+    var res := GetStringOutput(value := input.value);
+
+    return Success(res);
+  }
+}

--- a/TestModels/CodegenPatches/src/Index.dfy
+++ b/TestModels/CodegenPatches/src/Index.dfy
@@ -1,0 +1,31 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+include "CodegenPatchesImpl.dfy"
+
+module {:extern "simple.codegenpatches.internaldafny" } CodegenPatches refines AbstractSimpleCodegenpatchesService {
+  import Operations = CodegenPatchesImpl
+
+  function method DefaultCodegenPatchesConfig(): CodegenPatchesConfig {
+    CodegenPatchesConfig
+  }
+
+  method CodegenPatches(config: CodegenPatchesConfig)
+    returns (res: Result<ICodegenPatchesClient, Error>)
+  {
+    var client := new CodegenPatchesClient(Operations.Config);
+    return Success(client);
+  }
+
+  class CodegenPatchesClient... {
+    predicate ValidState() {
+       && Operations.ValidInternalConfig?(config)
+       && Modifies == Operations.ModifiesInternalConfig(config) + {History}
+    }
+
+    constructor(config: Operations.InternalConfig) {
+       this.config := config;
+       History := new ICodegenPatchesClientCallHistory();
+       Modifies := Operations.ModifiesInternalConfig(config) + {History};
+    }
+  }
+}

--- a/TestModels/CodegenPatches/src/WrappedCodegenPatchesImpl.dfy
+++ b/TestModels/CodegenPatches/src/WrappedCodegenPatchesImpl.dfy
@@ -1,0 +1,10 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+include "../Model/SimpleCodegenpatchesTypesWrapped.dfy"
+
+module {:extern "simple.codegenpatches.internaldafny.wrapped"} WrappedSimpleCodegenPatchesService refines WrappedAbstractSimpleCodegenpatchesService {
+    import WrappedService = CodegenPatches
+    function method WrappedDefaultCodegenPatchesConfig(): CodegenPatchesConfig {
+        CodegenPatchesConfig
+    }
+}

--- a/TestModels/CodegenPatches/test/CodegenPatchesImplTest.dfy
+++ b/TestModels/CodegenPatches/test/CodegenPatchesImplTest.dfy
@@ -17,11 +17,11 @@ module CodegenPatchesImplTest {
       modifies client.Modifies
       ensures client.ValidState()
     {
-      var s: string := "wassup?";
-      var convertedStringInput: GetStringInput := CodegenPatches.Types.GetStringInput(value := Some(s));
+      var convertedStringInput: GetStringInput := CodegenPatches.Types.GetStringInput();
 
       var ret := client.GetString(convertedStringInput);
 
       expect ret.Success?;
+      expect ret.value.value == Some("default");
     }
 }

--- a/TestModels/CodegenPatches/test/CodegenPatchesImplTest.dfy
+++ b/TestModels/CodegenPatches/test/CodegenPatchesImplTest.dfy
@@ -1,0 +1,27 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+include "../src/Index.dfy"
+
+module CodegenPatchesImplTest {
+    import CodegenPatches
+    import StandardLibrary.UInt
+    import opened SimpleCodegenpatchesTypes
+    import opened Wrappers
+    method{:test} TestCodegenPatches(){
+        var client :- expect CodegenPatches.CodegenPatches();
+        TestGetString(client);
+    }
+
+    method TestGetString(client: ICodegenPatchesClient)
+      requires client.ValidState()
+      modifies client.Modifies
+      ensures client.ValidState()
+    {
+      var s: string := "wassup?";
+      var convertedStringInput: GetStringInput := CodegenPatches.Types.GetStringInput(value := Some(s));
+
+      var ret := client.GetString(convertedStringInput);
+
+      expect ret.Success?;
+    }
+}

--- a/TestModels/CodegenPatches/test/WrappedCodegenPatchesTest.dfy
+++ b/TestModels/CodegenPatches/test/WrappedCodegenPatchesTest.dfy
@@ -1,0 +1,14 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+include "../src/WrappedCodegenPatchesImpl.dfy"
+include "CodegenPatchesImplTest.dfy"
+
+module WrappedCodegenPatchesTest {
+    import WrappedSimpleCodegenPatchesService
+    import CodegenPatchesImplTest
+    import opened Wrappers
+    method{:test} GetString() {
+        var client :- expect WrappedSimpleCodegenPatchesService.WrappedCodegenPatches();
+        CodegenPatchesImplTest.TestGetString(client);
+    }
+}

--- a/TestModels/MultipleModels/Makefile
+++ b/TestModels/MultipleModels/Makefile
@@ -9,8 +9,8 @@ include ../SharedMakefile.mk
 DIR_STRUCTURE_V2=V2
 
 PROJECT_SERVICES := \
-	PrimaryProject \
 	DependencyProject \
+	PrimaryProject \
 
 SERVICE_NAMESPACE_PrimaryProject=simple.multiplemodels.primaryproject
 SERVICE_NAMESPACE_DependencyProject=simple.multiplemodels.dependencyproject

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -328,6 +328,10 @@ _polymorph_java: _polymorph_wrapped
 _polymorph_java: POLYMORPH_LANGUAGE_TARGET=java
 _polymorph_java: _polymorph_dependencies
 
+# Dependency for generating Java code
+setup_prettier:
+	npm i --no-save prettier prettier-plugin-java
+
 ########################## .NET targets
 
 transpile_net: | transpile_implementation_net transpile_test_net transpile_dependencies_net

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -195,6 +195,7 @@ _polymorph:
 	$(GRADLEW) run --args="\
 	$(DAFNY_VERSION_OPTION) \
 	--library-root $(LIBRARY_ROOT) \
+	$(UPDATE_PATCH_FILES_OPTION) \
 	--properties-file $(LIBRARY_ROOT)/project.properties \
 	$(OUTPUT_DAFNY) \
 	$(OUTPUT_DOTNET) \

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -328,7 +328,7 @@ _polymorph_java: _polymorph_wrapped
 _polymorph_java: POLYMORPH_LANGUAGE_TARGET=java
 _polymorph_java: _polymorph_dependencies
 
-# Dependency for generating Java code
+# Dependency for formatting generating Java code
 setup_prettier:
 	npm i --no-save prettier prettier-plugin-java
 

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -278,6 +278,8 @@ polymorph_dafny:
 		$(MAKE) _polymorph_dafny || exit 1; \
 	done
 
+_polymorph_dafny: POLYMORPH_LANGUAGE_TARGET=dafny
+_polymorph_dafny: _polymorph_dependencies
 _polymorph_dafny: OUTPUT_DAFNY=\
     --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model) \
 	--include-dafny $(STANDARD_LIBRARY_PATH)/src/Index.dfy
@@ -287,8 +289,6 @@ _polymorph_dafny: OUTPUT_DAFNY_WRAPPED=\
     --include-dafny $(STANDARD_LIBRARY_PATH)/src/Index.dfy
 _polymorph_dafny: OUTPUT_LOCAL_SERVICE=--local-service-test
 _polymorph_dafny: _polymorph_wrapped
-_polymorph_dafny: POLYMORPH_LANGUAGE_TARGET=dafny
-_polymorph_dafny: _polymorph_dependencies
 
 # Generates dotnet code for all namespaces in this project
 .PHONY: polymorph_net

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -243,11 +243,11 @@ _polymorph_dependencies:
 # Generates all target runtime code for all namespaces in this project.
 .PHONY: polymorph_code_gen
 polymorph_code_gen:
-	for service in $(PROJECT_SERVICES) ; do \
+	set -e; for service in $(PROJECT_SERVICES) ; do \
 		export service_deps_var=SERVICE_DEPS_$${service} ; \
 		export namespace_var=SERVICE_NAMESPACE_$${service} ; \
 		export SERVICE=$${service} ; \
-		$(MAKE) _polymorph_code_gen || exit 1; \
+		$(MAKE) _polymorph_code_gen ; \
 	done
 
 _polymorph_code_gen: OUTPUT_DAFNY=\
@@ -271,11 +271,11 @@ _polymorph_code_gen: _polymorph_dependencies
 .PHONY: polymorph_dafny
 polymorph_dafny:
 	$(MAKE) -C $(STANDARD_LIBRARY_PATH) polymorph_dafny
-	for service in $(PROJECT_SERVICES) ; do \
+	set -e; for service in $(PROJECT_SERVICES) ; do \
 		export service_deps_var=SERVICE_DEPS_$${service} ; \
 		export namespace_var=SERVICE_NAMESPACE_$${service} ; \
 		export SERVICE=$${service} ; \
-		$(MAKE) _polymorph_dafny || exit 1; \
+		$(MAKE) _polymorph_dafny ; \
 	done
 
 _polymorph_dafny: POLYMORPH_LANGUAGE_TARGET=dafny
@@ -293,11 +293,11 @@ _polymorph_dafny: _polymorph_wrapped
 # Generates dotnet code for all namespaces in this project
 .PHONY: polymorph_net
 polymorph_net:
-	for service in $(PROJECT_SERVICES) ; do \
+	set -e; for service in $(PROJECT_SERVICES) ; do \
 		export service_deps_var=SERVICE_DEPS_$${service} ; \
 		export namespace_var=SERVICE_NAMESPACE_$${service} ; \
 		export SERVICE=$${service} ; \
-		$(MAKE) _polymorph_net || exit 1; \
+		$(MAKE) _polymorph_net ; \
 	done
 
 _polymorph_net: OUTPUT_DOTNET=\
@@ -313,11 +313,11 @@ _polymorph_net: _polymorph_dependencies
 # Generates java code for all namespaces in this project
 .PHONY: polymorph_java
 polymorph_java:
-	for service in $(PROJECT_SERVICES) ; do \
+	set -e; for service in $(PROJECT_SERVICES) ; do \
 		export service_deps_var=SERVICE_DEPS_$${service} ; \
 		export namespace_var=SERVICE_NAMESPACE_$${service} ; \
 		export SERVICE=$${service} ; \
-		$(MAKE) _polymorph_java || exit 1; \
+		$(MAKE) _polymorph_java ; \
 	done
 
 _polymorph_java: OUTPUT_JAVA=--output-java $(LIBRARY_ROOT)/runtimes/java/src/main/smithy-generated

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -206,6 +206,7 @@ _polymorph:
 	cd $(CODEGEN_CLI_ROOT); \
 	$(GRADLEW) run --args="\
 	$(DAFNY_VERSION_OPTION) \
+	--library-root $(LIBRARY_ROOT) \
 	--properties-file $(LIBRARY_ROOT)/project.properties \
 	$(OUTPUT_DAFNY) \
 	$(OUTPUT_DOTNET) \
@@ -221,6 +222,7 @@ _polymorph_wrapped:
 	cd $(CODEGEN_CLI_ROOT); \
 	$(GRADLEW) run --args="\
 	$(DAFNY_VERSION_OPTION) \
+	--library-root $(LIBRARY_ROOT) \
 	--properties-file $(LIBRARY_ROOT)/project.properties \
 	$(OUTPUT_DAFNY_WRAPPED) \
 	$(OUTPUT_DOTNET_WRAPPED) \

--- a/TestModels/dafny-dependencies/StandardLibrary/Makefile
+++ b/TestModels/dafny-dependencies/StandardLibrary/Makefile
@@ -25,6 +25,7 @@ polymorph_dafny :
 	cd $(CODEGEN_CLI_ROOT); \
 	$(GRADLEW) run --args="\
 	$(DAFNY_VERSION_OPTION) \
+	--library-root $(LIBRARY_ROOT) \
 	--properties-file $(STANDARD_LIBRARY_PATH)/project.properties \
 	--model $(STANDARD_LIBRARY_PATH)/Model \
 	--namespace aws.polymorph \

--- a/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
+++ b/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
@@ -78,7 +78,8 @@ public class CodegenCli {
                 .withTargetLangOutputDirs(outputDirs)
                 .withAwsSdkStyle(cliArguments.awsSdkStyle)
                 .withLocalServiceTest(cliArguments.localServiceTest)
-                .withDafnyVersion(cliArguments.dafnyVersion);
+                .withDafnyVersion(cliArguments.dafnyVersion)
+                .withUpdatePatchFiles(cliArguments.updatePatchFiles);
         cliArguments.propertiesFile.ifPresent(engineBuilder::withPropertiesFile);
         cliArguments.javaAwsSdkVersion.ifPresent(engineBuilder::withJavaAwsSdkVersion);
         cliArguments.includeDafnyFile.ifPresent(engineBuilder::withIncludeDafnyFile);
@@ -161,9 +162,8 @@ public class CodegenCli {
             .hasArg()
             .build())
           .addOption(Option.builder()
-            .longOpt("patch-files-dir")
-            .desc("<optional> patch files to apply to generated code")
-            .hasArg()
+            .longOpt("update-patch-files")
+            .desc("<optional> update patch files in <library-root>/codegen-patches instead of applying them")
             .build());
     }
 
@@ -184,7 +184,8 @@ public class CodegenCli {
             Optional<Path> propertiesFile,
             Optional<Path> includeDafnyFile,
             boolean awsSdkStyle,
-            boolean localServiceTest
+            boolean localServiceTest,
+            boolean updatePatchFiles
     ) {
         /**
          * @param args arguments to parse
@@ -258,11 +259,13 @@ public class CodegenCli {
                 includeDafnyFile = Optional.of(Paths.get(commandLine.getOptionValue("include-dafny")));
             }
 
+            final boolean updatePatchFiles = commandLine.hasOption("update-patch-files");
+
             return Optional.of(new CliArguments(
                     libraryRoot, modelPath, dependentModelPaths, namespace,
                     outputDotnetDir, outputJavaDir, outputDafnyDir,
                     javaAwsSdkVersion, dafnyVersion, propertiesFile, includeDafnyFile, awsSdkStyle,
-                    localServiceTest
+                    localServiceTest, updatePatchFiles
             ));
         }
     }

--- a/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
+++ b/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
@@ -79,6 +79,7 @@ public class CodegenCli {
         cliArguments.propertiesFile.ifPresent(engineBuilder::withPropertiesFile);
         cliArguments.javaAwsSdkVersion.ifPresent(engineBuilder::withJavaAwsSdkVersion);
         cliArguments.includeDafnyFile.ifPresent(engineBuilder::withIncludeDafnyFile);
+        cliArguments.patchFilesDir.ifPresent(engineBuilder::withPatchFilesDir);
         final CodegenEngine engine = engineBuilder.build();
         engine.run();
     }
@@ -150,6 +151,11 @@ public class CodegenCli {
             .longOpt("include-dafny")
             .desc("<optional> files to be include in the generated Dafny")
             .hasArg()
+            .build())
+          .addOption(Option.builder()
+            .longOpt("patch-files-dir")
+            .desc("<optional> patch files to apply to generated code")
+            .hasArg()
             .build());
     }
 
@@ -169,7 +175,8 @@ public class CodegenCli {
             Optional<Path> propertiesFile,
             Optional<Path> includeDafnyFile,
             boolean awsSdkStyle,
-            boolean localServiceTest
+            boolean localServiceTest,
+            Optional<Path> patchFilesDir
     ) {
         /**
          * @param args arguments to parse
@@ -241,11 +248,13 @@ public class CodegenCli {
                 includeDafnyFile = Optional.of(Paths.get(commandLine.getOptionValue("include-dafny")));
             }
 
+            Optional<Path> patchFilesDir = Optional.of(Paths.get(commandLine.getOptionValue("patch-files-dir")));
+
             return Optional.of(new CliArguments(
                     modelPath, dependentModelPaths, namespace,
                     outputDotnetDir, outputJavaDir, outputDafnyDir,
                     javaAwsSdkVersion, dafnyVersion, propertiesFile, includeDafnyFile, awsSdkStyle,
-                    localServiceTest
+                    localServiceTest, patchFilesDir
             ));
         }
     }

--- a/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
+++ b/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
@@ -70,6 +70,7 @@ public class CodegenCli {
         cliArguments.outputDotnetDir.ifPresent(path -> outputDirs.put(TargetLanguage.DOTNET, path));
 
         final CodegenEngine.Builder engineBuilder = new CodegenEngine.Builder()
+                .withFromSmithyBuildPlugin(false)
                 .withLibraryRoot(cliArguments.libraryRoot)
                 .withServiceModel(serviceModel)
                 .withDependentModelPaths(cliArguments.dependentModelPaths)

--- a/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
+++ b/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
@@ -248,7 +248,8 @@ public class CodegenCli {
                 includeDafnyFile = Optional.of(Paths.get(commandLine.getOptionValue("include-dafny")));
             }
 
-            Optional<Path> patchFilesDir = Optional.of(Paths.get(commandLine.getOptionValue("patch-files-dir")));
+            Optional<Path> patchFilesDir = Optional.ofNullable(commandLine.getOptionValue("patch-files-dir"))
+                    .map(Paths::get);
 
             return Optional.of(new CliArguments(
                     modelPath, dependentModelPaths, namespace,

--- a/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
+++ b/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
@@ -40,6 +40,7 @@ public class CodegenCli {
             cliArgumentsOptional = CliArguments.parse(args);
         } catch (ParseException e) {
             LOGGER.error("Command-line arguments could not be parsed", e);
+            System.exit(1);
         }
         if (cliArgumentsOptional.isEmpty()) {
             printHelpMessage();

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -236,15 +236,16 @@ public class CodegenEngine {
             netLocalService(outputDir);
         }
 
-        LOGGER.info("Formatting .NET code in {}", libraryRoot);
+        Path dotnetRoot = libraryRoot.resolve("runtimes").resolve("net");
+        LOGGER.info("Formatting .NET code in {}", dotnetRoot);
         // Locate all *.csproj files in the directory
         try {
             Stream<String> args = Streams.concat(
                     Stream.of("dotnet", "format"),
-                    Files.walk(libraryRoot)
+                    Files.walk(dotnetRoot)
                          .filter(path -> path.toFile().getName().endsWith(".csproj"))
                          .map(Path::toString));
-            runCommand(libraryRoot, args.toArray(String[]::new));
+            runCommand(dotnetRoot, args.toArray(String[]::new));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -236,15 +236,15 @@ public class CodegenEngine {
             netLocalService(outputDir);
         }
 
-        LOGGER.info("Formatting .NET code in {}", outputDir);
-        // Locate all *.csproj files in the directory
         // TODO-HACK: Need to look in the parent directory of "runtimes/net"
         Path projectRoot = outputDir.getParent();
+        LOGGER.info("Formatting .NET code in {}", projectRoot);
+        // Locate all *.csproj files in the directory
         try {
             Stream<String> args = Streams.concat(
                     Stream.of("dotnet", "format"),
                     Files.list(projectRoot)
-                         .filter(path -> path.endsWith(".csproj"))
+                         .filter(path -> path.toFile().getName().endsWith(".csproj"))
                          .map(Path::toString));
             runCommand(projectRoot, args.toArray(String[]::new));
         } catch (IOException e) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -238,13 +238,15 @@ public class CodegenEngine {
 
         LOGGER.info("Formatting .NET code in {}", outputDir);
         // Locate all *.csproj files in the directory
+        // TODO-HACK: Need to look in the parent directory of "runtimes/net"
+        Path projectRoot = outputDir.getParent();
         try {
             Stream<String> args = Streams.concat(
                     Stream.of("dotnet", "format"),
-                    Files.list(outputDir)
+                    Files.list(projectRoot)
                          .filter(path -> path.endsWith(".csproj"))
                          .map(Path::toString));
-            runCommand(outputDir, args.toArray(String[]::new));
+            runCommand(projectRoot, args.toArray(String[]::new));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -297,8 +297,9 @@ public class CodegenEngine {
                     .map(file -> Pair.of(getDafnyVersionForPatchFile(file), file))
                     .sorted(Collections.reverseOrder(Map.Entry.comparingByKey()))
                     .toList();
-            for (Pair<DafnyVersion, Path> patchFile : sortedPatchFiles) {
-                if (dafnyVersion.compareTo(patchFile.getKey()) > 0) {
+            for (Pair<DafnyVersion, Path> patchFilePair : sortedPatchFiles) {
+                if (dafnyVersion.compareTo(patchFilePair.getKey()) > 0) {
+                    Path patchFile = patchFilePair.getValue();
                     StringBuilder output = new StringBuilder();
                     int exitCode = IoUtils.runCommand(
                             List.of("git", "apply", patchFile.toString()),

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -179,8 +179,6 @@ public class CodegenEngine {
                 ".");
 
         applyPatchFiles(TargetLanguage.DAFNY, outputDir);
-
-        throw new RuntimeException("KABOOM!");
     }
 
     private void generateJava(final Path outputDir) {
@@ -253,8 +251,6 @@ public class CodegenEngine {
         }
 
         applyPatchFiles(TargetLanguage.DOTNET, outputDir);
-
-        throw new RuntimeException("KABOOM!");
     }
 
     private void netLocalService(final Path outputDir) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -242,7 +242,7 @@ public class CodegenEngine {
         try {
             Stream<String> args = Streams.concat(
                     Stream.of("dotnet", "format"),
-                    Files.list(dotnetRoot)
+                    Files.walk(dotnetRoot)
                          .filter(path -> path.toFile().getName().endsWith(".csproj"))
                          .map(Path::toString));
             runCommand(dotnetRoot, args.toArray(String[]::new));

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -179,6 +179,8 @@ public class CodegenEngine {
                 ".");
 
         applyPatchFiles(TargetLanguage.DAFNY, outputDir);
+
+        throw new RuntimeException("KABOOM!");
     }
 
     private void generateJava(final Path outputDir) {
@@ -251,6 +253,8 @@ public class CodegenEngine {
         }
 
         applyPatchFiles(TargetLanguage.DOTNET, outputDir);
+
+        throw new RuntimeException("KABOOM!");
     }
 
     private void netLocalService(final Path outputDir) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -351,7 +351,7 @@ public class CodegenEngine {
                 if (!patchContent.isBlank()) {
                     IOUtils.writeToFile(patchContent, patchFile.toFile());
                 }
-            } else {
+            } else if (Files.exists(patchFilesDir)) {
                 List<Pair<DafnyVersion, Path>> sortedPatchFiles = Files.list(patchFilesDir)
                         .map(file -> Pair.of(getDafnyVersionForPatchFile(file), file))
                         .sorted(Collections.reverseOrder(Map.Entry.comparingByKey()))

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -236,16 +236,15 @@ public class CodegenEngine {
             netLocalService(outputDir);
         }
 
-        Path dotnetRoot = libraryRoot.resolve("runtimes").resolve("net");
-        LOGGER.info("Formatting .NET code in {}", dotnetRoot);
+        LOGGER.info("Formatting .NET code in {}", libraryRoot);
         // Locate all *.csproj files in the directory
         try {
             Stream<String> args = Streams.concat(
                     Stream.of("dotnet", "format"),
-                    Files.walk(dotnetRoot)
+                    Files.walk(libraryRoot)
                          .filter(path -> path.toFile().getName().endsWith(".csproj"))
                          .map(Path::toString));
-            runCommand(dotnetRoot, args.toArray(String[]::new));
+            runCommand(libraryRoot, args.toArray(String[]::new));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -315,6 +315,7 @@ public class CodegenEngine {
             for (Pair<DafnyVersion, Path> patchFilePair : sortedPatchFiles) {
                 if (dafnyVersion.compareTo(patchFilePair.getKey()) >= 0) {
                     Path patchFile = patchFilePair.getValue();
+                    LOGGER.info("Applying patch file {}", patchFile);
                     runCommand(outputDir, "git", "apply", patchFile.toString());
                     return;
                 }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class CodegenEngine {
     private static final Logger LOGGER = LoggerFactory.getLogger(CodegenEngine.class);
@@ -278,6 +280,8 @@ public class CodegenEngine {
         LOGGER.info(".NET project files generated in {}", outputDir);
     }
 
+    private static final Pattern PATCH_FILE_PATTERN = Pattern.compile("dafny-(.*).patch");
+
     private void applyPatchFiles(TargetLanguage targetLanguage, Path outputDir) {
         if (!patchFilesDir.isPresent()) {
             return;
@@ -314,8 +318,9 @@ public class CodegenEngine {
 
     private DafnyVersion getDafnyVersionForPatchFile(Path file) {
         String fileName = file.getFileName().toString();
-        if (fileName.startsWith("dafny-")) {
-            String versionString = fileName.substring("dafny-".length());
+        Matcher matcher = PATCH_FILE_PATTERN.matcher(fileName);
+        if (matcher.matches()) {
+            String versionString = matcher.group(1);
             return DafnyVersion.parse(versionString);
         } else {
             throw new IllegalArgumentException("Patch files must be of the form dafny-<version>.patch: " + file);

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -351,7 +351,9 @@ public class CodegenEngine {
                 if (!patchContent.isBlank()) {
                     IOUtils.writeToFile(patchContent, patchFile.toFile());
                 }
-            } else if (Files.exists(patchFilesDir)) {
+            }
+
+            if (Files.exists(patchFilesDir)) {
                 List<Pair<DafnyVersion, Path>> sortedPatchFiles = Files.list(patchFilesDir)
                         .map(file -> Pair.of(getDafnyVersionForPatchFile(file), file))
                         .sorted(Collections.reverseOrder(Map.Entry.comparingByKey()))

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -169,6 +169,14 @@ public class CodegenEngine {
             LOGGER.info("Dafny code generated in {}", outputDir);
         }
 
+        LOGGER.info("Formatting Dafny code in {}", outputDir);
+        runCommand(outputDir,
+                "dafny", "format",
+                "--function-syntax:3",
+                "--quantifier-syntax:3",
+                "--unicode-char:false",
+                ".");
+
         applyPatchFiles(TargetLanguage.DAFNY, outputDir);
     }
 
@@ -184,6 +192,7 @@ public class CodegenEngine {
             javaLocalService(outputDir);
         }
 
+        LOGGER.info("Formatting Java code in {}", outputDir);
         runCommand(outputDir,
                 "npx", "prettier", "--plugin=prettier-plugin-java", outputDir.toString(), "--write");
 
@@ -226,6 +235,7 @@ public class CodegenEngine {
             netLocalService(outputDir);
         }
 
+        LOGGER.info("Formatting .NET code in {}", outputDir);
         runCommand(outputDir, "dotnet", "format", outputDir.toString() + "/*.csproj");
 
         applyPatchFiles(TargetLanguage.DOTNET, outputDir);

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -242,7 +242,7 @@ public class CodegenEngine {
         try {
             Stream<String> args = Streams.concat(
                     Stream.of("dotnet", "format"),
-                    Files.walk(dotnetRoot)
+                    Files.list(dotnetRoot)
                          .filter(path -> path.toFile().getName().endsWith(".csproj"))
                          .map(Path::toString));
             runCommand(dotnetRoot, args.toArray(String[]::new));

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -313,7 +313,7 @@ public class CodegenEngine {
                     .sorted(Collections.reverseOrder(Map.Entry.comparingByKey()))
                     .toList();
             for (Pair<DafnyVersion, Path> patchFilePair : sortedPatchFiles) {
-                if (dafnyVersion.compareTo(patchFilePair.getKey()) > 0) {
+                if (dafnyVersion.compareTo(patchFilePair.getKey()) >= 0) {
                     Path patchFile = patchFilePair.getValue();
                     runCommand(outputDir, "git", "apply", patchFile.toString());
                     return;

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -991,8 +991,9 @@ public class TypeConversionCodegen {
         if (serviceShape.hasTrait(LocalServiceTrait.class)) {
             final LocalServiceTrait localServiceTrait = serviceShape.expectTrait(LocalServiceTrait.class);
 
-            Set<String> dependentNamespaces = ModelUtils.findAllDependentNamespaces(
-                new HashSet<ShapeId>(Collections.singleton(localServiceTrait.getConfigId())), model);
+            TreeSet<String> dependentNamespaces = new TreeSet<>(
+                    ModelUtils.findAllDependentNamespaces(
+                            new HashSet<>(Collections.singleton(localServiceTrait.getConfigId())), model));
 
             if (localServiceTrait.getDependencies() != null) {
                 localServiceTrait.getDependencies().stream()
@@ -1006,7 +1007,7 @@ public class TypeConversionCodegen {
             }
 
             if (dependentNamespaces.size() > 0) {
-                Set<TokenTree> cases = new HashSet<>();
+                TreeSet<TokenTree> cases = new TreeSet<>();
                 for (String dependentNamespace : dependentNamespaces) {
 
                     TokenTree toAppend = TokenTree.of(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -1007,10 +1007,8 @@ public class TypeConversionCodegen {
             }
 
             if (dependentNamespaces.size() > 0) {
-                List<TokenTree> cases = new ArrayList<>();
-                for (String dependentNamespace : dependentNamespaces) {
-
-                    TokenTree toAppend = TokenTree.of(
+                Stream<TokenTree> cases = dependentNamespaces.stream().map(dependentNamespace ->
+                    TokenTree.of(
                         """
                         case %1$s.Error_%3$s dafnyVal:
                           return %2$s.TypeConversion.FromDafny_CommonError(
@@ -1021,11 +1019,9 @@ public class TypeConversionCodegen {
                             DotNetNameResolver.convertToCSharpNamespaceWithSegmentMapper(dependentNamespace, DotNetNameResolver::capitalizeNamespaceSegment),
                             DafnyNameResolver.dafnyBaseModuleName(dependentNamespace)
                         )
-                    );
-
-                    cases.add(toAppend);
-                }
-                dependencyErrorCasesFromDafny = TokenTree.of(cases.stream()).lineSeparated();
+                    )
+                );
+                dependencyErrorCasesFromDafny = TokenTree.of(cases).lineSeparated();
             }
         }
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydotnet/TypeConversionCodegen.java
@@ -1007,7 +1007,7 @@ public class TypeConversionCodegen {
             }
 
             if (dependentNamespaces.size() > 0) {
-                TreeSet<TokenTree> cases = new TreeSet<>();
+                List<TokenTree> cases = new ArrayList<>();
                 for (String dependentNamespace : dependentNamespaces) {
 
                     TokenTree toAppend = TokenTree.of(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/smithy/dafny/codegen/DafnyClientCodegenPlugin.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/smithy/dafny/codegen/DafnyClientCodegenPlugin.java
@@ -37,7 +37,7 @@ public final class DafnyClientCodegenPlugin implements SmithyBuildPlugin {
         final Map<TargetLanguage, Path> outputDirs = new HashMap<>();
         outputDirs.put(TargetLanguage.DAFNY, manifest.resolvePath(Paths.get("Model")));
         settings.targetLanguages.forEach(lang -> {
-            final Path dir = Paths.get("runtimes", lang.getSymbol(), "Generated");
+            final Path dir = Paths.get("runtimes", lang.name().toLowerCase(), "Generated");
             outputDirs.put(lang, manifest.resolvePath(dir));
         });
         final Path propertiesFile = manifest.resolvePath(Paths.get("project.properties"));

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/smithy/dafny/codegen/DafnyClientCodegenPlugin.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/smithy/dafny/codegen/DafnyClientCodegenPlugin.java
@@ -37,7 +37,7 @@ public final class DafnyClientCodegenPlugin implements SmithyBuildPlugin {
         final Map<TargetLanguage, Path> outputDirs = new HashMap<>();
         outputDirs.put(TargetLanguage.DAFNY, manifest.resolvePath(Paths.get("Model")));
         settings.targetLanguages.forEach(lang -> {
-            final Path dir = Paths.get("runtimes", lang.name().toLowerCase(), "Generated");
+            final Path dir = Paths.get("runtimes", lang.getSymbol(), "Generated");
             outputDirs.put(lang, manifest.resolvePath(dir));
         });
         final Path propertiesFile = manifest.resolvePath(Paths.get("project.properties"));

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/smithy/dafny/codegen/DafnyClientCodegenPlugin.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/smithy/dafny/codegen/DafnyClientCodegenPlugin.java
@@ -37,7 +37,7 @@ public final class DafnyClientCodegenPlugin implements SmithyBuildPlugin {
         final Map<TargetLanguage, Path> outputDirs = new HashMap<>();
         outputDirs.put(TargetLanguage.DAFNY, manifest.resolvePath(Paths.get("Model")));
         settings.targetLanguages.forEach(lang -> {
-            final Path dir = Paths.get("runtimes", lang.getSymbol(), "Generated");
+            final Path dir = Paths.get("runtimes", lang.name().toLowerCase(), "Generated");
             outputDirs.put(lang, manifest.resolvePath(dir));
         });
         final Path propertiesFile = manifest.resolvePath(Paths.get("project.properties"));
@@ -48,6 +48,7 @@ public final class DafnyClientCodegenPlugin implements SmithyBuildPlugin {
         }
 
         final CodegenEngine codegenEngine = new CodegenEngine.Builder()
+                .withFromSmithyBuildPlugin(true)
                 .withLibraryRoot(manifest.getBaseDir())
                 .withServiceModel(model)
                 // TODO generate code based on service closure, not namespace

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/smithy/dafny/codegen/DafnyClientCodegenPlugin.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/smithy/dafny/codegen/DafnyClientCodegenPlugin.java
@@ -48,6 +48,7 @@ public final class DafnyClientCodegenPlugin implements SmithyBuildPlugin {
         }
 
         final CodegenEngine codegenEngine = new CodegenEngine.Builder()
+                .withLibraryRoot(manifest.getBaseDir())
                 .withServiceModel(model)
                 // TODO generate code based on service closure, not namespace
                 .withNamespace(settings.serviceId.getNamespace())


### PR DESCRIPTION
*Description of changes:*

In practice, the projects using `smithy-dafny` such as https://github.com/aws/aws-cryptographic-material-providers-library have had to apply manual edits to generated code, to deal with inconsistencies in AWS SDKs and/or missing `smithy-dafny` features. Besides making it more labour-intensive to regenerate code when necessary, this also makes it challenging to test such projects against different versions of Dafny, especially nightly pre-releases, when code generation has to produce different code for different Dafny versions.

To address this point, this PR adds a new required `--library-root` option. After generating code for a target language, the code generation engine also applies any applicable `<library-root>/codegen-patches/<language>/dafny-<version>.patch` file, selecting the highest such `<version>` that is less than the target `--dafny-version`. This allows the patch files to differ slightly based on the generated code shape. See https://github.com/aws/aws-cryptographic-material-providers-library/pull/195 for examples of using this mechanism.

It also moves the tasks of applying auto-formatters to the generated code into `smithy-dafny` instead of just in the shared makefiles. This makes it much easier to generate these patch files using `git diff`, since the downstream projects affected are already checking in formatted code. `--library-root` is necessary in particular to support formatting .NET code cleanly, since `dotnet format` requires `.csproj` files as arguments. Because the polymorph CLI and the Smithy build plugin have slightly different conventions around library layout, the common CodegenEngine class also now has a `fromSmithyBuildPlugin` boolean to handle both cases, but this is not exposed to users as a CLI option or Smithy build plugin configuration parameter.

Applying `dafny format` also requires that the generated Dafny code can immediately be at least parsed successfully, which implies any dependencies must be already generated. This meant having to tweak orderings in a few Makefiles to satisfy this, but this seemed reasonable given dependencies already needed to be ordered correctly.

Note also that the addition of `--library-root` means that the values of `--output-dafny/java/dotnet/etc` could in the future default to their conventional locations according to the library folder structure that the shared makefiles support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
