### PR TITLE
chore: Cut dafny issues on nightly failures

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -24,3 +24,16 @@ jobs:
     uses: ./.github/workflows/test_models_net_tests.yml
     with:
       dafny: ${{ inputs.dafny }}
+
+  # TODO: Temporary to test mechanism intended only for nightly_dafny.yml
+  cut-issue-on-failure:
+    runs-on: ubuntu-20.04
+    needs: [manual-ci-verification, manual-ci-java, manual-ci-net]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    steps:
+      - name: Create release blocker on dafny-lang/dafny
+        run: |
+          gh issue create \
+            --title "(TEST ISSUE PLEASE IGNORE) Dafny nightly regression from ${{ github.workflow_ref }}" \
+            --label "severity: release-blocker" \
+            --body "See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -11,36 +11,16 @@ on:
         required: true
         type: string
 
-permissions:
-  issues: write
-
 jobs:
-  # manual-ci-verification:
-  #   uses: ./.github/workflows/test_models_dafny_verification.yml
-  #   with:
-  #     dafny: ${{ inputs.dafny }}
-  # manual-ci-java:
-  #   uses: ./.github/workflows/test_models_java_tests.yml
-  #   with:
-  #     dafny: ${{ inputs.dafny }}
-  # manual-ci-net:
-  #   uses: ./.github/workflows/test_models_net_tests.yml
-  #   with:
-  #     dafny: ${{ inputs.dafny }}
-
-  # TODO: Temporary to test mechanism intended only for nightly_dafny.yml
-  cut-issue-on-failure:
-    runs-on: ubuntu-20.04
-    # needs: [manual-ci-verification, manual-ci-java, manual-ci-net]
-    # if: ${{ always() && contains(needs.*.result, 'failure') }}
-    env:
-      GH_TOKEN: ${{ secrets.CI_TOKEN }}
-    steps:
-      - name: Create release blocker on dafny-lang/dafny
-        run: |
-          gh issue create \
-            --repo "dafny-lang/dafny" \
-            --title "(TEST ISSUE PLEASE IGNORE) Dafny nightly regression from ${{ github.repository }}" \
-            --label "autocut" \
-            --body "Failure in ${{ github.workflow_ref }}. \
-            See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+  manual-ci-verification:
+    uses: ./.github/workflows/test_models_dafny_verification.yml
+    with:
+      dafny: ${{ inputs.dafny }}
+  manual-ci-java:
+    uses: ./.github/workflows/test_models_java_tests.yml
+    with:
+      dafny: ${{ inputs.dafny }}
+  manual-ci-net:
+    uses: ./.github/workflows/test_models_net_tests.yml
+    with:
+      dafny: ${{ inputs.dafny }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -41,5 +41,5 @@ jobs:
           gh issue create \
             --repo "dafny-lang/dafny" \
             --title "(TEST ISSUE PLEASE IGNORE) Dafny nightly regression from ${{ github.workflow_ref }}" \
-            --label "severity: release-blocker" \
+            --label "release-blocker" \
             --body "See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -41,6 +41,7 @@ jobs:
           gh issue create \
             --repo "dafny-lang/dafny" \
             --title "(TEST ISSUE PLEASE IGNORE) Dafny nightly regression from ${{ github.repository }}" \
-            --label "release-blocker" \
-            --label "autocut" \
-            --body "Failure in ${{ github.workflow_ref }}.\n\nSee ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --label "release-blocker,autocut" \
+            --body "Failure in ${{ github.workflow_ref }}. \
+            \
+            See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -12,31 +12,31 @@ on:
         type: string
 
 jobs:
-  manual-ci-verification:
-    uses: ./.github/workflows/test_models_dafny_verification.yml
-    with:
-      dafny: ${{ inputs.dafny }}
-  manual-ci-java:
-    uses: ./.github/workflows/test_models_java_tests.yml
-    with:
-      dafny: ${{ inputs.dafny }}
-  manual-ci-net:
-    uses: ./.github/workflows/test_models_net_tests.yml
-    with:
-      dafny: ${{ inputs.dafny }}
+  # manual-ci-verification:
+  #   uses: ./.github/workflows/test_models_dafny_verification.yml
+  #   with:
+  #     dafny: ${{ inputs.dafny }}
+  # manual-ci-java:
+  #   uses: ./.github/workflows/test_models_java_tests.yml
+  #   with:
+  #     dafny: ${{ inputs.dafny }}
+  # manual-ci-net:
+  #   uses: ./.github/workflows/test_models_net_tests.yml
+  #   with:
+  #     dafny: ${{ inputs.dafny }}
 
   # TODO: Temporary to test mechanism intended only for nightly_dafny.yml
   cut-issue-on-failure:
     runs-on: ubuntu-20.04
-    needs: [manual-ci-verification, manual-ci-java, manual-ci-net]
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    # needs: [manual-ci-verification, manual-ci-java, manual-ci-net]
+    # if: ${{ always() && contains(needs.*.result, 'failure') }}
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Create release blocker on dafny-lang/dafny
         run: |
           gh issue create \
-            --repo "dafny-lang/dafny"
+            --repo "dafny-lang/dafny" \
             --title "(TEST ISSUE PLEASE IGNORE) Dafny nightly regression from ${{ github.workflow_ref }}" \
             --label "severity: release-blocker" \
             --body "See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Create release blocker on dafny-lang/dafny
         run: |
           gh issue create \
+            --repo "dafny-lang/dafny"
             --title "(TEST ISSUE PLEASE IGNORE) Dafny nightly regression from ${{ github.workflow_ref }}" \
             --label "severity: release-blocker" \
             --body "See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -34,12 +34,13 @@ jobs:
     # needs: [manual-ci-verification, manual-ci-java, manual-ci-net]
     # if: ${{ always() && contains(needs.*.result, 'failure') }}
     env:
-      GH_TOKEN: ${{ secrets.ROBINS_PAT_FOR_EXPERIMENTS }}
+      GH_TOKEN: ${{ secrets.CI_TOKEN }}
     steps:
       - name: Create release blocker on dafny-lang/dafny
         run: |
           gh issue create \
             --repo "dafny-lang/dafny" \
-            --title "(TEST ISSUE PLEASE IGNORE) Dafny nightly regression from ${{ github.workflow_ref }}" \
+            --title "(TEST ISSUE PLEASE IGNORE) Dafny nightly regression from ${{ github.repository }}" \
             --label "release-blocker" \
-            --body "See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --label "autocut" \
+            --body "Failure in ${{ github.workflow_ref }}.\n\nSee ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -41,7 +41,6 @@ jobs:
           gh issue create \
             --repo "dafny-lang/dafny" \
             --title "(TEST ISSUE PLEASE IGNORE) Dafny nightly regression from ${{ github.repository }}" \
-            --label "release-blocker,autocut" \
+            --label "autocut" \
             --body "Failure in ${{ github.workflow_ref }}. \
-            \
             See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+permissions:
+  issues: write
+
 jobs:
   # manual-ci-verification:
   #   uses: ./.github/workflows/test_models_dafny_verification.yml

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [manual-ci-verification, manual-ci-java, manual-ci-net]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Create release blocker on dafny-lang/dafny
         run: |

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -34,7 +34,7 @@ jobs:
     # needs: [manual-ci-verification, manual-ci-java, manual-ci-net]
     # if: ${{ always() && contains(needs.*.result, 'failure') }}
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.ROBINS_PAT_FOR_EXPERIMENTS }}
     steps:
       - name: Create release blocker on dafny-lang/dafny
         run: |

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -27,3 +27,15 @@ jobs:
     uses: ./.github/workflows/test_models_net_tests.yml
     with:
       dafny: 'nightly-latest'
