### PR TITLE
fix(Java-SDK): handle generic service exceptions

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ShimV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ShimV2.java
@@ -250,7 +250,7 @@ public class ShimV2 extends Generator {
         "return $L",
         subject.dafnyNameResolver.createFailure(
           successTypeDescriptor,
-          CodeBlock.of("$T.create_Opaque(ex.toString())", dafnyError)
+          CodeBlock.of("ToDafny.Error(ex)")
         )
       );
     return Optional.of(builder.endControlFlow().build());

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ShimV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ShimV2.java
@@ -231,7 +231,6 @@ public class ShimV2 extends Generator {
             )
           );
       });
-    TypeName dafnyError = subject.dafnyNameResolver.abstractClassForError();
     builder
       .nextControlFlow(
         "catch ($T ex)",

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
@@ -689,11 +689,17 @@ public class ToDafnyAwsV2 extends ToDafny {
       .methodBuilder("Error")
       .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
       .returns(subject.dafnyNameResolver.abstractClassForError())
-      .addComment("While this is logically identical to the other Opaque Error case,")
+      .addComment(
+        "While this is logically identical to the other Opaque Error case,"
+      )
       .addComment("it is semantically distinct.")
-      .addComment("An un-modeled Service Error is different from a Java Heap Exhaustion error.")
+      .addComment(
+        "An un-modeled Service Error is different from a Java Heap Exhaustion error."
+      )
       .addComment("In the future, Smithy-Dafny MAY allow for this distinction.")
-      .addComment("Which would allow Dafny developers to treat the two differently.")
+      .addComment(
+        "Which would allow Dafny developers to treat the two differently."
+      )
       .addParameter(
         subject.nativeNameResolver.baseErrorForService(),
         "nativeValue"
@@ -713,11 +719,17 @@ public class ToDafnyAwsV2 extends ToDafny {
       .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
       .returns(subject.dafnyNameResolver.abstractClassForError())
       .addParameter(Exception.class, "nativeValue")
-      .addComment("While this is logically identical to the other Opaque Error case,")
+      .addComment(
+        "While this is logically identical to the other Opaque Error case,"
+      )
       .addComment("it is semantically distinct.")
-      .addComment("An un-modeled Service Error is different from a Java Heap Exhaustion error.")
+      .addComment(
+        "An un-modeled Service Error is different from a Java Heap Exhaustion error."
+      )
       .addComment("In the future, Smithy-Dafny MAY allow for this distinction.")
-      .addComment("Which would allow Dafny developers to treat the two differently.")
+      .addComment(
+        "Which would allow Dafny developers to treat the two differently."
+      )
       .addStatement(
         "return $T.create_Opaque(nativeValue)",
         subject.dafnyNameResolver.abstractClassForError()

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
@@ -689,6 +689,11 @@ public class ToDafnyAwsV2 extends ToDafny {
       .methodBuilder("Error")
       .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
       .returns(subject.dafnyNameResolver.abstractClassForError())
+      .addComment("While this is logically identical to the other Opaque Error case,")
+      .addComment("it is semantically distinct.")
+      .addComment("An unmodeled Service Error is different than a Java Heap Exhaustion error.")
+      .addComment("In the future, Smithy-Dafny MAY allow for this distinction.")
+      .addComment("Which would allow Dafny developers to treat the two differently.")
       .addParameter(
         subject.nativeNameResolver.baseErrorForService(),
         "nativeValue"
@@ -708,6 +713,11 @@ public class ToDafnyAwsV2 extends ToDafny {
       .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
       .returns(subject.dafnyNameResolver.abstractClassForError())
       .addParameter(Exception.class, "nativeValue")
+      .addComment("While this is logically identical to the other Opaque Error case,")
+      .addComment("it is semantically distinct.")
+      .addComment("An unmodeled Service Error is different than a Java Heap Exhaustion error.")
+      .addComment("In the future, Smithy-Dafny MAY allow for this distinction.")
+      .addComment("Which would allow Dafny developers to treat the two differently.")
       .addStatement(
         "return $T.create_Opaque(nativeValue)",
         subject.dafnyNameResolver.abstractClassForError()

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
@@ -691,7 +691,7 @@ public class ToDafnyAwsV2 extends ToDafny {
       .returns(subject.dafnyNameResolver.abstractClassForError())
       .addComment("While this is logically identical to the other Opaque Error case,")
       .addComment("it is semantically distinct.")
-      .addComment("An unmodeled Service Error is different than a Java Heap Exhaustion error.")
+      .addComment("An un-modeled Service Error is different from a Java Heap Exhaustion error.")
       .addComment("In the future, Smithy-Dafny MAY allow for this distinction.")
       .addComment("Which would allow Dafny developers to treat the two differently.")
       .addParameter(
@@ -715,7 +715,7 @@ public class ToDafnyAwsV2 extends ToDafny {
       .addParameter(Exception.class, "nativeValue")
       .addComment("While this is logically identical to the other Opaque Error case,")
       .addComment("it is semantically distinct.")
-      .addComment("An unmodeled Service Error is different than a Java Heap Exhaustion error.")
+      .addComment("An un-modeled Service Error is different from a Java Heap Exhaustion error.")
       .addComment("In the future, Smithy-Dafny MAY allow for this distinction.")
       .addComment("Which would allow Dafny developers to treat the two differently.")
       .addStatement(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2.java
@@ -707,10 +707,7 @@ public class ToDafnyAwsV2 extends ToDafny {
       .methodBuilder("Error")
       .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
       .returns(subject.dafnyNameResolver.abstractClassForError())
-      .addParameter(
-        Exception.class,
-        "nativeValue"
-      )
+      .addParameter(Exception.class, "nativeValue")
       .addStatement(
         "return $T.create_Opaque(nativeValue)",
         subject.dafnyNameResolver.abstractClassForError()

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeAwsV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeAwsV2.java
@@ -520,9 +520,13 @@ public class ToNativeAwsV2 extends ToNative {
     return initializeMethodSpec(methodName, inputType, returnType)
       .addComment("While the first two cases are logically identical,")
       .addComment("there is a semantic distinction.")
-      .addComment("An un-modeled Service Error is different from a Java Heap Exhaustion error.")
+      .addComment(
+        "An un-modeled Service Error is different from a Java Heap Exhaustion error."
+      )
       .addComment("In the future, Smithy-Dafny MAY allow for this distinction.")
-      .addComment("Which would allow Dafny developers to treat the two differently.")
+      .addComment(
+        "Which would allow Dafny developers to treat the two differently."
+      )
       // If obj is an instance of the Service's Base Exception
       .beginControlFlow(
         "if ($L.$L instanceof $T)",
@@ -557,8 +561,13 @@ public class ToNativeAwsV2 extends ToNative {
         Dafny.datatypeConstructorIs("Some")
       )
       // if not null, stringify the object
-      .addStatement("final String suffix = $L.dtor_obj() != null ? String.format($S, $L.dtor_obj()) : $S;",
-        VAR_INPUT, "  Unknown Object: %s", VAR_INPUT, "")
+      .addStatement(
+        "final String suffix = $L.dtor_obj() != null ? String.format($S, $L.dtor_obj()) : $S;",
+        VAR_INPUT,
+        "  Unknown Object: %s",
+        VAR_INPUT,
+        ""
+      )
       // Convert String from Dafny
       .addStatement(
         "final $T message = $L($L.$L.$L) + suffix",

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeAwsV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeAwsV2.java
@@ -175,6 +175,7 @@ public class ToNativeAwsV2 extends ToNative {
       .addMethods(convertRelevant)
       .addMethods(convertServiceErrors)
       .addMethod(modeledService(subject.serviceShape))
+      .addMethod(errorOpaque())
       .build();
   }
 
@@ -510,5 +511,62 @@ public class ToNativeAwsV2 extends ToNative {
       });
     method.addStatement("return $L.build()", VAR_BUILDER);
     return method.build();
+  }
+
+  protected MethodSpec errorOpaque() {
+    final String methodName = "Error";
+    final TypeName inputType = subject.dafnyNameResolver.classForOpaqueError();
+    final ClassName returnType = ClassName.get(RuntimeException.class);
+    return initializeMethodSpec(
+      methodName,
+      inputType,
+      returnType
+    )
+      // If obj is an instance of the Service's Base Exception
+      .beginControlFlow(
+        "if ($L.$L() instanceof $T)",
+        VAR_INPUT,
+        Dafny.datatypeDeconstructor("obj"),
+        subject.nativeNameResolver.baseErrorForService()
+      )
+      .addStatement(
+        "return ($T) $L.$L()",
+        subject.nativeNameResolver.baseErrorForService(),
+        VAR_INPUT,
+        Dafny.datatypeDeconstructor("obj")
+      )
+      // If obj is ANY Exception
+      .nextControlFlow("else if ($L.$L() instanceof $T)",
+        VAR_INPUT,
+        Dafny.datatypeDeconstructor("obj"),
+        Exception.class
+      )
+      .addStatement(
+        "return ($T) $L.$L()",
+        RuntimeException.class,
+        VAR_INPUT,
+        Dafny.datatypeDeconstructor("obj")
+      )
+      // If String is set
+      .nextControlFlow("else if ($L.$L().$L())",
+        VAR_INPUT,
+        Dafny.datatypeDeconstructor("message"),
+        Dafny.datatypeConstructorIs("Some")
+      )
+      .addStatement("final $T message = $L($L.$L().$L())",
+        String.class,
+        SIMPLE_CONVERSION_METHOD_FROM_SHAPE_TYPE.get(ShapeType.STRING),
+        VAR_INPUT,
+        Dafny.datatypeDeconstructor("message"),
+        Dafny.datatypeDeconstructor("value")
+      )
+      .addStatement("return new $T(message)", RuntimeException.class)
+      .endControlFlow()
+      // If obj is not ANY exception and String is not set, Give Up with IllegalStateException
+      .addStatement("return new $T(String.format($S, $L))",
+        IllegalStateException.class,
+        "Unknown error thrown while calling " + AwsSdkNativeV2.shortNameForService(subject.serviceShape) + ". %s",
+        VAR_INPUT)
+      .build();
   }
 }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeAwsV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeAwsV2.java
@@ -517,45 +517,46 @@ public class ToNativeAwsV2 extends ToNative {
     final String methodName = "Error";
     final TypeName inputType = subject.dafnyNameResolver.classForOpaqueError();
     final ClassName returnType = ClassName.get(RuntimeException.class);
-    return initializeMethodSpec(
-      methodName,
-      inputType,
-      returnType
-    )
+    return initializeMethodSpec(methodName, inputType, returnType)
       // If obj is an instance of the Service's Base Exception
       .beginControlFlow(
-        "if ($L.$L() instanceof $T)",
+        "if ($L.$L instanceof $T)",
         VAR_INPUT,
         Dafny.datatypeDeconstructor("obj"),
         subject.nativeNameResolver.baseErrorForService()
       )
       .addStatement(
-        "return ($T) $L.$L()",
+        "return ($T) $L.$L",
         subject.nativeNameResolver.baseErrorForService(),
         VAR_INPUT,
         Dafny.datatypeDeconstructor("obj")
       )
       // If obj is ANY Exception
-      .nextControlFlow("else if ($L.$L() instanceof $T)",
+      .nextControlFlow(
+        "else if ($L.$L instanceof $T)",
         VAR_INPUT,
         Dafny.datatypeDeconstructor("obj"),
         Exception.class
       )
       .addStatement(
-        "return ($T) $L.$L()",
+        "return ($T) $L.$L",
         RuntimeException.class,
         VAR_INPUT,
         Dafny.datatypeDeconstructor("obj")
       )
       // If String is set
-      .nextControlFlow("else if ($L.$L().$L())",
+      .nextControlFlow(
+        "else if ($L.$L.$L())",
         VAR_INPUT,
         Dafny.datatypeDeconstructor("message"),
         Dafny.datatypeConstructorIs("Some")
       )
-      .addStatement("final $T message = $L($L.$L().$L())",
+      .addStatement(
+        "final $T message = $L($L.$L.$L)",
         String.class,
-        SIMPLE_CONVERSION_METHOD_FROM_SHAPE_TYPE.get(ShapeType.STRING),
+        SIMPLE_CONVERSION_METHOD_FROM_SHAPE_TYPE
+          .get(ShapeType.STRING)
+          .asNormalReference(),
         VAR_INPUT,
         Dafny.datatypeDeconstructor("message"),
         Dafny.datatypeDeconstructor("value")
@@ -563,10 +564,14 @@ public class ToNativeAwsV2 extends ToNative {
       .addStatement("return new $T(message)", RuntimeException.class)
       .endControlFlow()
       // If obj is not ANY exception and String is not set, Give Up with IllegalStateException
-      .addStatement("return new $T(String.format($S, $L))",
+      .addStatement(
+        "return new $T(String.format($S, $L))",
         IllegalStateException.class,
-        "Unknown error thrown while calling " + AwsSdkNativeV2.shortNameForService(subject.serviceShape) + ". %s",
-        VAR_INPUT)
+        "Unknown error thrown while calling " +
+        AwsSdkNativeV2.shortNameForService(subject.serviceShape) +
+        ". %s",
+        VAR_INPUT
+      )
       .build();
   }
 }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeAwsV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeAwsV2.java
@@ -520,7 +520,7 @@ public class ToNativeAwsV2 extends ToNative {
     return initializeMethodSpec(methodName, inputType, returnType)
       .addComment("While the first two cases are logically identical,")
       .addComment("there is a semantic distinction.")
-      .addComment("An unmodeled Service Error is different than a Java Heap Exhaustion error.")
+      .addComment("An un-modeled Service Error is different from a Java Heap Exhaustion error.")
       .addComment("In the future, Smithy-Dafny MAY allow for this distinction.")
       .addComment("Which would allow Dafny developers to treat the two differently.")
       // If obj is an instance of the Service's Base Exception

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/AwsSdkNativeV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/AwsSdkNativeV2.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.TitleTrait;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -60,7 +61,6 @@ public class AwsSdkNativeV2 extends Native {
     String,
     String
   > AWS_SERVICE_NAMESPACE_TO_BASE_EXCEPTION;
-  private static final Map<String, String> AWS_SERVICE_NAMESPACE_TO_SHORT_NAME;
 
   static {
     // The namespaces used as keys in these maps correspond to the Smithy namespace,
@@ -84,13 +84,6 @@ public class AwsSdkNativeV2 extends Native {
         Map.entry("com.amazonaws.kms", "KmsException"),
         Map.entry("com.amazonaws.dynamodb", "DynamoDbException"),
         Map.entry("com.amazonaws.s3", "S3Exception")
-      );
-    // These short names are used for convince in docs and errors messages.
-    AWS_SERVICE_NAMESPACE_TO_SHORT_NAME =
-      Map.ofEntries(
-        Map.entry("com.amazonaws.kms", "KMS"),
-        Map.entry("com.amazonaws.dynamodb", "DDB"),
-        Map.entry("com.amazonaws.s3", "S3")
       );
   }
 
@@ -120,16 +113,6 @@ public class AwsSdkNativeV2 extends Native {
           )
       );
     }
-    boolean knownShortName = AWS_SERVICE_NAMESPACE_TO_SHORT_NAME.containsKey(
-      namespace
-    );
-    if (!knownShortName) {
-      throw new IllegalArgumentException(
-        "Polymorph does not know this service's short name: %s".formatted(
-            namespace
-          )
-      );
-    }
   }
 
   /**
@@ -155,19 +138,14 @@ public class AwsSdkNativeV2 extends Native {
     );
   }
 
-  public static String shortNameForService(ServiceShape shape) {
+  public static String titleForService(ServiceShape shape) {
     String awsServiceSmithyNamespace = shape.toShapeId().getNamespace();
-    boolean knownShortName = AWS_SERVICE_NAMESPACE_TO_SHORT_NAME.containsKey(
-      awsServiceSmithyNamespace
-    );
-    if (!knownShortName) {
-      throw new IllegalArgumentException(
+    TitleTrait titleTrait = shape.getTrait(TitleTrait.class)
+      .orElseThrow(() -> new IllegalArgumentException(
         "Polymorph does not know this service's short name: %s".formatted(
-            awsServiceSmithyNamespace
-          )
-      );
-    }
-    return AWS_SERVICE_NAMESPACE_TO_SHORT_NAME.get(awsServiceSmithyNamespace);
+          awsServiceSmithyNamespace
+        )));
+    return titleTrait.getValue();
   }
 
   /**

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/AwsSdkNativeV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/AwsSdkNativeV2.java
@@ -13,6 +13,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.naming.DefaultNamingStrategy;
@@ -28,6 +29,7 @@ import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.StringTrait;
 import software.amazon.smithy.model.traits.TitleTrait;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.utils.StringUtils;
@@ -139,13 +141,8 @@ public class AwsSdkNativeV2 extends Native {
   }
 
   public static String titleForService(ServiceShape shape) {
-    String awsServiceSmithyNamespace = shape.toShapeId().getNamespace();
-    TitleTrait titleTrait = shape.getTrait(TitleTrait.class)
-      .orElseThrow(() -> new IllegalArgumentException(
-        "Polymorph does not know this service's short name: %s".formatted(
-          awsServiceSmithyNamespace
-        )));
-    return titleTrait.getValue();
+    Optional<TitleTrait> maybeTrait = shape.getTrait(TitleTrait.class);
+    return maybeTrait.isPresent() ? maybeTrait.get().getValue() : "AWS";
   }
 
   /**

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/AwsSdkNativeV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/AwsSdkNativeV2.java
@@ -60,10 +60,7 @@ public class AwsSdkNativeV2 extends Native {
     String,
     String
   > AWS_SERVICE_NAMESPACE_TO_BASE_EXCEPTION;
-  private static final Map<
-    String,
-    String
-    > AWS_SERVICE_NAMESPACE_TO_SHORT_NAME;
+  private static final Map<String, String> AWS_SERVICE_NAMESPACE_TO_SHORT_NAME;
 
   static {
     // The namespaces used as keys in these maps correspond to the Smithy namespace,
@@ -123,13 +120,14 @@ public class AwsSdkNativeV2 extends Native {
           )
       );
     }
-    boolean knownShortName =
-      AWS_SERVICE_NAMESPACE_TO_SHORT_NAME.containsKey(namespace);
+    boolean knownShortName = AWS_SERVICE_NAMESPACE_TO_SHORT_NAME.containsKey(
+      namespace
+    );
     if (!knownShortName) {
       throw new IllegalArgumentException(
         "Polymorph does not know this service's short name: %s".formatted(
-          namespace
-        )
+            namespace
+          )
       );
     }
   }
@@ -159,13 +157,14 @@ public class AwsSdkNativeV2 extends Native {
 
   public static String shortNameForService(ServiceShape shape) {
     String awsServiceSmithyNamespace = shape.toShapeId().getNamespace();
-    boolean knownShortName =
-      AWS_SERVICE_NAMESPACE_TO_SHORT_NAME.containsKey(awsServiceSmithyNamespace);
+    boolean knownShortName = AWS_SERVICE_NAMESPACE_TO_SHORT_NAME.containsKey(
+      awsServiceSmithyNamespace
+    );
     if (!knownShortName) {
       throw new IllegalArgumentException(
         "Polymorph does not know this service's short name: %s".formatted(
-          awsServiceSmithyNamespace
-        )
+            awsServiceSmithyNamespace
+          )
       );
     }
     return AWS_SERVICE_NAMESPACE_TO_SHORT_NAME.get(awsServiceSmithyNamespace);

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/AwsSdkNativeV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/AwsSdkNativeV2.java
@@ -60,6 +60,10 @@ public class AwsSdkNativeV2 extends Native {
     String,
     String
   > AWS_SERVICE_NAMESPACE_TO_BASE_EXCEPTION;
+  private static final Map<
+    String,
+    String
+    > AWS_SERVICE_NAMESPACE_TO_SHORT_NAME;
 
   static {
     // The namespaces used as keys in these maps correspond to the Smithy namespace,
@@ -83,6 +87,13 @@ public class AwsSdkNativeV2 extends Native {
         Map.entry("com.amazonaws.kms", "KmsException"),
         Map.entry("com.amazonaws.dynamodb", "DynamoDbException"),
         Map.entry("com.amazonaws.s3", "S3Exception")
+      );
+    // These short names are used for convince in docs and errors messages.
+    AWS_SERVICE_NAMESPACE_TO_SHORT_NAME =
+      Map.ofEntries(
+        Map.entry("com.amazonaws.kms", "KMS"),
+        Map.entry("com.amazonaws.dynamodb", "DDB"),
+        Map.entry("com.amazonaws.s3", "S3")
       );
   }
 
@@ -112,6 +123,15 @@ public class AwsSdkNativeV2 extends Native {
           )
       );
     }
+    boolean knownShortName =
+      AWS_SERVICE_NAMESPACE_TO_SHORT_NAME.containsKey(namespace);
+    if (!knownShortName) {
+      throw new IllegalArgumentException(
+        "Polymorph does not know this service's short name: %s".formatted(
+          namespace
+        )
+      );
+    }
   }
 
   /**
@@ -135,6 +155,20 @@ public class AwsSdkNativeV2 extends Native {
       packageNameForAwsSdkV2Shape(shape),
       AWS_SERVICE_NAMESPACE_TO_CLIENT_INTERFACE.get(awsServiceSmithyNamespace)
     );
+  }
+
+  public static String shortNameForService(ServiceShape shape) {
+    String awsServiceSmithyNamespace = shape.toShapeId().getNamespace();
+    boolean knownShortName =
+      AWS_SERVICE_NAMESPACE_TO_SHORT_NAME.containsKey(awsServiceSmithyNamespace);
+    if (!knownShortName) {
+      throw new IllegalArgumentException(
+        "Polymorph does not know this service's short name: %s".formatted(
+          awsServiceSmithyNamespace
+        )
+      );
+    }
+    return AWS_SERVICE_NAMESPACE_TO_SHORT_NAME.get(awsServiceSmithyNamespace);
   }
 
   /**

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/traits/NoMarkupInDocumentationTraitsValidator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/traits/NoMarkupInDocumentationTraitsValidator.java
@@ -40,7 +40,7 @@ public class NoMarkupInDocumentationTraitsValidator extends AbstractValidator {
           String docContent = trait.get().getValue();
           if (docContent.startsWith("/")) {
             events.add(
-              warning(
+              danger(
                 shape,
                 "@documentation content should not start with a '/'. " +
                 "This most likely happened because the source file is trying to use \"////...\" as a visual delimiter, " +

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/traits/NoMarkupInDocumentationTraitsValidator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/traits/NoMarkupInDocumentationTraitsValidator.java
@@ -6,8 +6,6 @@ package software.amazon.polymorph.traits;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Spliterator;
-import java.util.stream.StreamSupport;
 import org.commonmark.node.Document;
 import org.commonmark.node.Node;
 import org.commonmark.node.Paragraph;
@@ -42,7 +40,7 @@ public class NoMarkupInDocumentationTraitsValidator extends AbstractValidator {
           String docContent = trait.get().getValue();
           if (docContent.startsWith("/")) {
             events.add(
-              danger(
+              warning(
                 shape,
                 "@documentation content should not start with a '/'. " +
                 "This most likely happened because the source file is trying to use \"////...\" as a visual delimiter, " +
@@ -54,7 +52,7 @@ public class NoMarkupInDocumentationTraitsValidator extends AbstractValidator {
           Node document = parser.parse(docContent);
           if (!containsNoMarkup(document)) {
             events.add(
-              danger(
+              warning(
                 shape,
                 "smithy-dafny currently only supports @documentation with plaintext content, but this shape's documentation contains markdown."
               )

--- a/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/Constants.java
+++ b/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/Constants.java
@@ -21,7 +21,7 @@ public class Constants {
         } catch (KmsException ex) {
           return Result.create_Failure(ToDafny.Error(ex));
         } catch (Exception ex) {
-          return Result.create_Failure(Error.create_Opaque(ex.toString()));
+          return Result.create_Failure(ToDafny.Error(ex));
         }
       }
     """;
@@ -40,7 +40,7 @@ public class Constants {
         } catch (KmsException ex) {
           return Result.create_Failure(DoSomethingResponse._typeDescriptor(), Error._typeDescriptor(), ToDafny.Error(ex));
         } catch (Exception ex) {
-          return Result.create_Failure(DoSomethingResponse._typeDescriptor(), Error._typeDescriptor(), Error.create_Opaque(ex.toString()));
+          return Result.create_Failure(DoSomethingResponse._typeDescriptor(), Error._typeDescriptor(), ToDafny.Error(ex));
         }
       }
     """;
@@ -64,7 +64,7 @@ public class Constants {
         } catch (KmsException ex) {
           return Result.create_Failure(ToDafny.Error(ex));
         } catch (Exception ex) {
-          return Result.create_Failure(Error.create_Opaque(ex.toString()));
+          return Result.create_Failure(ToDafny.Error(ex));
         }
       }
     """;
@@ -82,7 +82,7 @@ public class Constants {
         } catch (KmsException ex) {
           return Result.create_Failure(dafny.Tuple0._typeDescriptor(), Error._typeDescriptor(), ToDafny.Error(ex));
         } catch (Exception ex) {
-          return Result.create_Failure(dafny.Tuple0._typeDescriptor(), Error._typeDescriptor(), Error.create_Opaque(ex.toString()));
+          return Result.create_Failure(dafny.Tuple0._typeDescriptor(), Error._typeDescriptor(), ToDafny.Error(ex));
         }
       }
     """;

--- a/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2Constants.java
+++ b/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2Constants.java
@@ -110,6 +110,11 @@ public class ToDafnyAwsV2Constants {
     public static software.amazon.cryptography.services.kms.internaldafny.types.Error Error(
             java.lang.Exception nativeValue
     ) {
+      // While this is logically identical to the other Opaque Error case,
+      // it is semantically distinct.
+      // An un-modeled Service Error is different from a Java Heap Exhaustion error.
+      // In the future, Smithy-Dafny MAY allow for this distinction.
+      // Which would allow Dafny developers to treat the two differently.
       return software.amazon.cryptography.services.kms.internaldafny.types.Error.create_Opaque(nativeValue);
     }
     """;
@@ -119,6 +124,11 @@ public class ToDafnyAwsV2Constants {
     public static software.amazon.cryptography.services.kms.internaldafny.types.Error Error(
       java.lang.Exception nativeValue
     ) {
+      // While this is logically identical to the other Opaque Error case,
+      // it is semantically distinct.
+      // An un-modeled Service Error is different from a Java Heap Exhaustion error.
+      // In the future, Smithy-Dafny MAY allow for this distinction.
+      // Which would allow Dafny developers to treat the two differently.
       return software.amazon.cryptography.services.kms.internaldafny.types.Error.create_Opaque(nativeValue);
     }
     """;

--- a/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2Constants.java
+++ b/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToDafnyAwsV2Constants.java
@@ -108,26 +108,18 @@ public class ToDafnyAwsV2Constants {
   protected static String GENERATE_CONVERT_OPAQUE_ERROR =
     """
     public static software.amazon.cryptography.services.kms.internaldafny.types.Error Error(
-            software.amazon.awssdk.services.kms.model.KmsException nativeValue
+            java.lang.Exception nativeValue
     ) {
-      Wrappers_Compile.Option<dafny.DafnySequence<? extends java.lang.Character>> message;
-      message = java.util.Objects.nonNull(nativeValue.getMessage()) ?
-            Wrappers_Compile.Option.create_Some(software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(nativeValue.getMessage()))
-          : Wrappers_Compile.Option.create_None();
-      return new software.amazon.cryptography.services.kms.internaldafny.types.Error_Opaque(message);
+      return software.amazon.cryptography.services.kms.internaldafny.types.Error.create_Opaque(nativeValue);
     }
     """;
 
   protected static String GENERATE_CONVERT_OPAQUE_ERROR_WITH_TYPE_DESCRIPTORS =
     """
     public static software.amazon.cryptography.services.kms.internaldafny.types.Error Error(
-            software.amazon.awssdk.services.kms.model.KmsException nativeValue
+      java.lang.Exception nativeValue
     ) {
-      Wrappers_Compile.Option<dafny.DafnySequence<? extends java.lang.Character>> message;
-      message = java.util.Objects.nonNull(nativeValue.getMessage()) ?
-            Wrappers_Compile.Option.create_Some(dafny.DafnySequence._typeDescriptor(dafny.TypeDescriptor.CHAR), software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(nativeValue.getMessage()))
-          : Wrappers_Compile.Option.create_None(dafny.DafnySequence._typeDescriptor(dafny.TypeDescriptor.CHAR));
-      return new software.amazon.cryptography.services.kms.internaldafny.types.Error_Opaque(message);
+      return software.amazon.cryptography.services.kms.internaldafny.types.Error.create_Opaque(nativeValue);
     }
     """;
 

--- a/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeConstants.java
+++ b/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeConstants.java
@@ -140,12 +140,18 @@ public class ToNativeConstants {
        }
 
        public static RuntimeException Error(Error_Opaque dafnyValue) {
+         // While the first two cases are logically identical,
+         // there is a semantic distinction.
+         // An un-modeled Service Error is different from a Java Heap Exhaustion error.
+         // In the future, Smithy-Dafny MAY allow for this distinction.
+         // Which would allow Dafny developers to treat the two differently.
          if (dafnyValue.dtor_obj() instanceof KmsException) {
            return (KmsException) dafnyValue.dtor_obj();
          } else if (dafnyValue.dtor_obj() instanceof Exception) {
            return (RuntimeException) dafnyValue.dtor_obj();
          } else if (dafnyValue.dtor_message().is_Some()) {
-          final String message = software.amazon.smithy.dafny.conversion.ToNative.Simple.String(dafnyValue.dtor_message().dtor_value());
+          final String suffix = dafnyValue.dtor_obj() != null ? String.format(%s, dafnyValue.dtor_obj()) : %s;;
+          final String message = software.amazon.smithy.dafny.conversion.ToNative.Simple.String(dafnyValue.dtor_message().dtor_value()) + suffix;
           return new RuntimeException(message);
          }
          return new IllegalStateException(String.format(%s, dafnyValue));
@@ -155,6 +161,8 @@ public class ToNativeConstants {
         STRING_CONVERSION,
         STRING_CONVERSION,
         STRING_CONVERSION,
-        "\"Unknown error thrown while calling KMS. %s\""
+        "\"  Unknown Object: %s\"",
+        "\"\"",
+        "\"Unknown error thrown while calling AWS. %s\""
       );
 }

--- a/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeConstants.java
+++ b/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeConstants.java
@@ -97,11 +97,17 @@ public class ToNativeConstants {
     """
     package software.amazon.cryptography.services.kms.internaldafny;
 
+     import java.lang.Exception;
+     import java.lang.IllegalStateException;
+     import java.lang.RuntimeException;
+     import java.lang.String;
      import software.amazon.awssdk.services.kms.KmsClient;
      import software.amazon.awssdk.services.kms.model.DependencyTimeoutException;
      import software.amazon.awssdk.services.kms.model.DoSomethingRequest;
      import software.amazon.awssdk.services.kms.model.DoSomethingResponse;
+     import software.amazon.awssdk.services.kms.model.KmsException;
      import software.amazon.cryptography.services.kms.internaldafny.types.Error_DependencyTimeoutException;
+     import software.amazon.cryptography.services.kms.internaldafny.types.Error_Opaque;
      import software.amazon.cryptography.services.kms.internaldafny.types.IKeyManagementServiceClient;
 
      public class ToNative {
@@ -132,6 +138,23 @@ public class ToNativeConstants {
        public static KmsClient KeyManagementService(IKeyManagementServiceClient dafnyValue) {
            return ((Shim) dafnyValue).impl();
        }
+
+       public static RuntimeException Error(Error_Opaque dafnyValue) {
+         if (dafnyValue.dtor_obj() instanceof KmsException) {
+           return (KmsException) dafnyValue.dtor_obj();
+         } else if (dafnyValue.dtor_obj() instanceof Exception) {
+           return (RuntimeException) dafnyValue.dtor_obj();
+         } else if (dafnyValue.dtor_message().is_Some()) {
+          final String message = software.amazon.smithy.dafny.conversion.ToNative.Simple.String(dafnyValue.dtor_message().dtor_value());
+          return new RuntimeException(message);
+         }
+         return new IllegalStateException(String.format(%s, dafnyValue));
+       }
      }
-    """.formatted(STRING_CONVERSION, STRING_CONVERSION, STRING_CONVERSION);
+    """.formatted(
+        STRING_CONVERSION,
+        STRING_CONVERSION,
+        STRING_CONVERSION,
+        "\"Unknown error thrown while calling KMS. %s\""
+      );
 }


### PR DESCRIPTION
*Issue #, if available:*

SDK Exceptions that are not modeled by a service are treated as Opaque.
In Java, this lead to an IllegalStateException, instead of a NotAuthorized Exception.
This PR refactors the generated Java to capture un-modeled SDK exceptions,
such as NotAuthorized,
in the Opaque Error Types `obj` field,
and un-wrap them.

*Description of changes:*
- The Above
- Treat Markdown usage in documentation as warning instead of a danger; otherwise, current consumers (DB-ESDK) cannot pick up the latest Smithy-Dafny

Replaces https://github.com/smithy-lang/smithy-dafny/pull/464


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
