### PR TITLE
fix(Java-SDK): dtor_message is never safe for Opaque

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeAwsV2.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeAwsV2.java
@@ -553,33 +553,6 @@ public class ToNativeAwsV2 extends ToNative {
         VAR_INPUT,
         Dafny.datatypeDeconstructor("obj")
       )
-      // If String is set
-      .nextControlFlow(
-        "else if ($L.$L.$L())",
-        VAR_INPUT,
-        Dafny.datatypeDeconstructor("message"),
-        Dafny.datatypeConstructorIs("Some")
-      )
-      // if not null, stringify the object
-      .addStatement(
-        "final String suffix = $L.dtor_obj() != null ? String.format($S, $L.dtor_obj()) : $S;",
-        VAR_INPUT,
-        "  Unknown Object: %s",
-        VAR_INPUT,
-        ""
-      )
-      // Convert String from Dafny
-      .addStatement(
-        "final $T message = $L($L.$L.$L) + suffix",
-        String.class,
-        SIMPLE_CONVERSION_METHOD_FROM_SHAPE_TYPE
-          .get(ShapeType.STRING)
-          .asNormalReference(),
-        VAR_INPUT,
-        Dafny.datatypeDeconstructor("message"),
-        Dafny.datatypeDeconstructor("value")
-      )
-      .addStatement("return new $T(message)", RuntimeException.class)
       .endControlFlow()
       // If obj is not ANY exception and String is not set, Give Up with IllegalStateException
       .addStatement(

--- a/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeConstants.java
+++ b/codegen/smithy-dafny-codegen/src/test/java/software/amazon/polymorph/smithyjava/generator/awssdk/v2/ToNativeConstants.java
@@ -100,7 +100,6 @@ public class ToNativeConstants {
      import java.lang.Exception;
      import java.lang.IllegalStateException;
      import java.lang.RuntimeException;
-     import java.lang.String;
      import software.amazon.awssdk.services.kms.KmsClient;
      import software.amazon.awssdk.services.kms.model.DependencyTimeoutException;
      import software.amazon.awssdk.services.kms.model.DoSomethingRequest;
@@ -149,10 +148,6 @@ public class ToNativeConstants {
            return (KmsException) dafnyValue.dtor_obj();
          } else if (dafnyValue.dtor_obj() instanceof Exception) {
            return (RuntimeException) dafnyValue.dtor_obj();
-         } else if (dafnyValue.dtor_message().is_Some()) {
-          final String suffix = dafnyValue.dtor_obj() != null ? String.format(%s, dafnyValue.dtor_obj()) : %s;;
-          final String message = software.amazon.smithy.dafny.conversion.ToNative.Simple.String(dafnyValue.dtor_message().dtor_value()) + suffix;
-          return new RuntimeException(message);
          }
          return new IllegalStateException(String.format(%s, dafnyValue));
        }
@@ -161,8 +156,6 @@ public class ToNativeConstants {
         STRING_CONVERSION,
         STRING_CONVERSION,
         STRING_CONVERSION,
-        "\"  Unknown Object: %s\"",
-        "\"\"",
         "\"Unknown error thrown while calling AWS. %s\""
       );
 }


### PR DESCRIPTION
*Issue #, if available:*

> Dafny’s compiled Java is very dangerous to use outside of Dafny compiled Java; the best advice we can give is to always write code as if you were the Dafny Compiler. For example, when working with a Datatype, only call a type’s deconstructor’s member if you KNOW the type is that deconstructor. Dafny’s compiled Java does NOT make such operations safe in any way.

The issue here is that we are calling a member of a deconstructor on an instance we KNOW is NOT a deconstructor that has the member. 

As such, calling `dtor_message` on `Error_Opaque` would lead to a Cast Exception. 

The fix is to not call it. 

*Description of changes:*
- Remove `dtor_message` block from Opaque_Error ToNative conversion method

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
