### PR TITLE
feat: Provide reusable SmithyDafnyMakefile.mk

### DIFF
--- a/.github/workflows/test_models_net_tests.yml
+++ b/.github/workflows/test_models_net_tests.yml
@@ -112,7 +112,7 @@ jobs:
         working-directory: ./${{ matrix.library }}
         run: |
           make polymorph_dafny DAFNY_VERSION_OPTION="--dafny-version $DAFNY_VERSION"
-          make polymorph_net DAFNY_VERSION_OPTION="--dafny-version $DAFNY_VERSION"
+          make polymorph_dotnet DAFNY_VERSION_OPTION="--dafny-version $DAFNY_VERSION"
 
       - name: Compile ${{ matrix.library }} implementation
         shell: bash

--- a/SharedMakefile.mk
+++ b/SharedMakefile.mk
@@ -1,37 +1,62 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# These make targets that are shared
-# between all the Dafny projects
-# in this repo.
+# These are make targets that can be shared between all projects
+# that use a common layout.
 # They will only function if executed inside a project directory.
+# See https://github.com/smithy-lang/smithy-dafny/tree/main-1.x/TestModels
+# for examples.
 
-# There are serveral variables that are used here.
+# There are several variables that are used here.
 # The expectation is to define these variables
 # inside each project.
 
 # Variables:
 # MAX_RESOURCE_COUNT -- The Dafny report generator max resource count.
 # 	This is is per project because the verification variability can differ.
-# LIBRARIES -- List of dependencies for the project.
-# 	It should be the list of top leve directory names
-# SMITHY_NAMESPACE -- The smithy namespace to use for code generation. 
-# AWS_SDK_CMD -- the `--aws-sdk` command to generate AWS SDK style interfaces
+# PROJECT_DEPENDENCIES -- List of dependencies for the project.
+# 	It should be the list of top level directory names
+# PROJECT_SERVICES -- List of names of each local service in the project
+# SERVICE_NAMESPACE_<service> -- for each service in PROJECT_SERVICES,
+#   the list of dependencies for that smithy namespace. It should be a list
+#   of Model directories
+# SERVICE_DEPS_<service> -- for each service in PROJECT_SERVICES,
+#   the list of dependencies for that smithy namespace. It should be a list
+#   of Model directories
+# AWS_SDK_CMD -- the `--aws-sdk` command to generate AWS SDK style interfaces.
+# STD_LIBRARY -- path from this file to the StandardLibrary Dafny project.
+# SMITHY_DEPS -- path from this file to smithy dependencies, such as custom traits.
 
 # This evaluates to the local path _of this file_.
 # This means that these are the project roots
 # that are shared by all libraries in this repo.
 PROJECT_ROOT := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
-# This relative path is for include files between libraries.
-# If an absolut path is used, this path will not be portable.
-PROJECT_RELATIVE_ROOT := $(dir $(lastword $(MAKEFILE_LIST)))
 # This evaluates to the path of the current working directory.
 # i.e. The specific library under consideration.
-LIBRARY_ROOT = $(PWD)
+LIBRARY_ROOT := $(PWD)
+# Smithy Dafny code gen needs to know
+# where the smithy model is.
+# This is generally in the same directory as the library.
+# However in the case of a wrapped library,
+# such as the test vectors
+# the implementation MAY be in a different library
+# than the model.
+# By having two related variables
+# test vector projects can point to
+# the specific model they need
+# but still build everything in their local library directory.
+SMITHY_MODEL_ROOT := $(LIBRARY_ROOT)/Model
 
-STANDARD_LIBRARY_PATH := $(PROJECT_ROOT)/dafny-dependencies/StandardLibrary
+# TODO: Move to smithy-dafny shared makefile
+STD_LIBRARY := $(PROJECT_ROOT)/dafny-dependencies/StandardLibrary
+# TODO: Move to smithy-dafny shared makefile
 CODEGEN_CLI_ROOT := $(PROJECT_ROOT)/../codegen/smithy-dafny-codegen-cli
+# TODO: Move to smithy-dafny shared makefile OR use runtimes/java/gradlew as appropriate
 GRADLEW := $(PROJECT_ROOT)/../codegen/gradlew
+# TODO: Move to smithy-dafny shared makefile
+# The path to the smithy-dafny code generation CLI.
+# Defaults to the copy in the smithy-dafny submodule but can be overridden.
+CODEGEN_CLI_ROOT := $(PROJECT_ROOT)/smithy-dafny/codegen/smithy-dafny-codegen-cli
 
 ########################## Dafny targets
 
@@ -41,6 +66,18 @@ GRADLEW := $(PROJECT_ROOT)/../codegen/gradlew
 # Error: modules 'A' and 'B' both have CompileName 'same.extern.name'
 # We need to come up with some way to verify files per-language.
 # Rewrite this as part of Java implementation of LanguageSpecificLogic TestModel.
+
+# Proof of correctness for the math below
+#  function Z3_PROCESSES(cpus:nat): nat
+#  { if cpus >= 3 then 2 else 1 }
+
+#  function DAFNY_PROCESSES(cpus: nat): nat
+#   requires 0 < cpus // 0 cpus would do no work!
+#  { (cpus - 1 )/Z3_PROCESSES(cpus) }
+
+#  lemma Correct(cpus:nat)
+#    ensures DAFNY_PROCESSES(cpus) * Z3_PROCESSES(cpus) <= cpus
+#  {}
 
 # Verify the entire project
 verify:Z3_PROCESSES=$(shell echo $$(( $(CORES) >= 3 ? 2 : 1 )))
@@ -53,11 +90,41 @@ verify:
 		-unicodeChar:0 \
 		-functionSyntax:3 \
 		-verificationLogger:csv \
-		-timeLimit:300 \
+		-timeLimit:100 \
 		-trace \
 		%
 
-format:
+# Verify single file FILE with text logger.
+# This is useful for debugging resource count usage within a file.
+# Use PROC to further scope the verification
+verify_single:
+	dafny \
+		-vcsCores:$(CORES) \
+		-compile:0 \
+		-definiteAssignment:3 \
+		-unicodeChar:0 \
+		-functionSyntax:3 \
+		-verificationLogger:text \
+		-timeLimit:100 \
+		-trace \
+		$(if ${PROC},-proc:*$(PROC)*,) \
+		$(FILE)
+
+#Verify only a specific namespace at env var $(SERVICE)
+verify_service:
+	@: $(if ${SERVICE},,$(error You must pass the SERVICE to generate for));
+	dafny \
+		-vcsCores:$(CORES) \
+		-compile:0 \
+		-definiteAssignment:3 \
+		-unicodeChar:0 \
+		-functionSyntax:3 \
+		-verificationLogger:csv \
+		-timeLimit:100 \
+		-trace \
+		`find ./dafny/$(SERVICE) -name '*.dfy'` \
+
+format_dafny:
 	dafny format \
 		--function-syntax 3 \
 		--unicode-char false \
