### PR TITLE
feat: Add VERIFY_TIMEOUT

### DIFF
--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -14,6 +14,9 @@
 # Variables:
 # MAX_RESOURCE_COUNT -- The Dafny report generator max resource count.
 # 	This is is per project because the verification variability can differ.
+# VERIFY_TIMEOUT -- The Dafny verification timeout in seconds.
+# 	This is only a guard against builds taking way too long to fail.
+#   The resource count limit above is much more important for fighting brittle verification.
 # PROJECT_DEPENDENCIES -- List of dependencies for the project.
 # 	It should be the list of top level directory names
 # PROJECT_SERVICES -- List of names of each local service in the project
@@ -82,7 +85,7 @@ verify:
 		-unicodeChar:0 \
 		-functionSyntax:3 \
 		-verificationLogger:csv \
-		-timeLimit:100 \
+		-timeLimit:$(VERIFY_TIMEOUT) \
 		-trace \
 		%
 
@@ -97,7 +100,7 @@ verify_single:
 		-unicodeChar:0 \
 		-functionSyntax:3 \
 		-verificationLogger:text \
-		-timeLimit:100 \
+		-timeLimit:$(VERIFY_TIMEOUT) \
 		-trace \
 		$(if ${PROC},-proc:*$(PROC)*,) \
 		$(FILE)
@@ -112,7 +115,7 @@ verify_service:
 		-unicodeChar:0 \
 		-functionSyntax:3 \
 		-verificationLogger:csv \
-		-timeLimit:100 \
+		-timeLimit:$(VERIFY_TIMEOUT) \
 		-trace \
 		`find ./dafny/$(SERVICE) -name '*.dfy'` \
 

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -33,6 +33,7 @@
 #   defaults to $(SMITHY_DAFNY_ROOT)/codegen/gradlew
 
 MAX_RESOURCE_COUNT := 10000000
+VERIFY_TIMEOUT := 100
 
 # This evaluates to the path of the current working directory.
 # i.e. The specific library under consideration.


### PR DESCRIPTION
*Description of changes:*
Allows projects to raise this a little from the default of 100 seconds (needed for https://github.com/aws/aws-encryption-sdk-dafny/pull/638)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
