### PR TITLE
feat: --patch-files-dir option

### DIFF
--- a/TestModels/CodegenPatches/README.md
+++ b/TestModels/CodegenPatches/README.md
@@ -16,7 +16,7 @@ The easiest way to create these patches is the following workflow
 2. Apply the necessary manual edits (preferrably with marker comments to make them stand out better).
 3. Commit the generated code to git.
 4. Regenerate the code, passing the `--update-patch-files` option to the polymorph CLI.
-   With this repository's `SharedMakefile.mk`, you can define `UPDATE_PATCH_FILES_OPTION="--update-patch-files"`.
+   With this repository's `SharedMakefile.mk`, you can define `POLYMORPH_OPTIONS="--update-patch-files"`.
    This will extract the necessary patch to modify the generated code to match what's checked in.
 
 ## Build

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -195,7 +195,7 @@ _polymorph:
 	$(GRADLEW) run --args="\
 	$(DAFNY_VERSION_OPTION) \
 	--library-root $(LIBRARY_ROOT) \
-	$(UPDATE_PATCH_FILES_OPTION) \
+	--patch-files-dir $(if $(DIR_STRUCTURE_V2),$(LIBRARY_ROOT)/codegen-patches/$(SERVICE),$(LIBRARY_ROOT)/codegen-patches) \
 	--properties-file $(LIBRARY_ROOT)/project.properties \
 	$(OUTPUT_DAFNY) \
 	$(OUTPUT_DOTNET) \
@@ -204,7 +204,8 @@ _polymorph:
 	--dependent-model $(PROJECT_ROOT)/$(SMITHY_DEPS) \
 	$(patsubst %, --dependent-model $(PROJECT_ROOT)/%/Model, $($(service_deps_var))) \
 	--namespace $($(namespace_var)) \
-	$(AWS_SDK_CMD)";
+	$(AWS_SDK_CMD) \
+	$(POLYMORPH_OPTIONS)";
 
 _polymorph_wrapped:
 	@: $(if ${CODEGEN_CLI_ROOT},,$(error You must pass the path CODEGEN_CLI_ROOT: CODEGEN_CLI_ROOT=/path/to/smithy-dafny/codegen/smithy-dafny-codegen-cli));
@@ -221,7 +222,8 @@ _polymorph_wrapped:
 	$(patsubst %, --dependent-model $(PROJECT_ROOT)/%/Model, $($(service_deps_var))) \
 	--namespace $($(namespace_var)) \
 	$(OUTPUT_LOCAL_SERVICE) \
-	$(AWS_SDK_CMD)";
+	$(AWS_SDK_CMD) \
+	$(POLYMORPH_OPTIONS)";
 
 _polymorph_dependencies:
 	@$(foreach dependency, \

--- a/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
+++ b/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
@@ -83,6 +83,7 @@ public class CodegenCli {
         cliArguments.propertiesFile.ifPresent(engineBuilder::withPropertiesFile);
         cliArguments.javaAwsSdkVersion.ifPresent(engineBuilder::withJavaAwsSdkVersion);
         cliArguments.includeDafnyFile.ifPresent(engineBuilder::withIncludeDafnyFile);
+        cliArguments.patchFilesDir.ifPresent(engineBuilder::withPatchFilesDir);
         final CodegenEngine engine = engineBuilder.build();
         engine.run();
     }
@@ -162,8 +163,13 @@ public class CodegenCli {
             .hasArg()
             .build())
           .addOption(Option.builder()
+            .longOpt("patch-files-dir")
+            .desc("<optional> location of patch files. Defaults to <library-root>/codegen-patches")
+            .hasArg()
+            .build())
+          .addOption(Option.builder()
             .longOpt("update-patch-files")
-            .desc("<optional> update patch files in <library-root>/codegen-patches instead of applying them")
+            .desc("<optional> update patch files in <patch-files-dir> instead of applying them")
             .build());
     }
 
@@ -185,6 +191,7 @@ public class CodegenCli {
             Optional<Path> includeDafnyFile,
             boolean awsSdkStyle,
             boolean localServiceTest,
+            Optional<Path> patchFilesDir,
             boolean updatePatchFiles
     ) {
         /**
@@ -259,13 +266,15 @@ public class CodegenCli {
                 includeDafnyFile = Optional.of(Paths.get(commandLine.getOptionValue("include-dafny")));
             }
 
+            Optional<Path> patchFilesDir = Optional.ofNullable(commandLine.getOptionValue("patch-files-dir"))
+                    .map(Paths::get);
             final boolean updatePatchFiles = commandLine.hasOption("update-patch-files");
 
             return Optional.of(new CliArguments(
                     libraryRoot, modelPath, dependentModelPaths, namespace,
                     outputDotnetDir, outputJavaDir, outputDafnyDir,
                     javaAwsSdkVersion, dafnyVersion, propertiesFile, includeDafnyFile, awsSdkStyle,
-                    localServiceTest, updatePatchFiles
+                    localServiceTest, patchFilesDir, updatePatchFiles
             ));
         }
     }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -189,9 +189,7 @@ public class CodegenEngine {
                 "--unicode-char:false",
                 ".");
 
-        if (!this.localServiceTest) {
-            handlePatching(TargetLanguage.DAFNY, outputDir);
-        }
+        handlePatching(TargetLanguage.DAFNY, outputDir);
     }
 
     private void generateJava(final Path outputDir) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -530,8 +530,7 @@ public class CodegenEngine {
         }
 
         /**
-         * If true, updates the relevant patch files in (library-root)/codegen-patches
-         * to change the generated code into the state of the code before generation.
+         * The location of patch files. Defaults to (library-root)/codegen-patches.
          */
         public Builder withPatchFilesDir(final Path patchFilesDir) {
             this.patchFilesDir = patchFilesDir;

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -335,7 +335,7 @@ public class CodegenEngine {
     }
 
     private void handlePatching(TargetLanguage targetLanguage, Path outputDir) {
-        if (!patchFilesDir.isPresent()) {
+        if (patchFilesDir.isEmpty()) {
             return;
         }
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -534,7 +534,7 @@ public class CodegenEngine {
          * to change the generated code into the state of the code before generation.
          */
         public Builder withPatchFilesDir(final Path patchFilesDir) {
-            this.updatePatchFiles = updatePatchFiles;
+            this.patchFilesDir = patchFilesDir;
             return this;
         }
 


### PR DESCRIPTION
*Description of changes:*

Adding this in order to support patches in multi-model libraries. Otherwise, you can end up with a patch file that spans multiple services, and the shared makefile workflow will do the code generation for one at a time, but attempt to apply the patch across all services each time. This can lead to "patch does not apply" errors because the single patch file can only  be successfully applied after code generating ALL services.

The solution is to have separate patch files directories per service. The SharedMakefile now passes `--patch-files-dir codegen-patches/<service>` for libraries with `DIR_STRUCTURE_V2` set.

Patch files are now only applied if this option is given, rather than defaulting to `<library-root>/codegen-patches`. Previously patches were not applied if `--local-service-test` was passed, but this is a more flexible solution that gives the build process more control.

Also replaced the `UPDATE_PATCH_FILES_OPTION` Makefile environment variable with the more general `POLYMORPH_OPTIONS`, which we can use for other future options as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
