### PR TITLE
fix: Always pass -compileSuffix:1

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Populate Dafny versions list
       id: populate-dafny-versions-list
-      run: echo "dafny-versions-list=['4.1.0', '4.2.0', '4.4.0']" >> $GITHUB_OUTPUT
+      run: echo "dafny-versions-list=['4.2.0', '4.4.0']" >> $GITHUB_OUTPUT
     outputs:
       dafny-version-list: ${{ steps.populate-dafny-versions-list.outputs.dafny-versions-list }}
         

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Populate Dafny versions list
       id: populate-dafny-versions-list
-      run: echo "dafny-versions-list=['4.1.0', '4.3.0']" >> $GITHUB_OUTPUT
+      run: echo "dafny-versions-list=['4.2.0', '4.4.0']" >> $GITHUB_OUTPUT
     outputs:
       dafny-version-list: ${{ steps.populate-dafny-versions-list.outputs.dafny-versions-list }}
         

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -29,18 +29,6 @@ PROJECT_RELATIVE_ROOT := $(dir $(lastword $(MAKEFILE_LIST)))
 # i.e. The specific library under consideration.
 LIBRARY_ROOT = $(PWD)
 
-# Later versions of Dafny no longer default to adding "_Compile"
-# to the names of modules when translating.
-# Our target language code still assumes it does,
-# so IF the /compileSuffix option is available in our verion of Dafny
-# we need to provide it.
-COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE := $(shell dafny /help | grep -q /compileSuffix; echo $$?)
-ifeq ($(COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE), 0)
-	COMPILE_SUFFIX_OPTION := -compileSuffix:1
-else
-	COMPILE_SUFFIX_OPTION :=
-endif
-
 STANDARD_LIBRARY_PATH := $(PROJECT_ROOT)/dafny-dependencies/StandardLibrary
 CODEGEN_CLI_ROOT := $(PROJECT_ROOT)/../codegen/smithy-dafny-codegen-cli
 GRADLEW := $(PROJECT_ROOT)/../codegen/gradlew
@@ -132,7 +120,7 @@ transpile_implementation:
         -spillTargetCode:3 \
         -compile:0 \
         -optimizeErasableDatatypeWrapper:0 \
-        $(COMPILE_SUFFIX_OPTION) \
+        -compileSuffix:1 \
         -quantifierSyntax:3 \
         -unicodeChar:0 \
         -functionSyntax:3 \
@@ -173,7 +161,7 @@ transpile_test:
 		-runAllTests:1 \
 		-compile:0 \
 		-optimizeErasableDatatypeWrapper:0 \
-		$(COMPILE_SUFFIX_OPTION) \
+		-compileSuffix:1 \
 		-quantifierSyntax:3 \
 		-unicodeChar:0 \
 		-functionSyntax:3 \

--- a/TestModels/SimpleTypes/SimpleEnumV2/Makefile
+++ b/TestModels/SimpleTypes/SimpleEnumV2/Makefile
@@ -67,7 +67,7 @@ transpile_implementation_net:
 		-runAllTests:1 \
 		-compile:0 \
 		-optimizeErasableDatatypeWrapper:0 \
-		$(COMPILE_SUFFIX_OPTION) \
+		-compileSuffix:1 \
 		-useRuntimeLib \
 		-out runtimes/net/ImplementationFromDafny \
 		./src/Index.dfy \
@@ -82,7 +82,7 @@ transpile_test_net:
 		-runAllTests:1 \
 		-compile:0 \
 		-optimizeErasableDatatypeWrapper:0 \
-		$(COMPILE_SUFFIX_OPTION) \
+		-compileSuffix:1 \
 		-useRuntimeLib \
 		-out runtimes/net/tests/TestsFromDafny \
 		`find ./test -name '*.dfy'` \

--- a/TestModels/dafny-dependencies/StandardLibrary/Makefile
+++ b/TestModels/dafny-dependencies/StandardLibrary/Makefile
@@ -57,7 +57,7 @@ transpile_implementation:
 		-spillTargetCode:3 \
 		-compile:0 \
 		-optimizeErasableDatatypeWrapper:0 \
-		$(COMPILE_SUFFIX_OPTION) \
+		-compileSuffix:1 \
 		-quantifierSyntax:3 \
 		-unicodeChar:0 \
 		-functionSyntax:3 \


### PR DESCRIPTION
*Description of changes:*

Fixes the nightly build: https://github.com/smithy-lang/smithy-dafny/actions/runs/7818075629/job/21327443046

Dafny master stopped including this option in `dafny /help` since it's intended to be a hidden option, which breaks the part of the build that checks if the Dafny version supports it. But this project and all known smithy-dafny projects are all already on at least Dafny 4.2 so they can all just pass the option unconditionally now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
