### PR TITLE
ci: Disable Rust in nightly build

### DIFF
--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -27,11 +27,13 @@ jobs:
     uses: ./.github/workflows/test_models_net_tests.yml
     with:
       dafny: "nightly-latest"
-  dafny-nightly-rust:
-    if: github.event_name != 'schedule' || github.repository_owner == 'smithy-lang'
-    uses: ./.github/workflows/test_models_rust_tests.yml
-    with:
-      dafny: "nightly-latest"
+  # This workflow is pinned to a specific commit from a feature branch
+  # that's "ahead" of master, so there's no point in testing against nightly prereleases for now.
+  # dafny-nightly-rust:
+  #   if: github.event_name != 'schedule' || github.repository_owner == 'smithy-lang'
+  #   uses: ./.github/workflows/test_models_rust_tests.yml
+  #   with:
+  #     dafny: "nightly-latest"
 
   cut-issue-on-failure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
*Description of changes:*

This workflow is pinned to a specific commit from a feature branch that's "ahead" of master, so there's no point in testing against nightly prereleases for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
