### PR TITLE
chore: apply patches verbosely in CodegenEngine

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -742,7 +742,7 @@ public class CodegenEngine {
           if (dafnyVersion.compareTo(patchFilePair.getKey()) >= 0) {
             Path patchFile = patchFilePair.getValue();
             LOGGER.info("Applying patch file {}", patchFile);
-            runCommand(libraryRoot, "git", "apply", patchFile.toString());
+            runCommand(libraryRoot, "git", "apply", "-v", patchFile.toString());
             return;
           }
         }


### PR DESCRIPTION
This should make it easier to diagnose CI failures where patches mysteriously fail to apply.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
