### PR TITLE
feat: allow recursion

### DIFF
--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -50,7 +50,6 @@ verify:
 		-vcsCores:$(Z3_PROCESSES) \
 		-compile:0 \
 		-definiteAssignment:3 \
-		-quantifierSyntax:3 \
 		-unicodeChar:0 \
 		-functionSyntax:3 \
 		-verificationLogger:csv \
@@ -61,7 +60,6 @@ verify:
 format:
 	dafny format \
 		--function-syntax 3 \
-		--quantifier-syntax 3 \
 		--unicode-char false \
 		`find . -name '*.dfy'`
 
@@ -69,7 +67,6 @@ format-check:
 	dafny format \
 		--check \
 		--function-syntax 3 \
-		--quantifier-syntax 3 \
 		--unicode-char false \
 		`find . -name '*.dfy'`
 
@@ -121,7 +118,6 @@ transpile_implementation:
         -compile:0 \
         -optimizeErasableDatatypeWrapper:0 \
         -compileSuffix:1 \
-        -quantifierSyntax:3 \
         -unicodeChar:0 \
         -functionSyntax:3 \
         -useRuntimeLib \
@@ -162,7 +158,6 @@ transpile_test:
 		-compile:0 \
 		-optimizeErasableDatatypeWrapper:0 \
 		-compileSuffix:1 \
-		-quantifierSyntax:3 \
 		-unicodeChar:0 \
 		-functionSyntax:3 \
 		-useRuntimeLib \

--- a/TestModels/dafny-dependencies/StandardLibrary/Makefile
+++ b/TestModels/dafny-dependencies/StandardLibrary/Makefile
@@ -59,7 +59,6 @@ transpile_implementation:
 		-compile:0 \
 		-optimizeErasableDatatypeWrapper:0 \
 		-compileSuffix:1 \
-		-quantifierSyntax:3 \
 		-unicodeChar:0 \
 		-functionSyntax:3 \
 		-useRuntimeLib \

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -182,7 +182,6 @@ public class CodegenEngine {
         runCommand(outputDir,
                 "dafny", "format",
                 "--function-syntax:3",
-                "--quantifier-syntax:3",
                 "--unicode-char:false",
                 ".");
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ModelUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ModelUtils.java
@@ -310,6 +310,20 @@ public class ModelUtils {
         return outList;
     }
 
+
+    // return a summary of a list, just the first and last elements.
+    public static List<ShapeId> GetSummary(List<ShapeId> list)
+    {
+	if (list.size() <= 2) {
+	    return list;
+	} else {
+	    List<ShapeId> result = new ArrayList<>();
+	    result.add(list.get(0));
+	    result.add(list.get(list.size()-1));
+	    return result;
+	}
+    }
+    
     /**
      * For every ShapeId in {@code initialShapes},
      * with the given {@code model},
@@ -326,12 +340,16 @@ public class ModelUtils {
             .map(Collections::singletonList)
             .collect(Collectors.toSet());
         Set<List<ShapeId>> pathsToShapes = new LinkedHashSet<>(new LinkedHashSet<>());
+        Set<List<ShapeId>> pathsSummary = new LinkedHashSet<>(new LinkedHashSet<>());
 
         // Breadth-first search via getDependencyShapeIds
         final Queue<List<ShapeId>> toTraverse = new LinkedList<>(initialShapeIdsAsPaths);
         while (!toTraverse.isEmpty()) {
             final List<ShapeId> currentShapeIdWithPath = toTraverse.remove();
-            if (pathsToShapes.add(currentShapeIdWithPath)) {
+
+	    // to avoid cycles, only keep the first list with a given first and last element
+	    List<ShapeId> summary = GetSummary(currentShapeIdWithPath);
+            if (pathsSummary.add(summary) && pathsToShapes.add(currentShapeIdWithPath)) {
                 final Shape currentShape = model.expectShape(currentShapeIdWithPath.get(
                     currentShapeIdWithPath.size()-1));
                 final List<List<ShapeId>> dependencyShapeIdsWithPaths = getDependencyShapeIds(currentShape).map(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ModelUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ModelUtils.java
@@ -311,19 +311,6 @@ public class ModelUtils {
     }
 
 
-    // return a summary of a list, just the first and last elements.
-    public static List<ShapeId> GetSummary(List<ShapeId> list)
-    {
-	if (list.size() <= 2) {
-	    return list;
-	} else {
-	    List<ShapeId> result = new ArrayList<>();
-	    result.add(list.get(0));
-	    result.add(list.get(list.size()-1));
-	    return result;
-	}
-    }
-    
     /**
      * For every ShapeId in {@code initialShapes},
      * with the given {@code model},
@@ -340,16 +327,16 @@ public class ModelUtils {
             .map(Collections::singletonList)
             .collect(Collectors.toSet());
         Set<List<ShapeId>> pathsToShapes = new LinkedHashSet<>(new LinkedHashSet<>());
-        Set<List<ShapeId>> pathsSummary = new LinkedHashSet<>(new LinkedHashSet<>());
+        Set<ShapeId> visited = new HashSet<>();
 
         // Breadth-first search via getDependencyShapeIds
         final Queue<List<ShapeId>> toTraverse = new LinkedList<>(initialShapeIdsAsPaths);
         while (!toTraverse.isEmpty()) {
             final List<ShapeId> currentShapeIdWithPath = toTraverse.remove();
 
-	    // to avoid cycles, only keep the first list with a given first and last element
-	    List<ShapeId> summary = GetSummary(currentShapeIdWithPath);
-            if (pathsSummary.add(summary) && pathsToShapes.add(currentShapeIdWithPath)) {
+            // to avoid cycles, only keep the first list with a given last element
+            ShapeId last = currentShapeIdWithPath.get(currentShapeIdWithPath.size()-1);
+            if (visited.add(last) && pathsToShapes.add(currentShapeIdWithPath)) {
                 final Shape currentShape = model.expectShape(currentShapeIdWithPath.get(
                     currentShapeIdWithPath.size()-1));
                 final List<List<ShapeId>> dependencyShapeIdsWithPaths = getDependencyShapeIds(currentShape).map(


### PR DESCRIPTION
*Description of changes:*

Given a perfectly legal recursive smithy model, smithy-java can find itself in an infinite loop.
Prune DependentShapesWithPaths to avoid this.

Also remove --quatifier-syntax:3, because that blocked me on this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
