### PR TITLE
ci: Use Dafny feature branch for testing Rust support

### DIFF
--- a/.github/actions/build_dafny_from_source/action.yml
+++ b/.github/actions/build_dafny_from_source/action.yml
@@ -23,6 +23,7 @@ runs:
         ref: ${{ inputs.dafny }}
 
     - name: Load Z3
+      shell: bash
       run: |
         sudo apt-get install -qq libarchive-tools
         mkdir -p dafny/Binaries/z3/bin
@@ -38,10 +39,12 @@ runs:
         dotnet-version: 6.0.x
 
     - name: Build Dafny
+      shell: bash
       run: |
         dotnet build dafny/Source/Dafny.sln
 
     - name: Add dafny to PATH
+      shell: bash
       run: |
         echo dafny/Scripts >> $GITHUB_PATH
     

--- a/.github/actions/build_dafny_from_source/action.yml
+++ b/.github/actions/build_dafny_from_source/action.yml
@@ -48,5 +48,8 @@ runs:
       run: |
         echo dafny/Scripts >> $GITHUB_PATH
     
-    # TODO: export DAFNY_VERSION
-    
+    - name: Export DAFNY_VERSION
+      shell: bash
+      run: |
+        echo "DAFNY_VERSION=4.7.0" >> $GITHUB_ENV
+

--- a/.github/actions/build_dafny_from_source/action.yml
+++ b/.github/actions/build_dafny_from_source/action.yml
@@ -1,0 +1,49 @@
+#
+# This local action builds Dafny from source
+# rather than using the setup-dafny-action.
+# Currently it's only used to test Rust support
+# against a feature branch of Dafny.
+#
+
+name: "Build Dafny from source"
+description: "Drop-in replacement for setup-dafny-action that builds the given branch of Dafny from source"
+inputs:
+  dafny:
+    description: "The Dafny branch to use"
+    required: true
+    type: string
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout Dafny
+      uses: actions/checkout@v4
+      with:
+        repository: dafny-lang/dafny
+        path: dafny
+        ref: ${{ inputs.dafny }}
+
+    - name: Load Z3
+      run: |
+        sudo apt-get install -qq libarchive-tools
+        mkdir -p dafny/Binaries/z3/bin
+        wget -qO- https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-08-02/z3-4.12.1-x64-ubuntu-20.04-bin.zip | bsdtar -xf -
+        mv z3-4.12.1 dafny/Binaries/z3/bin/
+        chmod +x dafny/Binaries/z3/bin/z3-4.12.1
+        mkdir -p unzippedRelease/dafny/z3/bin
+        ln dafny/Binaries/z3/bin/z3-4.12.1 unzippedRelease/dafny/z3/bin/z3-4.12.1
+
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Build Dafny
+      run: |
+        dotnet build dafny/Source/Dafny.sln
+
+    - name: Add dafny to PATH
+      run: |
+        echo dafny/Scripts >> $GITHUB_PATH
+    
+    # TODO: export DAFNY_VERSION
+    

--- a/.github/actions/build_dafny_from_source/action.yml
+++ b/.github/actions/build_dafny_from_source/action.yml
@@ -48,6 +48,7 @@ runs:
       run: |
         echo ${{ github.workspace }}/dafny/Scripts >> $GITHUB_PATH
 
+    # Hard-coding this for now since it's a pain to extract from an arbitrary branch
     - name: Export DAFNY_VERSION
       shell: bash
       run: |

--- a/.github/actions/build_dafny_from_source/action.yml
+++ b/.github/actions/build_dafny_from_source/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Add dafny to PATH
       shell: bash
       run: |
-        echo dafny/Scripts >> $GITHUB_PATH
+        echo ${{ github.workspace }}/dafny/Scripts >> $GITHUB_PATH
     
     - name: Export DAFNY_VERSION
       shell: bash

--- a/.github/actions/build_dafny_from_source/action.yml
+++ b/.github/actions/build_dafny_from_source/action.yml
@@ -47,9 +47,8 @@ runs:
       shell: bash
       run: |
         echo ${{ github.workspace }}/dafny/Scripts >> $GITHUB_PATH
