### PR TITLE
feat: Include Java runtime version in project.properties as well

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -191,7 +191,7 @@ public class CodegenEngine {
       "dafnyVersion",
       dafnyVersionString
     );
-    writeTemplatedFile("project.properties", parameters);
+    writeTemplatedFile("project.properties", outputPath.toString(), parameters);
   }
 
   private void generateDafny(final Path outputDir) {
@@ -735,11 +735,24 @@ public class CodegenEngine {
     String templatePath,
     Map<String, String> parameters
   ) {
-    IOUtils.writeTemplatedFile(
-      getClass(),
-      libraryRoot,
+    writeTemplatedFile(
+      templatePath,
       templatePath,
       parameters
+    );
+  }
+
+  private void writeTemplatedFile(
+          String templatePath,
+          String outputTemplatePath,
+          Map<String, String> parameters
+  ) {
+    IOUtils.writeTemplatedFile(
+            getClass(),
+            libraryRoot,
+            templatePath,
+            outputTemplatePath,
+            parameters
     );
   }
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -735,24 +735,20 @@ public class CodegenEngine {
     String templatePath,
     Map<String, String> parameters
   ) {
-    writeTemplatedFile(
-      templatePath,
-      templatePath,
-      parameters
-    );
+    writeTemplatedFile(templatePath, templatePath, parameters);
   }
 
   private void writeTemplatedFile(
-          String templatePath,
-          String outputTemplatePath,
-          Map<String, String> parameters
+    String templatePath,
+    String outputTemplatePath,
+    Map<String, String> parameters
   ) {
     IOUtils.writeTemplatedFile(
-            getClass(),
-            libraryRoot,
-            templatePath,
-            outputTemplatePath,
-            parameters
+      getClass(),
+      libraryRoot,
+      templatePath,
+      outputTemplatePath,
+      parameters
     );
   }
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/IOUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/IOUtils.java
@@ -82,6 +82,7 @@ public class IOUtils {
     Class<?> klass,
     Path rootPath,
     String templatePath,
+    String templateOutputPath,
     Map<String, String> parameters
   ) {
     String content = IoUtils.readUtf8Resource(
@@ -90,9 +91,9 @@ public class IOUtils {
     );
 
     content = evalTemplate(content, parameters);
-    templatePath = evalTemplate(templatePath, parameters);
+    templateOutputPath = evalTemplate(templateOutputPath, parameters);
 
-    Path outputPath = rootPath.resolve(templatePath);
+    Path outputPath = rootPath.resolve(templateOutputPath);
     try {
       Files.createDirectories(outputPath.getParent());
     } catch (IOException e) {

--- a/codegen/smithy-dafny-codegen/src/main/resources/templates/project.properties
+++ b/codegen/smithy-dafny-codegen/src/main/resources/templates/project.properties
@@ -1,3 +1,4 @@
 # This file stores the top level dafny version information.
 # All elements of the project need to agree on this version.
 dafnyVersion=$dafnyVersion:L
+dafnyRuntimeJavaVersion=$dafnyVersion:L


### PR DESCRIPTION
*Description of changes:*

For the benefit of the DB ESDK nightly build, since it defines `dafnyRuntimeJavaVersion` separately from `dafnyVersion`.

It also turns out I accidentally dropped handling of the `--properties-file` path in #390, so this also allows `writeTemplatedFile` to customize the output path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
