### PR TITLE
chore: Try to update existing issues

### DIFF
--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -48,8 +48,14 @@ jobs:
     steps:
       - name: Create release blocker on dafny-lang/dafny
         run: |
-          gh issue create \
-            --repo "dafny-lang/dafny" \
-            --title "[PRERELEASE REGRESSION] Dafny prerelease regression from ${{ github.repository }}" \
-            --body "Failure in ${{ github.workflow_ref }}. \
-            See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          id=$(gh search issues -R dafny-lang/dafny --match title "[PRERELEASE REGRESSION] Dafny prerelease regression from ${{ github.repository }}" --json number,state -q '[.[] | select( .state=="open" )][0].number')
+          if [ -n "$id" ]; then
+            gh issue comment -R dafny-lang/dafny $id \
+              -b "Another failure in ${{ github.workflow_ref }}. \
+                See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          else
+            gh issue create -R dafny-lang/dafny \
+              -t "[PRERELEASE REGRESSION] Dafny prerelease regression from ${{ github.repository }}" \
+              -b "Failure in ${{ github.workflow_ref }}. \
+                See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi


### PR DESCRIPTION
This automation creates a lot of noise on `dafny-lang/dafny`. Instead of always creating new issues, we create a comment, when possible.