-    
+
     - name: Export DAFNY_VERSION
       shell: bash
       run: |
         echo "DAFNY_VERSION=4.7.0" >> $GITHUB_ENV
-

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -47,9 +47,9 @@ jobs:
       fail-fast: false
       matrix:
         # Rust code generation is under development and depends on pending changes to the
-        # Dafny Rust code generation, so we test on a specific feature branch instead.
+        # Dafny Rust code generation, so we test on a specific commit from the feat-rust feature branch instead.
         dafny-version:
-          - feat-rust
+          - 00fe7ff70d3858d67d69a2b897a65c7f9d209e0a
     uses: ./.github/workflows/test_models_rust_tests.yml
     with:
       dafny: ${{ matrix.dafny-version }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -14,43 +14,42 @@ jobs:
     outputs:
       dafny-version-list: ${{ steps.populate-dafny-versions-list.outputs.dafny-versions-list }}
 
-  pr-ci-verification:
-    needs: pr-populate-dafny-versions
-    strategy:
-      fail-fast: false
-      matrix:
-        dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
-    uses: ./.github/workflows/test_models_dafny_verification.yml
-    with:
-      dafny: ${{ matrix.dafny-version }}
-  pr-ci-java:
-    needs: pr-populate-dafny-versions
-    strategy:
-      fail-fast: false
-      matrix:
-        dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
-    uses: ./.github/workflows/test_models_java_tests.yml
-    with:
-      dafny: ${{ matrix.dafny-version }}
-  pr-ci-net:
-    needs: pr-populate-dafny-versions
-    strategy:
-      fail-fast: false
-      matrix:
-        dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
-    uses: ./.github/workflows/test_models_net_tests.yml
-    with:
-      dafny: ${{ matrix.dafny-version }}
+  # pr-ci-verification:
+  #   needs: pr-populate-dafny-versions
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
+  #   uses: ./.github/workflows/test_models_dafny_verification.yml
+  #   with:
+  #     dafny: ${{ matrix.dafny-version }}
+  # pr-ci-java:
+  #   needs: pr-populate-dafny-versions
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
+  #   uses: ./.github/workflows/test_models_java_tests.yml
+  #   with:
+  #     dafny: ${{ matrix.dafny-version }}
+  # pr-ci-net:
+  #   needs: pr-populate-dafny-versions
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
+  #   uses: ./.github/workflows/test_models_net_tests.yml
+  #   with:
+  #     dafny: ${{ matrix.dafny-version }}
   pr-ci-rust:
     needs: pr-populate-dafny-versions
     strategy:
       fail-fast: false
       matrix:
         # Rust code generation is under development and depends on pending changes to the
-        # Dafny Rust code generation, so we only test on a relatively recent prerelease instead.
-        # This can be updated as needed when new features/fixes land in Dafny master.
+        # Dafny Rust code generation, so we test on a specific feature branch instead.
         dafny-version:
-          - nightly-2024-05-09-8432b17
+          - feat-rust
     uses: ./.github/workflows/test_models_rust_tests.yml
     with:
       dafny: ${{ matrix.dafny-version }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -14,33 +14,33 @@ jobs:
     outputs:
       dafny-version-list: ${{ steps.populate-dafny-versions-list.outputs.dafny-versions-list }}
 
-  # pr-ci-verification:
-  #   needs: pr-populate-dafny-versions
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
-  #   uses: ./.github/workflows/test_models_dafny_verification.yml
-  #   with:
-  #     dafny: ${{ matrix.dafny-version }}
-  # pr-ci-java:
-  #   needs: pr-populate-dafny-versions
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
-  #   uses: ./.github/workflows/test_models_java_tests.yml
-  #   with:
-  #     dafny: ${{ matrix.dafny-version }}
-  # pr-ci-net:
-  #   needs: pr-populate-dafny-versions
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
-  #   uses: ./.github/workflows/test_models_net_tests.yml
-  #   with:
-  #     dafny: ${{ matrix.dafny-version }}
+  pr-ci-verification:
+    needs: pr-populate-dafny-versions
+    strategy:
+      fail-fast: false
+      matrix:
+        dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
+    uses: ./.github/workflows/test_models_dafny_verification.yml
+    with:
+      dafny: ${{ matrix.dafny-version }}
+  pr-ci-java:
+    needs: pr-populate-dafny-versions
+    strategy:
+      fail-fast: false
+      matrix:
+        dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
+    uses: ./.github/workflows/test_models_java_tests.yml
+    with:
+      dafny: ${{ matrix.dafny-version }}
+  pr-ci-net:
+    needs: pr-populate-dafny-versions
+    strategy:
+      fail-fast: false
+      matrix:
+        dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
+    uses: ./.github/workflows/test_models_net_tests.yml
+    with:
+      dafny: ${{ matrix.dafny-version }}
   pr-ci-rust:
     needs: pr-populate-dafny-versions
     strategy:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,9 +49,9 @@ jobs:
       fail-fast: false
       matrix:
         # Rust code generation is under development and depends on pending changes to the
-        # Dafny Rust code generation, so we test on a specific feature branch instead.
+        # Dafny Rust code generation, so we test on a specific commit from the feat-rust feature branch instead.
         dafny-version:
-          - feat-rust
+          - 00fe7ff70d3858d67d69a2b897a65c7f9d209e0a
     uses: ./.github/workflows/test_models_rust_tests.yml
     with:
       dafny: ${{ matrix.dafny-version }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,10 +48,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dafny-version: ${{ fromJson(needs.pr-populate-dafny-versions.outputs.dafny-version-list) }}
-        # The Rust backend didn't exist yet in Dafny 4.2
-        exclude:
-          - dafny-version: 4.2.0
+        # Rust code generation is under development and depends on pending changes to the
+        # Dafny Rust code generation, so we test on a specific feature branch instead.
+        dafny-version:
+          - feat-rust
     uses: ./.github/workflows/test_models_rust_tests.yml
     with:
       dafny: ${{ matrix.dafny-version }}

--- a/.github/workflows/test_models_rust_tests.yml
+++ b/.github/workflows/test_models_rust_tests.yml
@@ -74,6 +74,11 @@ jobs:
         with:
           dafny: ${{ inputs.dafny }}
 
+      - name: TEST
+        shell: bash
+        run: |
+          echo $PATH
+
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/test_models_rust_tests.yml
+++ b/.github/workflows/test_models_rust_tests.yml
@@ -74,11 +74,6 @@ jobs:
         with:
           dafny: ${{ inputs.dafny }}
 
-      - name: TEST
-        shell: bash
-        run: |
-          echo $PATH
-
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/test_models_rust_tests.yml
+++ b/.github/workflows/test_models_rust_tests.yml
@@ -67,12 +67,10 @@ jobs:
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-PolymorphTestModels-Role-us-west-2
           role-session-name: JavaTests
 
-      - uses: actions/checkout@v3
-
-      - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.7.0
+      - name: Setup Dafny (build from source)
+        uses: ./.github/actions/build_dafny_from_source
         with:
-          dafny-version: ${{ inputs.dafny }}
+          dafny: ${{ inputs.dafny }}
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/test_models_rust_tests.yml
+++ b/.github/workflows/test_models_rust_tests.yml
@@ -67,6 +67,8 @@ jobs:
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-PolymorphTestModels-Role-us-west-2
           role-session-name: JavaTests
 
+      - uses: actions/checkout@v3
+
       - name: Setup Dafny (build from source)
         uses: ./.github/actions/build_dafny_from_source
         with:

--- a/TestModels/SimpleTypes/SimpleBoolean/codegen-patches/rust/dafny-4.5.0.patch
+++ b/TestModels/SimpleTypes/SimpleBoolean/codegen-patches/rust/dafny-4.5.0.patch
@@ -1,60 +1,14 @@
 diff --git b/TestModels/SimpleTypes/SimpleBoolean/runtimes/rust/dafny_impl/src/implementation_from_dafny.rs a/TestModels/SimpleTypes/SimpleBoolean/runtimes/rust/dafny_impl/src/implementation_from_dafny.rs
-index ba5de6ff..dd0ece8a 100644
+index 0f09275d..dd0ece8a 100644
 --- b/TestModels/SimpleTypes/SimpleBoolean/runtimes/rust/dafny_impl/src/implementation_from_dafny.rs
 +++ a/TestModels/SimpleTypes/SimpleBoolean/runtimes/rust/dafny_impl/src/implementation_from_dafny.rs
-@@ -1,89 +1,522 @@
+@@ -1,5 +1,522 @@
  #![allow(warnings, unconditional_panic)]
  #![allow(nonstandard_style)]
--extern crate dafny_runtime;
--mod _System {
--  #[derive(Clone, PartialEq)]
--  #[repr(transparent)]
--  pub struct nat(pub ::dafny_runtime::DafnyInt);
--  impl ::std::default::Default for nat {
--    fn default() -> Self {
--      nat(::std::default::Default::default())
--    }
--  }
--  impl ::dafny_runtime::DafnyPrint for nat {
--    fn fmt_print(&self, _formatter: &mut ::std::fmt::Formatter, in_seq: bool) -> ::std::fmt::Result {
--      ::dafny_runtime::DafnyPrint::fmt_print(&self.0, _formatter, in_seq)
--    }
--  }
--  impl ::std::ops::Deref for nat {
--    type Target = ::dafny_runtime::DafnyInt;
--    fn deref(&self) -> &Self::Target {
--      &self.0
--    }
--  }
--  #[derive(PartialEq)]
--  pub enum Tuple2<T0, T1> {
--    _T2 { _0: T0, _1: T1 },
--    _PhantomVariant(::std::marker::PhantomData::<T0>, ::std::marker::PhantomData::<T1>)
--  }
--  impl <T0: Clone + ::dafny_runtime::DafnyPrint + 'static, T1: Clone + ::dafny_runtime::DafnyPrint + 'static>Tuple2<T0, T1> {
--    pub fn _0(&self) -> &T0 {
--      match self {
--        Tuple2::_T2 { _0, _1, } => _0,
--        Tuple2::_PhantomVariant(..) => panic!()
--      }
--    }
--    pub fn _1(&self) -> &T1 {
--      match self {
--        Tuple2::_T2 { _0, _1, } => _1,
--        Tuple2::_PhantomVariant(..) => panic!()
--      }
--    }
--  }
--  impl <T0: Clone + ::dafny_runtime::DafnyPrint + 'static, T1: Clone + ::dafny_runtime::DafnyPrint + 'static>::dafny_runtime::DafnyPrint for Tuple2<T0, T1> {
--    fn fmt_print(&self, _formatter: &mut ::std::fmt::Formatter, _in_seq: bool) -> std::fmt::Result {
--      match self {
--        Tuple2::_T2 { _0, _1, } => {
--          write!(_formatter, "_System.Tuple2._T2(")?;
--          ::dafny_runtime::DafnyPrint::fmt_print(_0, _formatter, false)?;
--          write!(_formatter, ", ")?;
--          ::dafny_runtime::DafnyPrint::fmt_print(_1, _formatter, false)?;
--          write!(_formatter, ")")?;
--          Ok(())
+-pub mod _module {
+-  
+-}
+\ No newline at end of file
 +pub use dafny_runtime;
 +pub use dafny_standard_library;
 +pub use dafny_standard_library::implementation_from_dafny::*;
@@ -165,39 +119,7 @@ index ba5de6ff..dd0ece8a 100644
 +    pub enum GetBooleanOutput {
 +        GetBooleanOutput {
 +            value: ::std::rc::Rc<super::r#_Wrappers_Compile::Option<bool>>,
-         },
--        Tuple2::_PhantomVariant(..) => {panic!()}
--      }
--    }
--  }
--  impl <T0: ::std::default::Default, T1: ::std::default::Default>::std::default::Default for Tuple2<T0, T1> {
--    fn default() -> Self {
--      Tuple2::_T2 {
--        _0: ::std::default::Default::default(),
--        _1: ::std::default::Default::default()
--      }
--    }
--  }
--  #[derive(PartialEq)]
--  pub enum Tuple0 {
--    _T0 {}
--  }
--  impl Tuple0 {}
--  impl ::dafny_runtime::DafnyPrint for Tuple0 {
--    fn fmt_print(&self, _formatter: &mut ::std::fmt::Formatter, _in_seq: bool) -> std::fmt::Result {
--      match self {
--        Tuple0::_T0 { } => {
--          write!(_formatter, "_System.Tuple0._T0")?;
--          Ok(())
--        }
--      }
--    }
--  }
--  impl ::std::default::Default for Tuple0 {
--    fn default() -> Self {
--      Tuple0::_T0 {}
--    }
--  }
++        },
 +    }
 +    impl GetBooleanOutput {
 +        pub fn value(&self) -> ::std::rc::Rc<super::r#_Wrappers_Compile::Option<bool>> {
@@ -605,11 +527,7 @@ index ba5de6ff..dd0ece8a 100644
 +            ::std::ptr::eq(self, other)
 +        }
 +    }
- }
--mod _module {
--  
--}
-\ No newline at end of file
++}
 +mod _module {}
 diff --git b/TestModels/SimpleTypes/SimpleBoolean/runtimes/rust/src/client.rs a/TestModels/SimpleTypes/SimpleBoolean/runtimes/rust/src/client.rs
 new file mode 100644

--- a/TestModels/SimpleTypes/SimpleString/codegen-patches/rust/dafny-4.5.0.patch
+++ b/TestModels/SimpleTypes/SimpleString/codegen-patches/rust/dafny-4.5.0.patch
@@ -1,60 +1,14 @@
 diff --git b/TestModels/SimpleTypes/SimpleString/runtimes/rust/dafny_impl/src/implementation_from_dafny.rs a/TestModels/SimpleTypes/SimpleString/runtimes/rust/dafny_impl/src/implementation_from_dafny.rs
-index ba5de6ff..469a527f 100644
+index 0f09275d..469a527f 100644
 --- b/TestModels/SimpleTypes/SimpleString/runtimes/rust/dafny_impl/src/implementation_from_dafny.rs
 +++ a/TestModels/SimpleTypes/SimpleString/runtimes/rust/dafny_impl/src/implementation_from_dafny.rs
-@@ -1,89 +1,637 @@
+@@ -1,5 +1,637 @@
  #![allow(warnings, unconditional_panic)]
  #![allow(nonstandard_style)]
--extern crate dafny_runtime;
--mod _System {
--  #[derive(Clone, PartialEq)]
--  #[repr(transparent)]
--  pub struct nat(pub ::dafny_runtime::DafnyInt);
--  impl ::std::default::Default for nat {
--    fn default() -> Self {
--      nat(::std::default::Default::default())
--    }
--  }
--  impl ::dafny_runtime::DafnyPrint for nat {
--    fn fmt_print(&self, _formatter: &mut ::std::fmt::Formatter, in_seq: bool) -> ::std::fmt::Result {
--      ::dafny_runtime::DafnyPrint::fmt_print(&self.0, _formatter, in_seq)
--    }
--  }
--  impl ::std::ops::Deref for nat {
--    type Target = ::dafny_runtime::DafnyInt;
--    fn deref(&self) -> &Self::Target {
--      &self.0
--    }
--  }
--  #[derive(PartialEq)]
--  pub enum Tuple2<T0, T1> {
--    _T2 { _0: T0, _1: T1 },
--    _PhantomVariant(::std::marker::PhantomData::<T0>, ::std::marker::PhantomData::<T1>)
--  }
--  impl <T0: Clone + ::dafny_runtime::DafnyPrint + 'static, T1: Clone + ::dafny_runtime::DafnyPrint + 'static>Tuple2<T0, T1> {
--    pub fn _0(&self) -> &T0 {
--      match self {
--        Tuple2::_T2 { _0, _1, } => _0,
--        Tuple2::_PhantomVariant(..) => panic!()
--      }
--    }
--    pub fn _1(&self) -> &T1 {
--      match self {
--        Tuple2::_T2 { _0, _1, } => _1,
--        Tuple2::_PhantomVariant(..) => panic!()
--      }
--    }
--  }
--  impl <T0: Clone + ::dafny_runtime::DafnyPrint + 'static, T1: Clone + ::dafny_runtime::DafnyPrint + 'static>::dafny_runtime::DafnyPrint for Tuple2<T0, T1> {
--    fn fmt_print(&self, _formatter: &mut ::std::fmt::Formatter, _in_seq: bool) -> std::fmt::Result {
--      match self {
--        Tuple2::_T2 { _0, _1, } => {
--          write!(_formatter, "_System.Tuple2._T2(")?;
--          ::dafny_runtime::DafnyPrint::fmt_print(_0, _formatter, false)?;
--          write!(_formatter, ", ")?;
--          ::dafny_runtime::DafnyPrint::fmt_print(_1, _formatter, false)?;
--          write!(_formatter, ")")?;
--          Ok(())
+-pub mod _module {
+-  
+-}
+\ No newline at end of file
 +pub extern crate dafny_runtime;
 +pub extern crate dafny_standard_library;
 +pub use dafny_standard_library::implementation_from_dafny::*;
@@ -118,39 +72,7 @@ index ba5de6ff..469a527f 100644
 +            value: ::std::rc::Rc<
 +                super::r#_Wrappers_Compile::Option<::dafny_runtime::DafnyStringUTF16>,
 +            >,
-         },
--        Tuple2::_PhantomVariant(..) => {panic!()}
--      }
--    }
--  }
--  impl <T0: ::std::default::Default, T1: ::std::default::Default>::std::default::Default for Tuple2<T0, T1> {
--    fn default() -> Self {
--      Tuple2::_T2 {
--        _0: ::std::default::Default::default(),
--        _1: ::std::default::Default::default()
--      }
--    }
--  }
--  #[derive(PartialEq)]
--  pub enum Tuple0 {
--    _T0 {}
--  }
--  impl Tuple0 {}
--  impl ::dafny_runtime::DafnyPrint for Tuple0 {
--    fn fmt_print(&self, _formatter: &mut ::std::fmt::Formatter, _in_seq: bool) -> std::fmt::Result {
--      match self {
--        Tuple0::_T0 { } => {
--          write!(_formatter, "_System.Tuple0._T0")?;
--          Ok(())
--        }
--      }
--    }
--  }
--  impl ::std::default::Default for Tuple0 {
--    fn default() -> Self {
--      Tuple0::_T0 {}
--    }
--  }
++        },
 +    }
 +    impl ::std::convert::AsRef<GetStringInput> for &GetStringInput {
 +        fn as_ref(&self) -> Self {
@@ -720,11 +642,7 @@ index ba5de6ff..469a527f 100644
 +            ::std::ptr::eq(self, other)
 +        }
 +    }
- }
--mod _module {
--  
--}
-\ No newline at end of file
++}
 +mod _module {}
 diff --git b/TestModels/SimpleTypes/SimpleString/runtimes/rust/src/client.rs a/TestModels/SimpleTypes/SimpleString/runtimes/rust/src/client.rs
 new file mode 100644


### PR DESCRIPTION
*Description of changes:*

Moves the CI to use the [feat-rust branch of Dafny](https://github.com/dafny-lang/dafny/tree/feat-rust) instead of a specific nightly prerelease, since the branch should be a stable target as we work on merging that work to master.

Note that the patch files don't change much with this switch because the `src_for_rust` subset isn't changing yet - I'm having trouble adding more files there for some reason, and will follow up in a different PR to improve that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
