### PR TITLE
fix: generated Modifies clauses for operations involving unions not valid Dafny

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
@@ -1770,7 +1770,7 @@ public class DafnyApiCodegen {
                         //   a condition on the existing comprehension, starting with `&&`
                         // e.g. `&& fooUnion.barUnionMember? ...`
                         modifiesClause = modifiesClause.append(TokenTree.of(
-                            "| %1$s? \n ".formatted(accessPathToCurrentShape)
+                            "&& %1$s? \n ".formatted(accessPathToCurrentShape)
                         ));
                     } else {
                         // If not using set comprehension, the destructor on a union member is added as


### PR DESCRIPTION
*Description of changes:*

Fixing an obvious typo based on the comment immediately above. Confirmed fix on @ajewellamz's branch. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