+
+  cut-issue-on-failure:
+    runs-on: ubuntu-20.04
+    needs: [dafny-nightly-verification, dafny-nightly-java, dafny-nightly-net]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    steps:
+      - name: Create release blocker on dafny-lang/dafny
+        run: |
+          gh issue create \
+            --title "Dafny nightly regression from ${{ github.workflow_ref }}" \
+            --label "severity: release-blocker" \
+            --body "See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -10,9 +10,6 @@ on:
     # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
     - cron: "30 16 * * *"
 
-permissions:
-  issues: write
-
 jobs:
   dafny-nightly-verification:
     # Don't run the cron builds on forks
@@ -32,16 +29,16 @@ jobs:
       dafny: 'nightly-latest'
 
   cut-issue-on-failure:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [dafny-nightly-verification, dafny-nightly-java, dafny-nightly-net]
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ contains(needs.*.result, 'failure') }}
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.CI_TOKEN }}
     steps:
       - name: Create release blocker on dafny-lang/dafny
         run: |
           gh issue create \
             --repo "dafny-lang/dafny" \
-            --title "Dafny nightly regression from ${{ github.workflow_ref }}" \
-            --label "severity: release-blocker" \
-            --body "See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --title "[PRERELEASE REGRESSION] Dafny prerelease regression from ${{ github.repository }}" \
+            --body "Failure in ${{ github.workflow_ref }}. \
+            See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -36,7 +36,7 @@ jobs:
   cut-issue-on-failure:
     runs-on: ubuntu-latest
     needs: [dafny-nightly-verification, dafny-nightly-java, dafny-nightly-net, dafny-nightly-rust]
-    if: ${{ contains(needs.*.result, 'failure') }}
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     env:
       GH_TOKEN: ${{ secrets.CI_TOKEN }}
     steps:

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Create release blocker on dafny-lang/dafny
         run: |
           gh issue create \
+            --repo "dafny-lang/dafny"
             --title "Dafny nightly regression from ${{ github.workflow_ref }}" \
             --label "severity: release-blocker" \
             --body "See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Create release blocker on dafny-lang/dafny
         run: |
           gh issue create \
-            --repo "dafny-lang/dafny"
+            --repo "dafny-lang/dafny" \
             --title "Dafny nightly regression from ${{ github.workflow_ref }}" \
             --label "severity: release-blocker" \
             --body "See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [dafny-nightly-verification, dafny-nightly-java, dafny-nightly-net]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Create release blocker on dafny-lang/dafny
         run: |

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -10,6 +10,9 @@ on:
     # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
     - cron: "30 16 * * *"
 
+permissions:
+  issues: write
+
 jobs:
   dafny-nightly-verification:
     # Don't run the cron builds on forks


### PR DESCRIPTION
*Description of changes:*
Creates an issue that will block the next Dafny release if the nightly build against the latest Dafny prerelease fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