@@ -76,6 +143,9 @@ dafny-reportgenerator:
 		--max-resource-count 10000000 \
 		TestResults/*.csv
 
+clean-dafny-report:
+	rm TestResults/*.csv
+
 # Dafny helper targets
 
 # Transpile the entire project's impl
@@ -85,7 +155,7 @@ _transpile_implementation_all: TRANSPILE_DEPENDENCIES=$(patsubst %, -library:$(P
 _transpile_implementation_all: transpile_implementation
 
 # The `$(OUT)` and $(TARGET) variables are problematic.
-# Idealy they are different for every target call.
+# Ideally they are different for every target call.
 # However the way make evaluates variables
 # having a target specific variable is hard.
 # This all comes up because a project
@@ -93,7 +163,7 @@ _transpile_implementation_all: transpile_implementation
 # This is worked around for now,
 # by the fact that the `TARGET`
 # for all these transpile calls will be the same.
-# For `OUT` this is solved by makeing the paths realative.
+# For `OUT` this is solved by making the paths relative.
 # So that the runtime is express once
 # and can be the same for all such runtimes.
 # Since such targets are all shared,
@@ -166,7 +236,7 @@ transpile_test:
 		$(TRANSPILE_DEPENDENCIES) \
 
 transpile_dependencies:
-	$(MAKE) -C $(STANDARD_LIBRARY_PATH) transpile_implementation_$(LANG)
+	$(MAKE) -C $(STD_LIBRARY) transpile_implementation_$(LANG)
 	@$(foreach dependency, \
 		$(PROJECT_DEPENDENCIES), \
 		$(MAKE) -C $(PROJECT_ROOT)/$(dependency) transpile_implementation_$(LANG); \
@@ -188,14 +258,16 @@ _polymorph:
 	@: $(if ${CODEGEN_CLI_ROOT},,$(error You must pass the path CODEGEN_CLI_ROOT: CODEGEN_CLI_ROOT=/path/to/smithy-dafny/codegen/smithy-dafny-codegen-cli));
 	cd $(CODEGEN_CLI_ROOT); \
 	$(GRADLEW) run --args="\
-	$(DAFNY_VERSION_OPTION) \
+	--dafny-version $(DAFNY_VERSION) \
 	--library-root $(LIBRARY_ROOT) \
 	--patch-files-dir $(if $(DIR_STRUCTURE_V2),$(LIBRARY_ROOT)/codegen-patches/$(SERVICE),$(LIBRARY_ROOT)/codegen-patches) \
-	--properties-file $(LIBRARY_ROOT)/project.properties \
+	--properties-file $(LIBRARY_ROOT)/project.properties \	
+	$(INPUT_DAFNY) \
 	$(OUTPUT_DAFNY) \
+	$(OUTPUT_JAVA) \
 	$(OUTPUT_DOTNET) \
 	$(OUTPUT_JAVA) \
-	--model $(if $(DIR_STRUCTURE_V2),$(LIBRARY_ROOT)/dafny/$(SERVICE)/Model,$(LIBRARY_ROOT)/Model) \
+	--model $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(SMITHY_MODEL_ROOT)) \
 	--dependent-model $(PROJECT_ROOT)/$(SMITHY_DEPS) \
 	$(patsubst %, --dependent-model $(PROJECT_ROOT)/%/Model, $($(service_deps_var))) \
 	--namespace $($(namespace_var)) \
@@ -228,6 +300,8 @@ _polymorph_dependencies:
 
 # Generates all target runtime code for all namespaces in this project.
 .PHONY: polymorph_code_gen
+polymorph_code_gen: POLYMORPH_LANGUAGE_TARGET=code_gen
+polymorph_code_gen: _polymorph_dependencies
 polymorph_code_gen:
 	set -e; for service in $(PROJECT_SERVICES) ; do \
 		export service_deps_var=SERVICE_DEPS_$${service} ; \
@@ -237,26 +311,31 @@ polymorph_code_gen:
 	done
 
 _polymorph_code_gen: OUTPUT_DAFNY=\
-    --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model) \
-	--include-dafny $(STANDARD_LIBRARY_PATH)/src/Index.dfy
+    --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model)
+_polymorph_code_gen: INPUT_DAFNY=\
+		--include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
 _polymorph_code_gen: OUTPUT_DOTNET=\
     $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/)
 _polymorph_code_gen: OUTPUT_JAVA=--output-java $(LIBRARY_ROOT)/runtimes/java/src/main/smithy-generated
 _polymorph_code_gen: _polymorph
 _polymorph_code_gen: OUTPUT_DAFNY_WRAPPED=\
     --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model) \
-	--include-dafny $(STANDARD_LIBRARY_PATH)/src/Index.dfy
+	--include-dafny $(STD_LIBRARY)/src/Index.dfy
 _polymorph_code_gen: OUTPUT_DOTNET_WRAPPED=\
     $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped)
 _polymorph_code_gen: OUTPUT_LOCAL_SERVICE=--local-service-test
 _polymorph_code_gen: _polymorph_wrapped
-_polymorph_code_gen: POLYMORPH_LANGUAGE_TARGET=code_gen
-_polymorph_code_gen: _polymorph_dependencies
+
+
+check_polymorph_diff:
+	git diff --exit-code $(LIBRARY_ROOT) || (echo "ERROR: polymorph-generated code does not match the committed code - see above for diff. Either commit the changes or regenerate with 'POLYMORPH_OPTIONS=--update-patch-files'." && exit 1)
 
 # Generates dafny code for all namespaces in this project
 .PHONY: polymorph_dafny
+polymorph_dafny: POLYMORPH_LANGUAGE_TARGET=dafny
+polymorph_dafny: _polymorph_dependencies
 polymorph_dafny:
-	$(MAKE) -C $(STANDARD_LIBRARY_PATH) polymorph_dafny
+	$(MAKE) -C $(STD_LIBRARY) polymorph_dafny
 	set -e; for service in $(PROJECT_SERVICES) ; do \
 		export service_deps_var=SERVICE_DEPS_$${service} ; \
 		export namespace_var=SERVICE_NAMESPACE_$${service} ; \
@@ -264,40 +343,41 @@ polymorph_dafny:
 		$(MAKE) _polymorph_dafny ; \
 	done
 
-_polymorph_dafny: POLYMORPH_LANGUAGE_TARGET=dafny
-_polymorph_dafny: _polymorph_dependencies
 _polymorph_dafny: OUTPUT_DAFNY=\
-    --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model) \
-	--include-dafny $(STANDARD_LIBRARY_PATH)/src/Index.dfy
+    --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model)
+_polymorph_dafny: INPUT_DAFNY=\
+		 --include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
 _polymorph_dafny: _polymorph
 _polymorph_dafny: OUTPUT_DAFNY_WRAPPED=\
     --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model) \
-    --include-dafny $(STANDARD_LIBRARY_PATH)/src/Index.dfy
+    --include-dafny $(STD_LIBRARY)/src/Index.dfy
 _polymorph_dafny: OUTPUT_LOCAL_SERVICE=--local-service-test
 _polymorph_dafny: _polymorph_wrapped
 
 # Generates dotnet code for all namespaces in this project
-.PHONY: polymorph_net
-polymorph_net:
+.PHONY: polymorph_dotnet
+polymorph_dotnet: POLYMORPH_LANGUAGE_TARGET=dotnet
+polymorph_dotnet: _polymorph_dependencies
+polymorph_dotnet:
 	set -e; for service in $(PROJECT_SERVICES) ; do \
 		export service_deps_var=SERVICE_DEPS_$${service} ; \
 		export namespace_var=SERVICE_NAMESPACE_$${service} ; \
 		export SERVICE=$${service} ; \
-		$(MAKE) _polymorph_net ; \
+		$(MAKE) _polymorph_dotnet ; \
 	done
 
-_polymorph_net: OUTPUT_DOTNET=\
+_polymorph_dotnet: OUTPUT_DOTNET=\
     $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/)
-_polymorph_net: _polymorph
-_polymorph_net: OUTPUT_DOTNET_WRAPPED=\
+_polymorph_dotnet: _polymorph
+_polymorph_dotnet: OUTPUT_DOTNET_WRAPPED=\
     $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped)
-_polymorph_net: OUTPUT_LOCAL_SERVICE=--local-service-test
-_polymorph_net: _polymorph_wrapped
-_polymorph_net: POLYMORPH_LANGUAGE_TARGET=net
-_polymorph_net: _polymorph_dependencies
+_polymorph_dotnet: OUTPUT_LOCAL_SERVICE=--local-service-test
+_polymorph_dotnet: _polymorph_wrapped
 
 # Generates java code for all namespaces in this project
 .PHONY: polymorph_java
+polymorph_java: POLYMORPH_LANGUAGE_TARGET=java
+polymorph_java: _polymorph_dependencies
 polymorph_java:
 	set -e; for service in $(PROJECT_SERVICES) ; do \
 		export service_deps_var=SERVICE_DEPS_$${service} ; \
@@ -311,12 +391,10 @@ _polymorph_java: _polymorph
 _polymorph_java: OUTPUT_JAVA_WRAPPED=--output-java $(LIBRARY_ROOT)/runtimes/java/src/main/smithy-generated
 _polymorph_java: OUTPUT_LOCAL_SERVICE=--local-service-test
 _polymorph_java: _polymorph_wrapped
-_polymorph_java: POLYMORPH_LANGUAGE_TARGET=java
-_polymorph_java: _polymorph_dependencies
 
 # Dependency for formatting generating Java code
 setup_prettier:
-	npm i --no-save prettier prettier-plugin-java
+	npm i --no-save prettier@3 prettier-plugin-java@2.5
 
 ########################## .NET targets
 
@@ -336,23 +414,32 @@ transpile_test_net: _transpile_test_all
 transpile_dependencies_net: LANG=net
 transpile_dependencies_net: transpile_dependencies
 
+test_net_mac_brew: FRAMEWORK=net6.0
 test_net:
 	dotnet run \
 		--project runtimes/net/tests/ \
-		--framework net6.0
+		--framework $(FRAMEWORK)
 
+test_net_mac_brew: FRAMEWORK=net6.0
 test_net_mac_intel:
 	DYLD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib" dotnet run \
 		--project runtimes/net/tests/ \
-		--framework net6.0
+		--framework $(FRAMEWORK)
 
+test_net_mac_brew: FRAMEWORK=net6.0
 test_net_mac_brew:
-	DYLD_LIBRARY_PATH="$(brew --prefix)/opt/openssl@1.1/lib" dotnet run \
+	DYLD_LIBRARY_PATH="$(shell brew --prefix)/opt/openssl@1.1/lib/" dotnet run \
 		--project runtimes/net/tests/ \
-		--framework net6.0
+		--framework $(FRAMEWORK)
 
 setup_net:
 	dotnet restore runtimes/net/
+
+format_net:
+	dotnet format runtimes/net/*.csproj
+
+format_net-check:
+	dotnet format runtimes/net/*.csproj --verify-no-changes
 
 ########################## Java targets
 
@@ -384,8 +471,8 @@ transpile_dependencies_java: LANG=java
 transpile_dependencies_java: transpile_dependencies
 
 mvn_local_deploy_dependencies:
-	$(MAKE) -C $(STANDARD_LIBRARY_PATH) mvn_local_deploy
-	$(patsubst %, $(MAKE) -C $(PROJECT_ROOT)/% mvn_local_deploy;, $(LIBRARIES))
+	$(MAKE) -C $(STD_LIBRARY) mvn_local_deploy
+	$(patsubst %, $(MAKE) -C $(PROJECT_ROOT)/% mvn_local_deploy;, $(PROJECT_DEPENDENCIES))
 
 # The Java MUST all exist already through the transpile step.
 mvn_local_deploy:
@@ -403,3 +490,55 @@ _clean:
 	rm -rf $(LIBRARY_ROOT)/runtimes/net/tests/bin $(LIBRARY_ROOT)/runtimes/net/tests/obj
 
 clean: _clean
+
+########################## local testing targets
+
+# These targets are added as a convenience for local development.
+# If you experience weird behavior using these targets,
+# fall back to the regular `build` or `test` targets.
+# These targets MUST only be used for local testing,
+# and MUST NOT be used in CI.
+
+# Targets to transpile single local service for convenience.
+# Specify the local service to build by passing a SERVICE env var.
+# Note that this does not generate identical files as `transpile_implementation_java`
+
+local_transpile_impl_java_single: TARGET=java
+local_transpile_impl_java_single: OUT=runtimes/java/ImplementationFromDafny
+local_transpile_impl_java_single: local_transpile_impl_single
+	cp -R runtimes/java/ImplementationFromDafny-java/* runtimes/java/src/main/dafny-generated
+	rm -rf runtimes/java/ImplementationFromDafny-java/
+
+local_transpile_impl_net_single: TARGET=cs
+local_transpile_impl_net_single: OUT=runtimes/net/ImplementationFromDafny
+local_transpile_impl_net_single: local_transpile_impl_single
+
+local_transpile_impl_single: deps_var=SERVICE_DEPS_$(SERVICE)
+local_transpile_impl_single: TRANSPILE_TARGETS=./dafny/$(SERVICE)/src/$(FILE)
+local_transpile_impl_single: TRANSPILE_DEPENDENCIES= \
+		$(patsubst %, -library:$(PROJECT_ROOT)/%/src/Index.dfy, $($(deps_var))) \
+		$(patsubst %, -library:$(PROJECT_ROOT)/%, $(PROJECT_INDEX)) \
+		-library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
+local_transpile_impl_single: transpile_implementation
+
+# Targets to transpile single local service for convenience.
+# Specify the local service to build by passing a SERVICE env var.
+# Note that this does not generate identical files as `transpile_test_java`,
+# and will clobber tests generated by other services.
+
+local_transpile_test_java_single: TARGET=java
+local_transpile_test_java_single: OUT=runtimes/java/TestsFromDafny
+local_transpile_test_java_single: local_transpile_test_single
+	cp -R runtimes/java/TestsFromDafny-java/* runtimes/java/src/test/dafny-generated
+	rm -rf runtimes/java/TestsFromDafny-java
+
+local_transpile_test_net_single: TARGET=cs
+local_transpile_test_net_single: OUT=runtimes/net/tests/TestsFromDafny
+local_transpile_test_net_single: local_transpile_test_single
+
+local_transpile_test_single: TRANSPILE_TARGETS=./dafny/$(SERVICE)/test/$(FILE)
+local_transpile_test_single: TRANSPILE_DEPENDENCIES= \
+		$(patsubst %, -library:dafny/%/src/Index.dfy, $(PROJECT_SERVICES)) \
+		$(patsubst %, -library:$(PROJECT_ROOT)/%, $(PROJECT_INDEX)) \
+		-library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
+local_transpile_test_single: transpile_test

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -225,12 +225,11 @@ transpile_test:
 		-library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy \
 		$(TRANSPILE_DEPENDENCIES) \
 
+# If we are not the StandardLibrary, transpile the StandardLibrary.
+# Transpile all other dependencies
 transpile_dependencies:
-	$(MAKE) -C $(PROJECT_ROOT)/$(STD_LIBRARY) transpile_implementation_$(LANG)
-	@$(foreach dependency, \
-		$(PROJECT_DEPENDENCIES), \
-		$(MAKE) -C $(PROJECT_ROOT)/$(dependency) transpile_implementation_$(LANG); \
-	)
+	$(if $(strip $(STD_LIBRARY)), $(MAKE) -C $(PROJECT_ROOT)/$(STD_LIBRARY) transpile_implementation_$(LANG), )
+	$(patsubst %, $(MAKE) -C $(PROJECT_ROOT)/% transpile_implementation_$(LANG);, $(PROJECT_DEPENDENCIES))
 
 ########################## Code-Gen targets
 

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -439,8 +439,10 @@ _mv_test_java:
 transpile_dependencies_java: LANG=java
 transpile_dependencies_java: transpile_dependencies
 
+# If we are not StandardLibrary, locally deploy the StandardLibrary.
+# Locally deploy all other dependencies 
 mvn_local_deploy_dependencies:
-	$(MAKE) -C $(PROJECT_ROOT)/$(STD_LIBRARY) mvn_local_deploy
+	$(if $(strip $(STD_LIBRARY)), $(MAKE) -C $(PROJECT_ROOT)/$(STD_LIBRARY) mvn_local_deploy, )
 	$(patsubst %, $(MAKE) -C $(PROJECT_ROOT)/% mvn_local_deploy;, $(PROJECT_DEPENDENCIES))
 
 # The Java MUST all exist already through the transpile step.

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -250,13 +250,12 @@ transpile_dependencies:
 # StandardLibrary is filtered out from dependent-model patsubst list;
 #   Its model is contained in $(LIBRARY_ROOT)/model, not $(LIBRARY_ROOT)/../StandardLibrary/Model.
 _polymorph:
-	@: $(if ${CODEGEN_CLI_ROOT},,$(error You must pass the path CODEGEN_CLI_ROOT: CODEGEN_CLI_ROOT=/path/to/smithy-dafny/codegen/smithy-dafny-codegen-cli));
 	cd $(CODEGEN_CLI_ROOT); \
 	$(GRADLEW) run --args="\
 	--dafny-version $(DAFNY_VERSION) \
 	--library-root $(LIBRARY_ROOT) \
 	--patch-files-dir $(if $(DIR_STRUCTURE_V2),$(LIBRARY_ROOT)/codegen-patches/$(SERVICE),$(LIBRARY_ROOT)/codegen-patches) \
-	--properties-file $(LIBRARY_ROOT)/project.properties \	
+	--properties-file $(LIBRARY_ROOT)/project.properties \
 	$(INPUT_DAFNY) \
 	$(OUTPUT_DAFNY) \
 	$(OUTPUT_JAVA) \
@@ -267,13 +266,14 @@ _polymorph:
 	$(patsubst %, --dependent-model $(PROJECT_ROOT)/%/Model, $($(service_deps_var))) \
 	--namespace $($(namespace_var)) \
 	$(AWS_SDK_CMD) \
-	$(POLYMORPH_OPTIONS)";
+	$(POLYMORPH_OPTIONS) \
+	";
 
 _polymorph_wrapped:
 	@: $(if ${CODEGEN_CLI_ROOT},,$(error You must pass the path CODEGEN_CLI_ROOT: CODEGEN_CLI_ROOT=/path/to/smithy-dafny/codegen/smithy-dafny-codegen-cli));
 	cd $(CODEGEN_CLI_ROOT); \
 	$(GRADLEW) run --args="\
-	$(DAFNY_VERSION_OPTION) \
+	--dafny-version $(DAFNY_VERSION) \
 	--library-root $(LIBRARY_ROOT) \
 	--properties-file $(LIBRARY_ROOT)/project.properties \
 	$(OUTPUT_DAFNY_WRAPPED) \
@@ -339,9 +339,9 @@ polymorph_dafny:
 	done
 
 _polymorph_dafny: OUTPUT_DAFNY=\
-    --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model)
+		--output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model)
 _polymorph_dafny: INPUT_DAFNY=\
-		 --include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
+		--include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
 _polymorph_dafny: _polymorph
 _polymorph_dafny: OUTPUT_DAFNY_WRAPPED=\
     --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model) \

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -259,7 +259,7 @@ _polymorph:
 	--dependent-model $(PROJECT_ROOT)/$(SMITHY_DEPS) \
 	$(patsubst %, --dependent-model $(PROJECT_ROOT)/%/Model, $($(service_deps_var))) \
 	--namespace $($(namespace_var)) \
-	$(OUTPUT_LOCAL_SERVICE) \
+	$(OUTPUT_LOCAL_SERVICE_$(SERVICE)) \
 	$(AWS_SDK_CMD) \
 	$(POLYMORPH_OPTIONS) \
 	";

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -260,6 +260,7 @@ _polymorph:
 	--dependent-model $(PROJECT_ROOT)/$(SMITHY_DEPS) \
 	$(patsubst %, --dependent-model $(PROJECT_ROOT)/%/Model, $($(service_deps_var))) \
 	--namespace $($(namespace_var)) \
+	$(OUTPUT_LOCAL_SERVICE) \
 	$(AWS_SDK_CMD) \
 	$(POLYMORPH_OPTIONS) \
 	";
@@ -278,7 +279,7 @@ _polymorph_wrapped:
 	--dependent-model $(PROJECT_ROOT)/$(SMITHY_DEPS) \
 	$(patsubst %, --dependent-model $(PROJECT_ROOT)/%/Model, $($(service_deps_var))) \
 	--namespace $($(namespace_var)) \
-	$(OUTPUT_LOCAL_SERVICE) \
+	--local-service-test \
 	$(AWS_SDK_CMD) \
 	$(POLYMORPH_OPTIONS)";
 
@@ -308,14 +309,6 @@ _polymorph_code_gen: OUTPUT_DOTNET=\
     $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/)
 _polymorph_code_gen: OUTPUT_JAVA=--output-java $(LIBRARY_ROOT)/runtimes/java/src/main/smithy-generated
 _polymorph_code_gen: _polymorph
-_polymorph_code_gen: OUTPUT_DAFNY_WRAPPED=\
-    --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model) \
-		--include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
-_polymorph_code_gen: OUTPUT_DOTNET_WRAPPED=\
-    $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped)
-_polymorph_code_gen: OUTPUT_LOCAL_SERVICE=--local-service-test
-_polymorph_code_gen: _polymorph_wrapped
-
 
 check_polymorph_diff:
 	git diff --exit-code $(LIBRARY_ROOT) || (echo "ERROR: polymorph-generated code does not match the committed code - see above for diff. Either commit the changes or regenerate with 'POLYMORPH_OPTIONS=--update-patch-files'." && exit 1)
@@ -338,11 +331,6 @@ _polymorph_dafny: OUTPUT_DAFNY=\
 _polymorph_dafny: INPUT_DAFNY=\
 		--include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
 _polymorph_dafny: _polymorph
-_polymorph_dafny: OUTPUT_DAFNY_WRAPPED=\
-    --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model) \
-    --include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
-_polymorph_dafny: OUTPUT_LOCAL_SERVICE=--local-service-test
-_polymorph_dafny: _polymorph_wrapped
 
 # Generates dotnet code for all namespaces in this project
 .PHONY: polymorph_dotnet
@@ -359,10 +347,6 @@ polymorph_dotnet:
 _polymorph_dotnet: OUTPUT_DOTNET=\
     $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/)
 _polymorph_dotnet: _polymorph
-_polymorph_dotnet: OUTPUT_DOTNET_WRAPPED=\
-    $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped)
-_polymorph_dotnet: OUTPUT_LOCAL_SERVICE=--local-service-test
-_polymorph_dotnet: _polymorph_wrapped
 
 # Generates java code for all namespaces in this project
 .PHONY: polymorph_java
@@ -378,9 +362,6 @@ polymorph_java:
 
 _polymorph_java: OUTPUT_JAVA=--output-java $(LIBRARY_ROOT)/runtimes/java/src/main/smithy-generated
 _polymorph_java: _polymorph
-_polymorph_java: OUTPUT_JAVA_WRAPPED=--output-java $(LIBRARY_ROOT)/runtimes/java/src/main/smithy-generated
-_polymorph_java: OUTPUT_LOCAL_SERVICE=--local-service-test
-_polymorph_java: _polymorph_wrapped
 
 # Dependency for formatting generating Java code
 setup_prettier:

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -26,6 +26,8 @@
 # AWS_SDK_CMD -- the `--aws-sdk` command to generate AWS SDK style interfaces.
 # STD_LIBRARY -- path from this file to the StandardLibrary Dafny project.
 # SMITHY_DEPS -- path from this file to smithy dependencies, such as custom traits.
+# GRADLEW -- the gradlew to use when building Java runtimes.
+#   defaults to $(SMITHY_DAFNY_ROOT)/codegen/gradlew
 
 MAX_RESOURCE_COUNT := 10000000
 
@@ -245,7 +247,7 @@ transpile_dependencies:
 #   Its model is contained in $(LIBRARY_ROOT)/model, not $(LIBRARY_ROOT)/../StandardLibrary/Model.
 _polymorph:
 	cd $(CODEGEN_CLI_ROOT); \
-	$(GRADLEW) run --args="\
+	./../gradlew run --args="\
 	--dafny-version $(DAFNY_VERSION) \
 	--library-root $(LIBRARY_ROOT) \
 	--patch-files-dir $(if $(DIR_STRUCTURE_V2),$(LIBRARY_ROOT)/codegen-patches/$(SERVICE),$(LIBRARY_ROOT)/codegen-patches) \
@@ -267,7 +269,7 @@ _polymorph:
 _polymorph_wrapped:
 	@: $(if ${CODEGEN_CLI_ROOT},,$(error You must pass the path CODEGEN_CLI_ROOT: CODEGEN_CLI_ROOT=/path/to/smithy-dafny/codegen/smithy-dafny-codegen-cli));
 	cd $(CODEGEN_CLI_ROOT); \
-	$(GRADLEW) run --args="\
+	./../gradlew run --args="\
 	--dafny-version $(DAFNY_VERSION) \
 	--library-root $(LIBRARY_ROOT) \
 	--properties-file $(LIBRARY_ROOT)/project.properties \
@@ -413,7 +415,7 @@ format_net-check:
 ########################## Java targets
 
 build_java: transpile_java mvn_local_deploy_dependencies
-	./runtimes/java/gradlew -p runtimes/java build
+	$(GRADLEW) -p runtimes/java build
 
 transpile_java: | transpile_implementation_java transpile_test_java transpile_dependencies_java
 
@@ -447,10 +449,10 @@ mvn_local_deploy_dependencies:
 
 # The Java MUST all exist already through the transpile step.
 mvn_local_deploy:
-	./runtimes/java/gradlew -p runtimes/java publishMavenLocalPublicationToMavenLocal
+	$(GRADLEW) -p runtimes/java publishMavenLocalPublicationToMavenLocal
 
 test_java:
-	./runtimes/java/gradlew -p runtimes/java runTests
+	$(GRADLEW) -p runtimes/java runTests
 
 _clean:
 	rm -f $(LIBRARY_ROOT)/Model/*Types.dfy $(LIBRARY_ROOT)/Model/*TypesWrapped.dfy

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -459,10 +459,10 @@ mvn_local_deploy:
 
 # The Java MUST all exsist if we want to publish to CodeArtifact
 mvn_ca_deploy:
-	./runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactCIRepository
+	$(GRADLEW) -p runtimes/java publishMavenPublicationToPublishToCodeArtifactCIRepository
 
 mvn_staging_deploy:
-	./runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactStagingRepository
+	$(GRADLEW) -p runtimes/java publishMavenPublicationToPublishToCodeArtifactStagingRepository
 
 test_java:
 	$(GRADLEW) -p runtimes/java runTests

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -27,10 +27,7 @@
 # STD_LIBRARY -- path from this file to the StandardLibrary Dafny project.
 # SMITHY_DEPS -- path from this file to smithy dependencies, such as custom traits.
 
-# This evaluates to the local path _of this file_.
-# This means that these are the project roots
-# that are shared by all libraries in this repo.
-# TODO: This needs to be set per consumer instead now
+MAX_RESOURCE_COUNT := 10000000
 
 # This evaluates to the path of the current working directory.
 # i.e. The specific library under consideration.
@@ -50,8 +47,6 @@ SMITHY_MODEL_ROOT := $(LIBRARY_ROOT)/Model
 
 CODEGEN_CLI_ROOT := $(SMITHY_DAFNY_ROOT)/codegen/smithy-dafny-codegen-cli
 GRADLEW := $(SMITHY_DAFNY_ROOT)/codegen/gradlew
-
-
 
 ########################## Dafny targets
 

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -447,7 +447,7 @@ mvn_local_deploy_dependencies:
 
 # The Java MUST all exist already through the transpile step.
 mvn_local_deploy:
-	./runtimes/java/gradlew -p runtimes/java publishToMavenLocal
+	./runtimes/java/gradlew -p runtimes/java publishMavenLocalPublicationToMavenLocal
 
 test_java:
 	./runtimes/java/gradlew -p runtimes/java runTests

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -413,7 +413,7 @@ format_net-check:
 ########################## Java targets
 
 build_java: transpile_java mvn_local_deploy_dependencies
-	gradle -p runtimes/java build
+	./runtimes/java/gradlew -p runtimes/java build
 
 transpile_java: | transpile_implementation_java transpile_test_java transpile_dependencies_java
 
@@ -447,10 +447,10 @@ mvn_local_deploy_dependencies:
 
 # The Java MUST all exist already through the transpile step.
 mvn_local_deploy:
-	gradle -p runtimes/java publishToMavenLocal
+	./runtimes/java/gradlew -p runtimes/java publishToMavenLocal
 
 test_java:
-	gradle -p runtimes/java runTests
+	./runtimes/java/gradlew -p runtimes/java runTests
 
 _clean:
 	rm -f $(LIBRARY_ROOT)/Model/*Types.dfy $(LIBRARY_ROOT)/Model/*TypesWrapped.dfy

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -318,7 +318,6 @@ check_polymorph_diff:
 polymorph_dafny: POLYMORPH_LANGUAGE_TARGET=dafny
 polymorph_dafny: _polymorph_dependencies
 polymorph_dafny:
-	$(MAKE) -C $(PROJECT_ROOT)/$(STD_LIBRARY) polymorph_dafny
 	set -e; for service in $(PROJECT_SERVICES) ; do \
 		export service_deps_var=SERVICE_DEPS_$${service} ; \
 		export namespace_var=SERVICE_NAMESPACE_$${service} ; \

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -182,7 +182,7 @@ transpile_implementation:
         -functionSyntax:3 \
         -useRuntimeLib \
         -out $(OUT) \
-        -library:$(PROJECT_ROOT)/dafny-dependencies/StandardLibrary/src/Index.dfy \
+        -library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy \
         $(TRANSPILE_DEPENDENCIES)
 
 # If the project under transpilation uses `replaceable` modules,
@@ -222,7 +222,7 @@ transpile_test:
 		-functionSyntax:3 \
 		-useRuntimeLib \
 		-out $(OUT) \
-		-library:$(PROJECT_ROOT)/dafny-dependencies/StandardLibrary/src/Index.dfy \
+		-library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy \
 		$(TRANSPILE_DEPENDENCIES) \
 
 transpile_dependencies:

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -120,7 +120,7 @@ format_dafny:
 		--unicode-char false \
 		`find . -name '*.dfy'`
 
-format-check:
+format_dafny-check:
 	dafny format \
 		--check \
 		--function-syntax 3 \

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -404,13 +404,13 @@ transpile_test_net: _transpile_test_all
 transpile_dependencies_net: LANG=net
 transpile_dependencies_net: transpile_dependencies
 
-test_net_mac_brew: FRAMEWORK=net6.0
+test_net: FRAMEWORK=net6.0
 test_net:
 	dotnet run \
 		--project runtimes/net/tests/ \
 		--framework $(FRAMEWORK)
 
-test_net_mac_brew: FRAMEWORK=net6.0
+test_net_mac_intel: FRAMEWORK=net6.0
 test_net_mac_intel:
 	DYLD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib" dotnet run \
 		--project runtimes/net/tests/ \

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -182,7 +182,7 @@ transpile_implementation:
         -functionSyntax:3 \
         -useRuntimeLib \
         -out $(OUT) \
-        -library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy \
+        $(if $(strip $(STD_LIBRARY)) , -library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy, ) \
         $(TRANSPILE_DEPENDENCIES)
 
 # If the project under transpilation uses `replaceable` modules,
@@ -222,7 +222,7 @@ transpile_test:
 		-functionSyntax:3 \
 		-useRuntimeLib \
 		-out $(OUT) \
-		-library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy \
+		$(if $(strip $(STD_LIBRARY)) , -library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy, ) \
 		$(TRANSPILE_DEPENDENCIES) \
 
 # If we are not the StandardLibrary, transpile the StandardLibrary.

--- a/TestModels/Aggregate/Makefile
+++ b/TestModels/Aggregate/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleAggregate

--- a/TestModels/Aggregate/Makefile
+++ b/TestModels/Aggregate/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleAggregate
@@ -16,4 +16,4 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/Aggregate/README.md
+++ b/TestModels/Aggregate/README.md
@@ -6,7 +6,7 @@ This project implements all the smithy [SimpleTypes](https://smithy.io/2.0/spec/
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/AggregateReferences/Makefile
+++ b/TestModels/AggregateReferences/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleAggregateReferences
@@ -14,7 +14,7 @@ SERVICE_DEPS_SimpleAggregateReferences :=
 
 SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
-OUTPUT_DAFNY=--output-dafny $(LIBRARY_ROOT)/Model --include-dafny $(STD_LIBRARY)/src/Index.dfy
+OUTPUT_DAFNY=--output-dafny $(LIBRARY_ROOT)/Model --include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
 
 # Override wrapped target, since wrapping isn't supported for this module
 _polymorph_wrapped :

--- a/TestModels/AggregateReferences/Makefile
+++ b/TestModels/AggregateReferences/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleAggregateReferences
@@ -14,7 +14,7 @@ SERVICE_DEPS_SimpleAggregateReferences :=
 
 SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
-OUTPUT_DAFNY=--output-dafny $(LIBRARY_ROOT)/Model --include-dafny $(STANDARD_LIBRARY_PATH)/src/Index.dfy
+OUTPUT_DAFNY=--output-dafny $(LIBRARY_ROOT)/Model --include-dafny $(STD_LIBRARY)/src/Index.dfy
 
 # Override wrapped target, since wrapping isn't supported for this module
 _polymorph_wrapped :
@@ -22,4 +22,4 @@ _polymorph_wrapped :
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/CodegenPatches/Makefile
+++ b/TestModels/CodegenPatches/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	CodegenPatches
@@ -16,7 +16,7 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+
 
 clean: _clean
 	rm -rf $(LIBRARY_ROOT)/runtimes/java/src/main/dafny-generated

--- a/TestModels/CodegenPatches/Makefile
+++ b/TestModels/CodegenPatches/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	CodegenPatches

--- a/TestModels/CodegenPatches/README.md
+++ b/TestModels/CodegenPatches/README.md
@@ -30,7 +30,7 @@ make polymorph_dafny
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/CodegenPatches/runtimes/java/build.gradle.kts
+++ b/TestModels/CodegenPatches/runtimes/java/build.gradle.kts
@@ -47,6 +47,11 @@ dependencies {
 }
 
 publishing {
+    publications.create<MavenPublication>("mavenLocal") {
+        groupId = group as String?
+        artifactId = description
+        from(components["java"])
+    }
     publications.create<MavenPublication>("maven") {
         groupId = group as String?
         artifactId = description

--- a/TestModels/Constraints/Makefile
+++ b/TestModels/Constraints/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleConstraints

--- a/TestModels/Constraints/Makefile
+++ b/TestModels/Constraints/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleConstraints
@@ -16,4 +16,4 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/Constraints/README.md
+++ b/TestModels/Constraints/README.md
@@ -17,7 +17,7 @@ make polymorph_dafny
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/Constructor/Makefile
+++ b/TestModels/Constructor/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleConstructor

--- a/TestModels/Constructor/Makefile
+++ b/TestModels/Constructor/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleConstructor
@@ -16,4 +16,4 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies
 # DEPENDENT-MODELS:=
-# LIBRARIES :=
+

--- a/TestModels/Constructor/README.md
+++ b/TestModels/Constructor/README.md
@@ -14,7 +14,7 @@ make polymorph_dafny
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/Dependencies/Makefile
+++ b/TestModels/Dependencies/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleDependencies

--- a/TestModels/Dependencies/Makefile
+++ b/TestModels/Dependencies/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleDependencies

--- a/TestModels/Dependencies/README.md
+++ b/TestModels/Dependencies/README.md
@@ -43,7 +43,7 @@ make verify
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/Errors/Makefile
+++ b/TestModels/Errors/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleErrors

--- a/TestModels/Errors/Makefile
+++ b/TestModels/Errors/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleErrors
@@ -16,7 +16,6 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
 
 clean: _clean
 	rm -rf $(LIBRARY_ROOT)/runtimes/java/src/main/dafny-generated

--- a/TestModels/Errors/runtimes/java/build.gradle.kts
+++ b/TestModels/Errors/runtimes/java/build.gradle.kts
@@ -47,6 +47,11 @@ dependencies {
 }
 
 publishing {
+    publications.create<MavenPublication>("mavenLocal") {
+        groupId = group as String?
+        artifactId = description
+        from(components["java"])
+    }
     publications.create<MavenPublication>("maven") {
         groupId = group as String?
         artifactId = description

--- a/TestModels/Extendable/Makefile
+++ b/TestModels/Extendable/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 NAMESPACE=simple.extendable.resources
 

--- a/TestModels/Extendable/Makefile
+++ b/TestModels/Extendable/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.extendable.resources
 
@@ -18,7 +18,7 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+
 
 format_net:
 	pushd runtimes/net && dotnet format && popd

--- a/TestModels/Extendable/README.md
+++ b/TestModels/Extendable/README.md
@@ -54,7 +54,7 @@ make verify
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/Extendable/runtimes/java/build.gradle.kts
+++ b/TestModels/Extendable/runtimes/java/build.gradle.kts
@@ -47,6 +47,11 @@ dependencies {
 }
 
 publishing {
+    publications.create<MavenPublication>("mavenLocal") {
+        groupId = group as String?
+        artifactId = description
+        from(components["java"])
+    }
     publications.create<MavenPublication>("maven") {
         groupId = group as String?
         artifactId = description

--- a/TestModels/Extern/Makefile
+++ b/TestModels/Extern/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleExtern

--- a/TestModels/Extern/Makefile
+++ b/TestModels/Extern/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleExtern
@@ -16,4 +16,4 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/Extern/README.md
+++ b/TestModels/Extern/README.md
@@ -10,7 +10,7 @@ This project tests a few simple scenarios of implementing a [dafny extern](https
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_dafny polymorph_net
+make polymorph_dafny polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/LanguageSpecificLogic/Makefile
+++ b/TestModels/LanguageSpecificLogic/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	LanguageSpecificLogic

--- a/TestModels/LanguageSpecificLogic/Makefile
+++ b/TestModels/LanguageSpecificLogic/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	LanguageSpecificLogic
@@ -20,4 +20,4 @@ NET_TEST_INDEX=test/replaces/net
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/LanguageSpecificLogic/README.md
+++ b/TestModels/LanguageSpecificLogic/README.md
@@ -37,7 +37,7 @@ Developers can also add language-specific tests inside the replacing module.
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_dafny polymorph_net
+make polymorph_dafny polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/LocalService/Makefile
+++ b/TestModels/LocalService/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 NAMESPACE=simple.localService
 

--- a/TestModels/LocalService/Makefile
+++ b/TestModels/LocalService/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.localService
 
@@ -18,7 +18,7 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+
 
 clean:
 	rm -f $(LIBRARY_ROOT)/Model/*Types.dfy $(LIBRARY_ROOT)/Model/*TypesWrapped.dfy

--- a/TestModels/LocalService/runtimes/java/build.gradle.kts
+++ b/TestModels/LocalService/runtimes/java/build.gradle.kts
@@ -47,6 +47,11 @@ dependencies {
 }
 
 publishing {
+    publications.create<MavenPublication>("mavenLocal") {
+        groupId = group as String?
+        artifactId = description
+        from(components["java"])
+    }
     publications.create<MavenPublication>("maven") {
         groupId = group as String?
         artifactId = description

--- a/TestModels/MultipleModels/Makefile
+++ b/TestModels/MultipleModels/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 # DIR_STRUCTURE_V2 is used to signal multiple subprojects/models in one project
 DIR_STRUCTURE_V2=V2

--- a/TestModels/MultipleModels/Makefile
+++ b/TestModels/MultipleModels/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 # DIR_STRUCTURE_V2 is used to signal multiple subprojects/models in one project
 DIR_STRUCTURE_V2=V2
@@ -27,4 +27,3 @@ SERVICE_DEPS_PrimaryProject := \
 SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # DEPENDENT-MODELS:=
-# LIBRARIES :=

--- a/TestModels/MultipleModels/README.md
+++ b/TestModels/MultipleModels/README.md
@@ -53,7 +53,7 @@ as the two model files in this project have a dependency structure.
 1. Generate the Wrappers using `polymorph`
 ```
 make polymorph_dafny DAFNY_VERSION_OPTION="--dafny-version A.B.C" \
-&& make polymorph_net DAFNY_VERSION_OPTION="--dafny-version A.B.C" \
+&& make polymorph_dotnet DAFNY_VERSION_OPTION="--dafny-version A.B.C" \
 && make polymorph_java DAFNY_VERSION_OPTION="--dafny-version A.B.C"
 ```
 

--- a/TestModels/MultipleModels/runtimes/java/build.gradle.kts
+++ b/TestModels/MultipleModels/runtimes/java/build.gradle.kts
@@ -47,6 +47,11 @@ dependencies {
 }
 
 publishing {
+    publications.create<MavenPublication>("mavenLocal") {
+        groupId = group as String?
+        artifactId = description
+        from(components["java"])
+    }
     publications.create<MavenPublication>("maven") {
         groupId = group as String?
         artifactId = description

--- a/TestModels/README.md
+++ b/TestModels/README.md
@@ -45,7 +45,7 @@ As well as the Dafny implemented in individual projects.
 Each runtime needs its own set of targets.
 This example is written assuming that the runtime you are targeting is .NET.
 
-* `polymorph_net` -- run polymorph on the project with `--output-dafny` and `--output-dotnet` to generate the code
+* `polymorph_dotnet` -- run polymorph on the project with `--output-dafny` and `--output-dotnet` to generate the code
 * `transpile_net` -- run `dafny` to produce the native code. Remember to output both the implementation and tests.
 * `setup_net` -- run any required setup. For example downloading dependencies
 * `test_net` -- run the tests

--- a/TestModels/Refinement/Makefile
+++ b/TestModels/Refinement/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 NAMESPACE=simple.refinement
 

--- a/TestModels/Refinement/Makefile
+++ b/TestModels/Refinement/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.refinement
 
@@ -18,4 +18,4 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/Refinement/README.md
+++ b/TestModels/Refinement/README.md
@@ -6,7 +6,7 @@ This project test the smithy behavior trait [readonly](https://smithy.io/1.0/spe
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_dafny polymorph_net
+make polymorph_dafny polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/Resource/Makefile
+++ b/TestModels/Resource/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 NAMESPACE=simple.resources
 

--- a/TestModels/Resource/Makefile
+++ b/TestModels/Resource/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.resources
 
@@ -18,7 +18,7 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+
 
 format_net:
 	pushd runtimes/net && dotnet format && popd

--- a/TestModels/Resource/README.md
+++ b/TestModels/Resource/README.md
@@ -45,7 +45,7 @@ make verify
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/Resource/runtimes/java/build.gradle.kts
+++ b/TestModels/Resource/runtimes/java/build.gradle.kts
@@ -47,6 +47,11 @@ dependencies {
 }
 
 publishing {
+    publications.create<MavenPublication>("mavenLocal") {
+        groupId = group as String?
+        artifactId = description
+        from(components["java"])
+    }
     publications.create<MavenPublication>("maven") {
         groupId = group as String?
         artifactId = description

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -1,0 +1,6 @@
+
+include ../SmithyDafnyMakefile.mk
+
+PROJECT_ROOT := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+SMITHY_DAFNY_ROOT := $(PROJECT_ROOT)
+STD_LIBRARY := dafny-dependencies/StandardLibrary

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -1,3 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 PROJECT_ROOT := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -1,9 +1,54 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# This evaluates to the local path _of this file_.
+# This means that these are the project roots
+# that are shared by all libraries in this repo.
 PROJECT_ROOT := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 
 SMITHY_DAFNY_ROOT := $(PROJECT_ROOT)/..
 STD_LIBRARY := dafny-dependencies/StandardLibrary
 
 include $(PROJECT_ROOT)/../SmithyDafnyMakefile.mk
+
+# Override all the _polymorph_<LANG> targets to also build local service tests with _polymorph_wrapped,
+# since all TestModels need to do that in place rather than in separate libraries.
+
+_polymorph_code_gen: OUTPUT_DAFNY=\
+    --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model)
+_polymorph_code_gen: INPUT_DAFNY=\
+		--include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
+_polymorph_code_gen: OUTPUT_DOTNET=\
+    $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/)
+_polymorph_code_gen: OUTPUT_JAVA=--output-java $(LIBRARY_ROOT)/runtimes/java/src/main/smithy-generated
+_polymorph_code_gen: _polymorph
+_polymorph_code_gen: OUTPUT_DAFNY_WRAPPED=\
+    --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model) \
+		--include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
+_polymorph_code_gen: OUTPUT_DOTNET_WRAPPED=\
+    $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped)
+_polymorph_code_gen: _polymorph_wrapped
+
+_polymorph_dafny: OUTPUT_DAFNY=\
+		--output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model)
+_polymorph_dafny: INPUT_DAFNY=\
+		--include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
+_polymorph_dafny: _polymorph
+_polymorph_dafny: OUTPUT_DAFNY_WRAPPED=\
+    --output-dafny $(if $(DIR_STRUCTURE_V2), $(LIBRARY_ROOT)/dafny/$(SERVICE)/Model, $(LIBRARY_ROOT)/Model) \
+    --include-dafny $(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy
+_polymorph_dafny: _polymorph_wrapped
+
+_polymorph_java: OUTPUT_JAVA=--output-java $(LIBRARY_ROOT)/runtimes/java/src/main/smithy-generated
+_polymorph_java: _polymorph
+_polymorph_java: OUTPUT_JAVA_WRAPPED=--output-java $(LIBRARY_ROOT)/runtimes/java/src/main/smithy-generated
+_polymorph_java: _polymorph_wrapped
+
+_polymorph_dotnet: OUTPUT_DOTNET=\
+    $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/)
+_polymorph_dotnet: _polymorph
+_polymorph_dotnet: OUTPUT_DOTNET_WRAPPED=\
+    $(if $(DIR_STRUCTURE_V2), --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped/$(SERVICE)/, --output-dotnet $(LIBRARY_ROOT)/runtimes/net/Generated/Wrapped)
+_polymorph_dotnet: _polymorph_wrapped
+
+

--- a/TestModels/SharedMakefile.mk
+++ b/TestModels/SharedMakefile.mk
@@ -1,6 +1,7 @@
 
-include ../SmithyDafnyMakefile.mk
-
 PROJECT_ROOT := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
-SMITHY_DAFNY_ROOT := $(PROJECT_ROOT)
+
+SMITHY_DAFNY_ROOT := $(PROJECT_ROOT)/..
 STD_LIBRARY := dafny-dependencies/StandardLibrary
+
+include $(PROJECT_ROOT)/../SmithyDafnyMakefile.mk

--- a/TestModels/SimpleTypes/BigDecimal/Makefile
+++ b/TestModels/SimpleTypes/BigDecimal/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.bigDecimal
 

--- a/TestModels/SimpleTypes/BigDecimal/Makefile
+++ b/TestModels/SimpleTypes/BigDecimal/Makefile
@@ -3,10 +3,10 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.bigDecimal
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/SimpleTypes/BigInteger/Makefile
+++ b/TestModels/SimpleTypes/BigInteger/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.bigInteger
 

--- a/TestModels/SimpleTypes/BigInteger/Makefile
+++ b/TestModels/SimpleTypes/BigInteger/Makefile
@@ -3,10 +3,10 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.bigInteger
 
 # This project has no dependencies
 # DEPENDENT-MODELS:=
-# LIBRARIES :=
+

--- a/TestModels/SimpleTypes/SimpleBlob/Makefile
+++ b/TestModels/SimpleTypes/SimpleBlob/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.blob
 
@@ -18,4 +18,4 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/SimpleTypes/SimpleBlob/Makefile
+++ b/TestModels/SimpleTypes/SimpleBlob/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.blob
 

--- a/TestModels/SimpleTypes/SimpleBlob/README.md
+++ b/TestModels/SimpleTypes/SimpleBlob/README.md
@@ -6,7 +6,7 @@ This project implements the smithy type [blob](https://smithy.io/2.0/spec/simple
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/SimpleTypes/SimpleBoolean/Makefile
+++ b/TestModels/SimpleTypes/SimpleBoolean/Makefile
@@ -6,7 +6,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.boolean
 
@@ -21,4 +21,4 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/SimpleTypes/SimpleBoolean/Makefile
+++ b/TestModels/SimpleTypes/SimpleBoolean/Makefile
@@ -6,7 +6,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.boolean
 

--- a/TestModels/SimpleTypes/SimpleBoolean/README.md
+++ b/TestModels/SimpleTypes/SimpleBoolean/README.md
@@ -6,7 +6,7 @@ This project implements the smithy type [boolean](https://smithy.io/2.0/spec/sim
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/SimpleTypes/SimpleByte/Makefile
+++ b/TestModels/SimpleTypes/SimpleByte/Makefile
@@ -3,10 +3,10 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.byte
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/SimpleTypes/SimpleByte/Makefile
+++ b/TestModels/SimpleTypes/SimpleByte/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.byte
 

--- a/TestModels/SimpleTypes/SimpleDouble/Makefile
+++ b/TestModels/SimpleTypes/SimpleDouble/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.smithyDouble
 

--- a/TestModels/SimpleTypes/SimpleDouble/Makefile
+++ b/TestModels/SimpleTypes/SimpleDouble/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.smithyDouble
 
@@ -18,7 +18,7 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+
 transpile_net_dependencies:
 
 format_net:

--- a/TestModels/SimpleTypes/SimpleDouble/README.md
+++ b/TestModels/SimpleTypes/SimpleDouble/README.md
@@ -48,7 +48,7 @@ make verify
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/SimpleTypes/SimpleEnum/Makefile
+++ b/TestModels/SimpleTypes/SimpleEnum/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.smithyEnum
 
@@ -18,4 +18,4 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/SimpleTypes/SimpleEnum/Makefile
+++ b/TestModels/SimpleTypes/SimpleEnum/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.smithyEnum
 

--- a/TestModels/SimpleTypes/SimpleEnum/README.md
+++ b/TestModels/SimpleTypes/SimpleEnum/README.md
@@ -6,7 +6,7 @@ This project implements the smithy type [enum](https://smithy.io/2.0/spec/simple
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/SimpleTypes/SimpleEnumV2/Makefile
+++ b/TestModels/SimpleTypes/SimpleEnumV2/Makefile
@@ -22,7 +22,7 @@ polymorph_dafny :
 	--namespace simple.types.enumv2"; \
 
 # Note: This build target fails. This project does not support code generation for Smithy 2.0 models.
-polymorph_net :
+polymorph_dotnet :
 	cd ../../../codegen/smithy-dafny-codegen-cli;\
 	./gradlew run --args="\
 	--output-dafny \

--- a/TestModels/SimpleTypes/SimpleFloat/Makefile
+++ b/TestModels/SimpleTypes/SimpleFloat/Makefile
@@ -3,10 +3,10 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.float
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/SimpleTypes/SimpleFloat/Makefile
+++ b/TestModels/SimpleTypes/SimpleFloat/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.float
 

--- a/TestModels/SimpleTypes/SimpleInteger/Makefile
+++ b/TestModels/SimpleTypes/SimpleInteger/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.integer
 

--- a/TestModels/SimpleTypes/SimpleInteger/Makefile
+++ b/TestModels/SimpleTypes/SimpleInteger/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.integer
 
@@ -18,4 +18,4 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies
 # DEPENDENT-MODELS:=
-# LIBRARIES :=
+

--- a/TestModels/SimpleTypes/SimpleInteger/README.md
+++ b/TestModels/SimpleTypes/SimpleInteger/README.md
@@ -6,7 +6,7 @@ This project implements the smithy type [integer](https://smithy.io/2.0/spec/sim
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/SimpleTypes/SimpleLong/Makefile
+++ b/TestModels/SimpleTypes/SimpleLong/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.smithyLong
 

--- a/TestModels/SimpleTypes/SimpleLong/Makefile
+++ b/TestModels/SimpleTypes/SimpleLong/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.smithyLong
 
@@ -18,4 +18,4 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/SimpleTypes/SimpleShort/Makefile
+++ b/TestModels/SimpleTypes/SimpleShort/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.short
 

--- a/TestModels/SimpleTypes/SimpleShort/Makefile
+++ b/TestModels/SimpleTypes/SimpleShort/Makefile
@@ -3,10 +3,9 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.short
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=

--- a/TestModels/SimpleTypes/SimpleString/Makefile
+++ b/TestModels/SimpleTypes/SimpleString/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.smithyString
 
@@ -18,4 +18,4 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/SimpleTypes/SimpleString/Makefile
+++ b/TestModels/SimpleTypes/SimpleString/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.smithyString
 

--- a/TestModels/SimpleTypes/SimpleString/README.md
+++ b/TestModels/SimpleTypes/SimpleString/README.md
@@ -6,7 +6,7 @@ This project implements the smithy type [String](https://smithy.io/2.0/spec/simp
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/SimpleTypes/SimpleTimestamp/Makefile
+++ b/TestModels/SimpleTypes/SimpleTimestamp/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.types.timestamp
 

--- a/TestModels/SimpleTypes/SimpleTimestamp/Makefile
+++ b/TestModels/SimpleTypes/SimpleTimestamp/Makefile
@@ -3,10 +3,10 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=simple.types.timestamp
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+

--- a/TestModels/Union/Makefile
+++ b/TestModels/Union/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../SharedMakefile.mk
 
 NAMESPACE=simple.union
 

--- a/TestModels/Union/Makefile
+++ b/TestModels/Union/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=simple.union
 
@@ -18,5 +18,5 @@ SMITHY_DEPS=dafny-dependencies/Model/traits.smithy
 
 # This project has no dependencies
 # DEPENDENT-MODELS:=
-# LIBRARIES :=
+
 transpile_net_dependencies:

--- a/TestModels/Union/README.md
+++ b/TestModels/Union/README.md
@@ -23,7 +23,7 @@ make polymorph_dafny
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_net
+make polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/aws-sdks/ddb/Makefile
+++ b/TestModels/aws-sdks/ddb/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	ComAmazonawsDynamodb \

--- a/TestModels/aws-sdks/ddb/Makefile
+++ b/TestModels/aws-sdks/ddb/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	ComAmazonawsDynamodb \
@@ -18,7 +18,7 @@ AWS_SDK_CMD=--aws-sdk
 
 # This project has no dependencies 
 # DEPENDENT-MODELS:= 
-# LIBRARIES :=
+
 
 # There is no wrapped target for aws-sdk types
 _polymorph_wrapped: ;

--- a/TestModels/aws-sdks/ddb/README.md
+++ b/TestModels/aws-sdks/ddb/README.md
@@ -8,7 +8,7 @@ NOTE: The `model.json` in this project comes from [private-aws-encryption-sdk-da
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_dafny polymorph_net
+make polymorph_dafny polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/aws-sdks/kms/Makefile
+++ b/TestModels/aws-sdks/kms/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=com.amazonaws.kms
 
@@ -20,7 +20,7 @@ AWS_SDK_CMD=--aws-sdk
 
 # This project has no dependencies
 # DEPENDENT-MODELS:=
-# LIBRARIES :=
+
 
 # There is no wrapped target for aws-sdk types
 _polymorph_wrapped: ;

--- a/TestModels/aws-sdks/kms/Makefile
+++ b/TestModels/aws-sdks/kms/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=com.amazonaws.kms
 

--- a/TestModels/aws-sdks/kms/README.md
+++ b/TestModels/aws-sdks/kms/README.md
@@ -8,7 +8,7 @@ NOTE: The `model.json` in this project comes from [private-aws-encryption-sdk-da
 ### .NET
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_dafny polymorph_net
+make polymorph_dafny polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/aws-sdks/sqs-via-cli/Makefile
+++ b/TestModels/aws-sdks/sqs-via-cli/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 NAMESPACE=com.amazonaws.sqs
 
@@ -20,7 +20,7 @@ AWS_SDK_CMD=--aws-sdk
 
 # This project has no dependencies
 # DEPENDENT-MODELS:=
-# LIBRARIES :=
+
 
 # There is no wrapped target for aws-sdk types
 _polymorph_wrapped: ;

--- a/TestModels/aws-sdks/sqs-via-cli/Makefile
+++ b/TestModels/aws-sdks/sqs-via-cli/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 NAMESPACE=com.amazonaws.sqs
 

--- a/TestModels/aws-sdks/sqs-via-cli/README.md
+++ b/TestModels/aws-sdks/sqs-via-cli/README.md
@@ -12,7 +12,7 @@ For more details, please see `TestModels/aws-sdks/sqs/README.md`.
 
 1. Generate the Wrappers using `polymorph`
 ```
-make polymorph_dafny polymorph_net
+make polymorph_dafny polymorph_dotnet
 ```
 
 2. Transpile the tests (and implementation) to the target runtime.

--- a/TestModels/dafny-dependencies/StandardLibrary/Makefile
+++ b/TestModels/dafny-dependencies/StandardLibrary/Makefile
@@ -23,7 +23,7 @@ polymorph_dafny :
 	@: $(if ${CODEGEN_CLI_ROOT},,$(error You must pass the path CODEGEN_CLI_ROOT: CODEGEN_CLI_ROOT=/path/to/smithy-dafny/codegen/smithy-dafny-codegen-cli));
 	cd $(CODEGEN_CLI_ROOT); \
 	$(GRADLEW) run --args="\
-	$(DAFNY_VERSION_OPTION) \
+	--dafny-version $(DAFNY_VERSION) \
 	--library-root $(LIBRARY_ROOT) \
 	--properties-file $(PROJECT_ROOT)/$(STD_LIBRARY)/project.properties \
 	--model $(PROJECT_ROOT)/$(STD_LIBRARY)/Model \

--- a/TestModels/dafny-dependencies/StandardLibrary/Makefile
+++ b/TestModels/dafny-dependencies/StandardLibrary/Makefile
@@ -3,7 +3,7 @@
 
 CORES=2
 
-include ../../../SharedMakefile.mk
+include ../../SharedMakefile.mk
 
 MAX_RESOURCE_COUNT=500000000
 
@@ -25,10 +25,10 @@ polymorph_dafny :
 	$(GRADLEW) run --args="\
 	$(DAFNY_VERSION_OPTION) \
 	--library-root $(LIBRARY_ROOT) \
-	--properties-file $(STD_LIBRARY)/project.properties \
-	--model $(STD_LIBRARY)/Model \
+	--properties-file $(PROJECT_ROOT)/$(STD_LIBRARY)/project.properties \
+	--model $(PROJECT_ROOT)/$(STD_LIBRARY)/Model \
 	--namespace aws.polymorph \
-	--dependent-model $(STD_LIBRARY)/../Model \
+	--dependent-model $(PROJECT_ROOT)/$(STD_LIBRARY)/../Model \
 	";
 
 polymorph_net :

--- a/TestModels/dafny-dependencies/StandardLibrary/Makefile
+++ b/TestModels/dafny-dependencies/StandardLibrary/Makefile
@@ -3,10 +3,9 @@
 
 CORES=2
 
-include ../../SharedMakefile.mk
+include ../../../SharedMakefile.mk
 
 MAX_RESOURCE_COUNT=500000000
-LIBRARIES :=
 
 # define standard colors
 ifneq (,$(findstring xterm,${TERM}))
@@ -26,10 +25,10 @@ polymorph_dafny :
 	$(GRADLEW) run --args="\
 	$(DAFNY_VERSION_OPTION) \
 	--library-root $(LIBRARY_ROOT) \
-	--properties-file $(STANDARD_LIBRARY_PATH)/project.properties \
-	--model $(STANDARD_LIBRARY_PATH)/Model \
+	--properties-file $(STD_LIBRARY)/project.properties \
+	--model $(STD_LIBRARY)/Model \
 	--namespace aws.polymorph \
-	--dependent-model $(STANDARD_LIBRARY_PATH)/../Model \
+	--dependent-model $(STD_LIBRARY)/../Model \
 	";
 
 polymorph_net :

--- a/TestModels/dafny-dependencies/StandardLibrary/Makefile
+++ b/TestModels/dafny-dependencies/StandardLibrary/Makefile
@@ -31,8 +31,8 @@ polymorph_dafny :
 	--dependent-model $(PROJECT_ROOT)/$(STD_LIBRARY)/../Model \
 	";
 
-polymorph_net :
-	echo "Skipping polymorph_net for StandardLibrary"
+polymorph_dotnet :
+	echo "Skipping polymorph_dotnet for StandardLibrary"
 
 polymorph_java :
 	echo "Skipping polymorph_java for StandardLibrary"

--- a/TestModels/dafny-dependencies/StandardLibrary/Makefile
+++ b/TestModels/dafny-dependencies/StandardLibrary/Makefile
@@ -20,7 +20,6 @@ endif
 
 # Overriding this target just to generate the project.properties file
 polymorph_dafny :
-	@: $(if ${CODEGEN_CLI_ROOT},,$(error You must pass the path CODEGEN_CLI_ROOT: CODEGEN_CLI_ROOT=/path/to/smithy-dafny/codegen/smithy-dafny-codegen-cli));
 	cd $(CODEGEN_CLI_ROOT); \
 	$(GRADLEW) run --args="\
 	--dafny-version $(DAFNY_VERSION) \


### PR DESCRIPTION
*Description of changes:*

Factors the content of `TestModels/SharedMakefile.mk` to a new top-level `SmithyDafnyMakefile.mk`, which is actually intended to be reused by any `smithy-dafny` project using the CLI through a submodule. Projects will still likely want their own repository-specific `SharedMakefile.mk` in order to set a few variables that are the same for all libraries, which is true for the `TestModels` subfolder here too.

Additional make targets and improvements from https://github.com/aws/aws-cryptographic-material-providers-library and general cleanup are also applied. Highlights:

* Delete `LIBRARIES`, which is unused and was replaced by `PROJECT_DEPENDENCIES`.
* Delete `SMITHY_NAMESPACE`, which is unused and was replaced by `SERVICE_NAMESPACE_<service>`
* Replace `STANDARD_LIBRARY_PATH` with `STD_LIBRARY`.
  * The test models were avoiding the same issue with the standard library trying to build itself by overriding the `transpile_***` targets to not build dependencies. Both mechanisms at once is redundant but safe.
* Introduce `MAX_RESOURCE_COUNT` with a default of `10000000`
* Tweak `GRADLEW` to be the variable to use for building Java runtimes, since the TestModels don't have a `gradlew` in each `runtimes/java` directory, but other projects like the MPL do. Running the smithy-dafny CLI always uses the copy in `codegen`.
* Don't also build `_polymorph_wrapped` by default, just have `TestModels/SharedMakefile.mk` add that instead.
* Invoke `_polymorph_dependencies` before building the current library, since that's necessary in some cases (and was already changed in MPL's makefile)

See https://github.com/smithy-lang/smithy-dafny/pull/326 for a diff of SmithyDafnyMakefile.mk with the old contents of TestModels/SharedMakefile.mk.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
