### PR TITLE
fix: Spurious error when colons are in file paths on Windows

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/IOUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/IOUtils.java
@@ -90,16 +90,17 @@ public class IOUtils {
     String templateOutputPath,
     Map<String, String> parameters
   ) {
+    if (templatePath.contains(":")) {
+      throw new IllegalArgumentException(
+              "':' cannot be used in template paths since they are not allowed on Windows. Use ';' instead."
+      );
+    }
+
     String content = IoUtils.readUtf8Resource(
       klass,
       "/templates/" + templatePath
     );
 
-    if (templateOutputPath.contains(":")) {
-      throw new IllegalArgumentException(
-        "':' cannot be used in template paths since they are not allowed on Windows. Use ';' instead."
-      );
-    }
     templateOutputPath = templateOutputPath.replace(';', ':');
 
     content = evalTemplate(content, parameters);

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/IOUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/IOUtils.java
@@ -92,7 +92,7 @@ public class IOUtils {
   ) {
     if (templatePath.contains(":")) {
       throw new IllegalArgumentException(
-              "':' cannot be used in template paths since they are not allowed on Windows. Use ';' instead."
+        "':' cannot be used in template paths since they are not allowed on Windows. Use ';' instead."
       );
     }
 


### PR DESCRIPTION
*Description of changes:*
Shows up in nightly builds of downstream projects, e.g. https://github.com/aws/aws-database-encryption-sdk-dynamodb/actions/runs/10475566277/job/29021782217

I attempted to run more workflows on multiple platforms to catch these kinds of errors, but unfortunately the testing locks up on Windows for some reason: https://github.com/smithy-lang/smithy-dafny/actions/runs/10461177137/job/28968995490?pr=524

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
