### PR TITLE
feat: Support reference types in Union for operations

### DIFF
--- a/TestModels/Resource/Model/resources.smithy
+++ b/TestModels/Resource/Model/resources.smithy
@@ -9,7 +9,7 @@ namespace simple.resources
 service SimpleResources {
   version: "2021-11-01",
   resources: [],
-  operations: [ GetResources ],
+  operations: [ GetResources, GetMutableResources ],
   errors: [ SimpleResourcesException ],
 }
 
@@ -26,6 +26,11 @@ operation GetResources {
   output: GetResourcesOutput,
 }
 
+operation GetMutableResources {
+  input: GetMutableResourcesInput,
+  output: GetMutableResourcesOutput,
+}
+
 structure GetResourcesInput {
   value: String
 }
@@ -33,6 +38,15 @@ structure GetResourcesInput {
 structure GetResourcesOutput {
   @required
   output: SimpleResourceReference
+}
+
+structure GetMutableResourcesInput {
+  value: String
+}
+
+structure GetMutableResourcesOutput {
+  @required
+  output: MutableResourceReference
 }
 
 @aws.polymorph#reference(resource: SimpleResource)
@@ -83,3 +97,33 @@ structure SimpleResourcesException {
   message: String,
 }
 
+
+@aws.polymorph#reference(resource: MutableResource)
+structure MutableResourceReference {}
+
+@smithy.api#suppress(["MutableLocalStateTrait"])
+@aws.polymorph#mutableLocalState
+resource MutableResource {
+  operations: [ GetMutableResourceData ]
+}
+
+operation GetMutableResourceData {
+  input: GetMutableResourceDataInput,
+  output: GetMutableResourceDataOutput,
+}
+
+structure GetMutableResourceDataInput {
+  blobValue: Blob,
+  booleanValue: Boolean,
+  stringValue: String,
+  integerValue: Integer,
+  longValue: Long,
+}
+
+structure GetMutableResourceDataOutput {
+  blobValue: Blob,
+  booleanValue: Boolean,
+  stringValue: String,
+  integerValue: Integer,
+  longValue: Long,
+}

--- a/TestModels/Resource/src/MutableResource.dfy
+++ b/TestModels/Resource/src/MutableResource.dfy
@@ -1,0 +1,117 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+include "../Model/SimpleResourcesTypes.dfy"
+
+module MutableResource {
+  import opened StandardLibrary
+  import Wrappers
+  import Types = SimpleResourcesTypes
+
+  // The default export set
+  export
+    // Revealing a class will reveal constructor and extends
+    reveals
+      MutableResource
+    provides
+      // Because `extends Types.IMutableResource` is revealed
+      // all the things that need to be implement from the trait
+      // need to be visible..
+      // These are provided so that the spec is not visible.
+      MutableResource.GetMutableResourceData',
+      MutableResource.ValidState,
+      MutableResource.InternalValidState,
+      MutableResource.GetMutableResourceDataEnsuresPublicly,
+      // These are values that need to be visible
+      // because they are in the spec of the constructor.
+      MutableResource.value,
+      MutableResource.name,
+      // Need to provide the dependent modules
+      Types,
+      Wrappers
+
+  // This is for testing
+  export ForTesting reveals *
+
+  class MutableResource extends Types.IMutableResource
+    {
+    predicate ValidState()
+      ensures ValidState() ==> History in Modifies && this in Modifies
+    {
+      && History in Modifies
+      && this in Modifies
+    }
+
+    predicate InternalValidState()
+      reads this`InternalModifies, InternalModifies
+      ensures InternalValidState() ==> History !in InternalModifies
+    {
+      && History !in InternalModifies
+      && this in InternalModifies
+    }
+
+    const name: string
+    const value: Wrappers.Option<string>
+
+    // Some internal state that we modify!
+    var MyInternalState: nat
+
+    constructor (
+      value: Wrappers.Option<string>,
+      name: string
+    )
+      requires |name| > 0
+      ensures this.value == value
+      ensures this.name == name
+      ensures ValidState() && fresh(History) && fresh(Modifies)
+      ensures InternalValidState()
+    {
+      this.value := value;
+      this.name := name;
+      MyInternalState := 0;
+
+      History := new Types.IMutableResourceCallHistory();
+      Modifies := {History, this};
+      InternalModifies := {this};
+
+    }
+
+    predicate GetMutableResourceDataEnsuresPublicly(
+      input: Types.GetMutableResourceDataInput,
+      output: Wrappers.Result<Types.GetMutableResourceDataOutput, Types.Error>
+    ) {true}
+
+    method GetMutableResourceData'(
+      input: Types.GetMutableResourceDataInput
+    ) returns (
+        output: Wrappers.Result<Types.GetMutableResourceDataOutput, Types.Error>
+      )
+      requires
+        && InternalValidState()
+      modifies InternalModifies
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases InternalModifies
+      ensures
+        && InternalValidState()
+      ensures GetMutableResourceDataEnsuresPublicly(input, output)
+      ensures unchanged(History)
+    {
+
+      // Yes, we can indeed modify our state!
+      MyInternalState := MyInternalState + 1;
+
+      var rtnString: string := if input.stringValue.Some? then
+        this.name + " " + input.stringValue.value
+      else
+        this.name;
+      var rtn: Types.GetMutableResourceDataOutput := Types.GetMutableResourceDataOutput(
+        blobValue := input.blobValue,
+        booleanValue := input.booleanValue,
+        stringValue := Wrappers.Some(rtnString),
+        integerValue := input.integerValue,
+        longValue := input.longValue
+      );
+      return Wrappers.Success(rtn);
+    }
+  }
+}

--- a/TestModels/Resource/src/SimpleResourcesOperations.dfy
+++ b/TestModels/Resource/src/SimpleResourcesOperations.dfy
@@ -3,16 +3,18 @@
 
 include "../Model/SimpleResourcesTypes.dfy"
 include "./SimpleResource.dfy"
+include "./MutableResource.dfy"
 
 module SimpleResourcesOperations refines AbstractSimpleResourcesOperations {
   import SimpleResource
+  import MutableResource
 
   datatype Config = Config(
     nameonly name: string
   )
 
   type InternalConfig = Config
-    
+
   predicate method ValidInternalConfig?(config: InternalConfig)
   {
     && |config.name| > 0
@@ -20,7 +22,7 @@ module SimpleResourcesOperations refines AbstractSimpleResourcesOperations {
 
   function ModifiesInternalConfig(config: InternalConfig): set<object>
   {{}}
-  
+
   predicate GetResourcesEnsuresPublicly(
     input: GetResourcesInput,
     output: Result<GetResourcesOutput, Error>
@@ -30,8 +32,8 @@ module SimpleResourcesOperations refines AbstractSimpleResourcesOperations {
     config: InternalConfig,
     input: GetResourcesInput
   ) returns (
-    output: Result<GetResourcesOutput, Error>
-  )
+      output: Result<GetResourcesOutput, Error>
+    )
     ensures output.Success? ==> output.value.output.ValidState()
   {
     var resource := new SimpleResource.SimpleResource(
@@ -41,7 +43,23 @@ module SimpleResourcesOperations refines AbstractSimpleResourcesOperations {
     var result: GetResourcesOutput := GetResourcesOutput(
       output := resource
     );
-    return Success(result);  
+    return Success(result);
   }
-  
+
+  predicate GetMutableResourcesEnsuresPublicly(input: GetMutableResourcesInput , output: Result<GetMutableResourcesOutput, Error>)
+  {true}
+
+  method GetMutableResources ( config: InternalConfig , input: GetMutableResourcesInput )
+    returns (output: Result<GetMutableResourcesOutput, Error>)
+  {
+    var resource := new MutableResource.MutableResource(
+      input.value,
+      config.name
+    );
+    var result: GetMutableResourcesOutput := GetMutableResourcesOutput(
+      output := resource
+    );
+    return Success(result);
+  }
+
 }

--- a/TestModels/Resource/test/Helpers.dfy
+++ b/TestModels/Resource/test/Helpers.dfy
@@ -52,4 +52,50 @@ module Helpers {
     expect Some(1) == output.integerValue;
     expect Some(1) == output.longValue; 
   }
+
+  function method allMutableNone(): Types.GetMutableResourceDataInput
+  {
+   Types.GetMutableResourceDataInput(
+      blobValue := None,
+      booleanValue := None,
+      stringValue := None,
+      integerValue := None,
+      longValue := None
+    )
+  }
+
+  method checkMutableMostNone(
+    name: string,
+    output: Types.GetMutableResourceDataOutput
+  )
+  {
+    expect Some(name) == output.stringValue;
+    expect None == output.blobValue;
+    expect None == output.booleanValue;
+    expect None == output.integerValue;
+    expect None == output.longValue; 
+  }
+
+  function method allMutableSome(): Types.GetMutableResourceDataInput
+  {
+   Types.GetMutableResourceDataInput(
+      blobValue := Some([1]),
+      booleanValue := Some(true),
+      stringValue := Some("Some"),
+      integerValue := Some(1),
+      longValue := Some(1)
+    )
+  }
+
+  method checkMutableSome(
+    name: string,
+    output: Types.GetMutableResourceDataOutput
+  )
+  {
+    expect Some(name + " Some") == output.stringValue;
+    expect Some([1]) == output.blobValue;
+    expect Some(true) == output.booleanValue;
+    expect Some(1) == output.integerValue;
+    expect Some(1) == output.longValue; 
+  }
 }

--- a/TestModels/Resource/test/SimpleResourcesTest.dfy
+++ b/TestModels/Resource/test/SimpleResourcesTest.dfy
@@ -3,6 +3,7 @@
 
 include "../src/Index.dfy"
 include "./Helpers.dfy"
+include "../src/MutableResource.dfy"
 
 module SimpleResourcesTest {
   import SimpleResources
@@ -16,8 +17,8 @@ module SimpleResourcesTest {
   )
     requires resource.ValidState()
     modifies resource.Modifies
-    ensures resource.ValidState()    
-  { 
+    ensures resource.ValidState()
+  {
     var input := allNone();
     var result :- expect resource.GetResourceData(input);
     checkMostNone(config.name, result);
@@ -29,19 +30,19 @@ module SimpleResourcesTest {
   )
     requires resource.ValidState()
     modifies resource.Modifies
-    ensures resource.ValidState()    
-  { 
+    ensures resource.ValidState()
+  {
     var input := allSome();
     var output :- expect resource.GetResourceData(input);
     checkSome(config.name, output);
-  }  
+  }
 
   method TestGetResources(
     config: Types.SimpleResourcesConfig,
     client: Types.ISimpleResourcesClient
   ) returns (
-    resource: Types.ISimpleResource
-  )
+      resource: Types.ISimpleResource
+    )
     requires client.ValidState()
     modifies client.Modifies
     ensures client.ValidState()
@@ -55,13 +56,17 @@ module SimpleResourcesTest {
     var output :- expect client.GetResources(input);
     return output.output;
   }
-  
+
   method TestClient(config: Types.SimpleResourcesConfig)
   {
     var client :- expect SimpleResources.SimpleResources(config);
     var resource := TestGetResources(config, client);
     TestNoneGetData(config, resource);
     TestSomeGetData(config, resource);
+
+    var mutableResource := TestGetMutableResources(config, client);
+    TestMutableNoneGetData(config, mutableResource);
+    TestMutableSomeGetData(config, mutableResource);
   }
 
   method {:test} TestDefaultConfig()
@@ -73,5 +78,74 @@ module SimpleResourcesTest {
   {
     TestClient(Types.SimpleResourcesConfig(name := "Dafny"));
   }
-  
+
+  // This is breaking encapsulation 
+  // this is not something for public clients to do.
+  // this is to access the internal state and verify that specific things are true/false.
+  import MutableResource = MutableResource`ForTesting
+
+  method TestMutableNoneGetData(
+    config: Types.SimpleResourcesConfig,
+    resource: Types.IMutableResource
+  )
+    requires resource.ValidState()
+    modifies resource.Modifies
+    ensures resource.ValidState()
+  {
+    var input := allMutableNone();
+
+    expect resource is MutableResource.MutableResource;
+    var test:MutableResource.MutableResource := resource;
+
+    var before := test.MyInternalState;
+
+    var result :- expect resource.GetMutableResourceData(input);
+    checkMutableMostNone(config.name, result);
+
+    // This sort of things SHOULD NOT be able to be proved.
+    // Dafny does not have a way to say `assert something is impossible to prove;`
+    // assert before != test.MyInternalState;
+
+    // This is assuming that everything verifies
+    // Given that, the Dafny in MutableResource
+    // was able to prove MutableResource,
+    // and the Types file was correct
+    // This is a basic check to make sure
+    // that this simplified separated class works.
+    expect before + 1 == test.MyInternalState;
+  }
+
+  method TestMutableSomeGetData(
+    config: Types.SimpleResourcesConfig,
+    resource: Types.IMutableResource
+  )
+    requires resource.ValidState()
+    modifies resource.Modifies
+    ensures resource.ValidState()
+  {
+    var input := allMutableSome();
+    var output :- expect resource.GetMutableResourceData(input);
+    checkMutableSome(config.name, output);
+  }
+
+  method TestGetMutableResources(
+    config: Types.SimpleResourcesConfig,
+    client: Types.ISimpleResourcesClient
+  ) returns (
+      resource: Types.IMutableResource
+    )
+    requires client.ValidState()
+    modifies client.Modifies
+    ensures client.ValidState()
+    ensures resource.Modifies !! {client.History}
+    ensures fresh(resource.Modifies - client.Modifies - {client.History} )
+    ensures resource.ValidState() && fresh(resource)
+  {
+    var input := Types.GetMutableResourcesInput(
+      value := Some("Test")
+    );
+    var output :- expect client.GetMutableResources(input);
+    return output.output;
+  }
+
 }

--- a/TestModels/Union/Model/union.smithy
+++ b/TestModels/Union/Model/union.smithy
@@ -47,3 +47,42 @@ structure GetKnownValueUnionOutput {
 union KnownValueUnion {
     Value: Integer
 }
+
+// Resources are reference types
+// This means that Dafny needs a little help
+// to reason about their possible state.
+union WithReferenceType {
+  Ref: SimpleResourceReference,
+  // A non-reference type is added to the union
+  // because not all unions may have
+  // all elements be a reference
+  NotRef: Integer,
+}
+
+@aws.polymorph#reference(resource: SimpleResource)
+structure SimpleResourceReference {}
+
+resource SimpleResource {
+  operations: [ GetResourceData ]
+}
+
+operation GetResourceData {
+  input: GetResourceDataInput,
+  output: GetResourceDataOutput,
+}
+
+structure GetResourceDataInput {
+  @required
+  requiredUnion: WithReferenceType,
+
+  optionUnion: WithReferenceType,
+}
+
+structure GetResourceDataOutput {
+  @required
+  requiredUnion: WithReferenceType,
+
+  optionUnion: WithReferenceType,
+}
+
+

--- a/TestModels/Union/src/SimpleResource.dfy
+++ b/TestModels/Union/src/SimpleResource.dfy
@@ -1,0 +1,135 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+include "../Model/SimpleUnionTypes.dfy"
+
+module SimpleResource {
+  import opened Types = SimpleUnionTypes
+  import opened Wrappers
+
+  /*
+    It is hard to prove things about mutable state.
+    Smithy-Dafny attempts to help with this
+    by adding the requires, ensures, and modifies clauses.
+    However making sure that this is generated correctly
+    can be complicated and tests are a very good idea.
+
+    Further it is possible to generate a Dafny specification
+    that can never be used.
+    So this file is to make sure that the code is generates
+    and verified in both the Dafny types file,
+    and in an implementation.
+    As well as verify at least one implementation is callable.
+  */
+
+  class SomeResource
+    extends Types.ISimpleResource
+    {
+
+    predicate ValidState()
+      ensures ValidState() ==> History in Modifies
+    {
+      && History in Modifies
+    }
+
+    predicate GetResourceDataEnsuresPublicly(input: GetResourceDataInput , output: Result<GetResourceDataOutput, Error>)
+    {
+      true
+    }
+
+    constructor() 
+      ensures fresh(Modifies)
+      ensures ValidState()
+    {
+      History := new Types.ISimpleResourceCallHistory();
+      Modifies := {History};
+    }
+
+    method GetResourceData' ( input: GetResourceDataInput )
+      returns (output: Result<GetResourceDataOutput, Error>)
+      requires
+        && ValidState()
+        && (match input.requiredUnion
+            case Ref(o) =>
+              && o.ValidState()
+              && o.Modifies !! {History}
+
+
+            case _ => true)
+        && ( input.optionUnion.Some?
+             ==> match input.optionUnion.value
+                 case Ref(o) =>
+                   && o.ValidState()
+                   && o.Modifies !! {History}
+
+
+                 case _ => true)
+      modifies Modifies - {History} ,
+               (match input.requiredUnion
+                case Ref(o) => o.Modifies
+                case _ => {}) ,
+               (if input.optionUnion.Some? then match input.optionUnion.value
+                                                case Ref(o) => o.Modifies
+                                                case _ => {}
+                else {})
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History} ,
+                (match input.requiredUnion
+                 case Ref(o) => o.Modifies
+                 case _ => {}) ,
+                (if input.optionUnion.Some? then match input.optionUnion.value
+                                                 case Ref(o) => o.Modifies
+                                                 case _ => {}
+                 else {})
+      ensures
+        && ValidState()
+        && ( output.Success? ==>
+               && (match output.value.requiredUnion
+                   case Ref(o) =>
+                     && o.ValidState()
+                     && o.Modifies !! {History}
+                     && fresh(o)
+                     && fresh ( o.Modifies - Modifies - {History} - (match input.requiredUnion
+                                                                     case Ref(o) => o.Modifies
+                                                                     case _ => {}) - (if input.optionUnion.Some? then match input.optionUnion.value
+                                                                                                                      case Ref(o) => o.Modifies
+                                                                                                                      case _ => {}
+                                                                                      else {}) )
+                   case _ => true)
+               && ( output.value.optionUnion.Some?
+                    ==> match output.value.optionUnion.value
+                        case Ref(o) =>
+                          && o.ValidState()
+                          && o.Modifies !! {History}
+                          && fresh(o)
+                          && fresh ( o.Modifies - Modifies - {History} - (match input.requiredUnion
+                                                                          case Ref(o) => o.Modifies
+                                                                          case _ => {}) - (if input.optionUnion.Some? then match input.optionUnion.value
+                                                                                                                           case Ref(o) => o.Modifies
+                                                                                                                           case _ => {}
+                                                                                           else {}) )
+                        case _ => true) )
+      ensures GetResourceDataEnsuresPublicly(input, output)
+      ensures unchanged(History)
+
+    {
+
+      if input.requiredUnion.Ref? {
+        var tmp :- input.requiredUnion.Ref.GetResourceData(Types.GetResourceDataInput(
+          requiredUnion := Types.NotRef(32)
+        ));
+      } else if input.optionUnion.Some? && input.optionUnion.value.Ref? {
+        var tmp :- input.optionUnion.value.Ref.GetResourceData(Types.GetResourceDataInput(
+          requiredUnion := Types.NotRef(32)
+        ));
+      } 
+
+      var freshResource := new SomeResource();
+
+      output := Success(Types.GetResourceDataOutput(
+        requiredUnion := Types.Ref(freshResource),
+        optionUnion := Some(Types.Ref(freshResource))
+      ));
+    }
+  }
+
+}

--- a/TestModels/Union/test/SimpleUnionImplTest.dfy
+++ b/TestModels/Union/test/SimpleUnionImplTest.dfy
@@ -1,9 +1,11 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 include "../src/Index.dfy"
+include "../src/SimpleResource.dfy"
 
 module SimpleUnionImplTest {
     import SimpleUnion
+    import SimpleResource
     import opened SimpleUnionTypes
     import opened Wrappers
     method{:test} TestUnion(){
@@ -50,4 +52,21 @@ module SimpleUnionImplTest {
         expect ret.union.value.Value?;
         expect ret.union.value.Value == 10;
     }
+
+    // This tests is to support Dafny features.
+    // So it does not need to do a lot
+    // See the resource for more details.
+    method {:test} TestUnionWithResource() {
+
+      var ref := new SimpleResource.SomeResource();
+      var inputRef := new SimpleResource.SomeResource();
+
+      var output :- expect ref.GetResourceData(
+        GetResourceDataInput(
+          requiredUnion := Ref(inputRef),
+          optionUnion := Some(Ref(inputRef))
+        )
+      );
+    }
+
 }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyApiCodegen.java
@@ -1167,7 +1167,15 @@ public class DafnyApiCodegen {
       (target.getType() == ShapeType.LIST &&
         model
           .expectShape(target.asListShape().get().getMember().getTarget())
-          .hasTrait(ReferenceTrait.class))
+          .hasTrait(ReferenceTrait.class)) ||
+      // If the member is a UNION
+      (target.getType() == ShapeType.UNION &&
+        target
+          .asUnionShape()
+          .get()
+          .members()
+          .stream()
+          .anyMatch(this::OnlyReferenceStructures))
     );
   }
 
@@ -1196,8 +1204,11 @@ public class DafnyApiCodegen {
       throw new IllegalStateException("Member not on operation");
     }
 
-    final boolean isList =
-      model.expectShape(member.getTarget()).getType() == ShapeType.LIST;
+    final Shape memberShape = model.expectShape(member.getTarget());
+    // These options are disjoint.
+    // That means that a shape can not be both a list and a union.
+    final boolean isList = memberShape.getType() == ShapeType.LIST;
+    final boolean isUnion = memberShape.getType() == ShapeType.UNION;
     // This is tricky, given where we are, there MUST be an output shape.
     // If this output is @positional,
     // then we need to drop the member name
@@ -1216,7 +1227,7 @@ public class DafnyApiCodegen {
     // then we can not prove freshness of these items
     final TokenTree removeInputs = direction == InputOutput.OUTPUT
       ? OperationModifiesInputs(operationShape.getId(), implementationType)
-        .prependSeperated(Token.of("-"))
+        .prependSeperated(Token.of("\n -"))
       : TokenTree.empty();
 
     // We need to do 3 things here
@@ -1225,7 +1236,7 @@ public class DafnyApiCodegen {
     // This second claim is to ensure that state can be reasoned about
     // third, everything MUST be fresh. This will make using things _much_ simpler
     // you may hate me now, but you will come around
-    if (member.isRequired() && !isList) {
+    if (member.isRequired() && !isList && !isUnion) {
       // Required single item
       return TokenTree
         .of(
@@ -1253,7 +1264,7 @@ public class DafnyApiCodegen {
         )
         .dropEmpty()
         .prependSeperated(Token.of("\n &&"));
-    } else if (!member.isRequired() && !isList) {
+    } else if (!member.isRequired() && !isList && !isUnion) {
       // Optional single item
       return TokenTree
         .of(
@@ -1312,9 +1323,108 @@ public class DafnyApiCodegen {
         )
         .dropEmpty()
         .lineSeparated();
+    } else if (isUnion && member.isRequired()) {
+      // Required Union
+
+      final UnionShape union = memberShape.asUnionShape().get();
+
+      return TokenTree
+        .of(
+          TokenTree.of("\n && ("),
+          OperationMemberValidState_UnionHelper(
+            union,
+            varName,
+            isOutput,
+            removeInputs,
+            implementationType
+          )
+        )
+        .append(Token.of(")"));
+    } else if (isUnion && !member.isRequired()) {
+      // Optional Union
+
+      final UnionShape union = memberShape.asUnionShape().get();
+
+      return TokenTree
+        .of(
+          TokenTree.of("\n && ( %1$s.Some? \n ==>".formatted(varName)),
+          OperationMemberValidState_UnionHelper(
+            union,
+            varName + ".value",
+            isOutput,
+            removeInputs,
+            implementationType
+          )
+        )
+        .append(Token.of(")"));
     } else {
       throw new IllegalStateException("Unsupported shape type");
     }
+  }
+
+  private TokenTree OperationMemberValidState_UnionHelper(
+    final UnionShape union,
+    final String varName,
+    final boolean isOutput,
+    final TokenTree removeInputs,
+    final ImplementationType implementationType
+  ) {
+    final String validStateInvariantName =
+      nameResolver.validStateInvariantName();
+    return TokenTree
+      .of(
+        union
+          .members()
+          .stream()
+          .filter(this::OnlyReferenceStructures)
+          .map(s ->
+            TokenTree
+              .of(
+                TokenTree.of(
+                  "|| ( %1$s.%2$s? ==>".formatted(varName, s.getMemberName())
+                ),
+                TokenTree.of(
+                  "&& %1$s.%2$s.%3$s()".formatted(
+                      varName,
+                      s.getMemberName(),
+                      validStateInvariantName
+                    )
+                ),
+                TokenTree.of(
+                  // If we are putting the method in an abstract module
+                  // then there is no object to share state with
+                  !implementationType.equals(ImplementationType.ABSTRACT)
+                    ? "&& %1$s.%2$s.Modifies !! {%4$s}".formatted(
+                        varName,
+                        s.getMemberName(),
+                        validStateInvariantName,
+                        nameResolver.callHistoryFieldName()
+                      )
+                    : ""
+                ),
+                isOutput
+                  ? TokenTree.of(
+                    Token.of("&& fresh(%1$s)".formatted(varName)),
+                    Token
+                      .of("&& fresh")
+                      .append(
+                        TokenTree
+                          .of(
+                            Token.of("%1$s.Modifies".formatted(varName)),
+                            removeInputs
+                          )
+                          .parenthesized()
+                      )
+                  )
+                  : TokenTree.empty(),
+                Token.of(")")
+              )
+              .flatten()
+              .dropEmpty()
+              .lineSeparated()
+          )
+      )
+      .lineSeparated();
   }
 
   private TokenTree OperationModifiesInputs(
@@ -1369,8 +1479,11 @@ public class DafnyApiCodegen {
       throw new IllegalStateException("Member not on operation");
     }
 
-    final boolean isList =
-      model.expectShape(member.getTarget()).getType() == ShapeType.LIST;
+    final Shape memberShape = model.expectShape(member.getTarget());
+    // These options are disjoint.
+    // That means that a shape can not be both a list and a union.
+    final boolean isList = memberShape.getType() == ShapeType.LIST;
+    final boolean isUnion = memberShape.getType() == ShapeType.UNION;
     // This is tricky, given where we are, there MUST be an output shape.
     // If this output is @positional,
     // then we need to drop the member name
@@ -1389,10 +1502,10 @@ public class DafnyApiCodegen {
     // The decreases clause is because
     // Dafny will skip type parameters
     // when generating a default decreases clause.
-    if (member.isRequired() && !isList) {
+    if (member.isRequired() && !isList && !isUnion) {
       // Required single item
       return TokenTree.of("%s.Modifies".formatted(varName));
-    } else if (!member.isRequired() && !isList) {
+    } else if (!member.isRequired() && !isList && !isUnion) {
       // Optional single item
       return TokenTree
         .of(
@@ -1421,9 +1534,80 @@ public class DafnyApiCodegen {
             )
         )
         .lineSeparated();
+    } else if (isUnion && member.isRequired()) {
+      // Required union item
+      // This is very annoying
+      // the way that the decreases clause work
+      // it needs to delimit this list of values
+      // It treads each return as an individual TokenTree
+      // Without the toString, this will be broken up in the wrong way :(
+      return TokenTree.of(
+        TokenTree
+          .of(
+            TokenTree.of("("),
+            OperationMemberModifies_UnionHelper(
+              memberShape.asUnionShape().get(),
+              varName
+            ),
+            TokenTree.of(")")
+          )
+          .lineSeparated()
+          .toString()
+      );
+    } else if (isUnion && !member.isRequired()) {
+      // Optional union item
+      // This is very annoying
+      // the way that the decreases clause work
+      // it needs to delimit this list of values
+      // It treads each return as an individual TokenTree
+      // Without the toString, this will be broken up in the wrong way :(
+
+      return TokenTree.of(
+        TokenTree
+          .of(
+            TokenTree.of("(if %1$s.Some? then".formatted(varName)),
+            OperationMemberModifies_UnionHelper(
+              memberShape.asUnionShape().get(),
+              varName + ".value"
+            ),
+            TokenTree.of("else {})")
+          )
+          .lineSeparated()
+          .toString()
+      );
     } else {
       throw new IllegalStateException("Unsupported shape type");
     }
+  }
+
+  private TokenTree OperationMemberModifies_UnionHelper(
+    final UnionShape union,
+    final String varName
+  ) {
+    return TokenTree
+      .of(
+        union
+          .members()
+          .stream()
+          // Only reference structures can hold state
+          .filter(this::OnlyReferenceStructures)
+          .map(s ->
+            TokenTree
+              .of(
+                TokenTree.of(
+                  "if %1$s.%2$s? then".formatted(varName, s.getMemberName())
+                ),
+                TokenTree.of(
+                  "%1$s.%2$s.Modifies".formatted(varName, s.getMemberName())
+                ),
+                TokenTree.of("else")
+              )
+              .lineSeparated()
+          )
+      )
+      .append(Token.of("{}"))
+      .flatten()
+      .lineSeparated();
   }
 
   private TokenTree generateEnsuresHistoricalCallEvents(
@@ -1883,11 +2067,12 @@ public class DafnyApiCodegen {
 
   /**
    * Given a list of ShapeIds representing a path from a root shape to a reference shape,
-   *   generates a TokenTree containing an {@code ensures} clause on the reference's ValidState
+   * generates a TokenTree containing an {@code ensures} clause on the reference's ValidState
+   *
    * @param managedReferenceMemberShapePath a list of shape IDs where:
-   *  - The first element is the initial shape ID
-   *  - The last element is the shape ID of a reference shape
-   *  - Intermediate elements are a path of shape IDs from the first to the last shape ID
+   *                                        - The first element is the initial shape ID
+   *                                        - The last element is the shape ID of a reference shape
+   *                                        - Intermediate elements are a path of shape IDs from the first to the last shape ID
    * @return TokenTree containing an {@code ensures} clause on the reference's ValidState
    */
   public TokenTree ensuresValidStateClauseForPathToReference(
@@ -1901,11 +2086,12 @@ public class DafnyApiCodegen {
 
   /**
    * Given a list of ShapeIds representing a path from a root shape to a reference shape,
-   *   generates a TokenTree containing a {@code requires} clause on the reference's ValidState
+   * generates a TokenTree containing a {@code requires} clause on the reference's ValidState
+   *
    * @param managedReferenceMemberShapePath a list of shape IDs where:
-   *  - The first element is the initial shape ID
-   *  - The last element is the shape ID of a reference shape
-   *  - Intermediate elements are a path of shape IDs from the first to the last shape ID
+   *                                        - The first element is the initial shape ID
+   *                                        - The last element is the shape ID of a reference shape
+   *                                        - Intermediate elements are a path of shape IDs from the first to the last shape ID
    * @return TokenTree containing an {@code requires} clause on the reference's ValidState
    */
   public TokenTree requiresValidStateClauseForPathToReference(
@@ -1919,11 +2105,12 @@ public class DafnyApiCodegen {
 
   /**
    * Given a list of ShapeIds representing a path from a root shape to a reference shape,
-   *   generates a TokenTree containing a clause starting with {@code prefix} on the reference's ValidState
+   * generates a TokenTree containing a clause starting with {@code prefix} on the reference's ValidState
+   *
    * @param managedReferenceMemberShapePath a list of shape IDs where:
-   *  - The first element is the initial shape ID
-   *  - The last element is the shape ID of a reference shape
-   *  - Intermediate elements are a path of shape IDs from the first to the last shape ID
+   *                                        - The first element is the initial shape ID
+   *                                        - The last element is the shape ID of a reference shape
+   *                                        - Intermediate elements are a path of shape IDs from the first to the last shape ID
    * @return TokenTree containing a clause starting with {@code prefix} on the reference's ValidState
    */
   public TokenTree validStateClauseForPathToReference(
@@ -2063,11 +2250,12 @@ public class DafnyApiCodegen {
 
   /**
    * Given a list of ShapeIds representing a path from a root shape to a reference shape,
-   *   generates a TokenTree containing a {@code modifies} clause on the reference's Modifies member
+   * generates a TokenTree containing a {@code modifies} clause on the reference's Modifies member
+   *
    * @param managedReferenceMemberShapePath a list of shape IDs where:
-   *  - The first element is the initial shape ID
-   *  - The last element is the shape ID of a reference shape
-   *  - Intermediate elements are a path of shape IDs from the first to the last shape ID
+   *                                        - The first element is the initial shape ID
+   *                                        - The last element is the shape ID of a reference shape
+   *                                        - Intermediate elements are a path of shape IDs from the first to the last shape ID
    * @return TokenTree containing a {@code modifies} clause on the reference's Modifies member
    */
   public TokenTree modifiesClauseForPathToReference(
@@ -2081,15 +2269,16 @@ public class DafnyApiCodegen {
 
   /**
    * Given a list of ShapeIds representing a path from a root shape to a reference shape,
-   *   generates a TokenTree containing a clause that would subtract the reference shape's Modifies member
-   *   from another set.
+   * generates a TokenTree containing a clause that would subtract the reference shape's Modifies member
+   * from another set.
    * (This is expected to be wrapped around something like
-   *   {@code ensures fresh(parentShape.Modifies (referenceMemberNotFreshClause here) )},
+   * {@code ensures fresh(parentShape.Modifies (referenceMemberNotFreshClause here) )},
    * as the Modifies clauses access here will not be part of the fresh variable.)
+   *
    * @param managedReferenceMemberShapePath a list of shape IDs where:
-   *  - The first element is the initial shape ID
-   *  - The last element is the shape ID of a reference shape
-   *  - Intermediate elements are a path of shape IDs from the first to the last shape ID
+   *                                        - The first element is the initial shape ID
+   *                                        - The last element is the shape ID of a reference shape
+   *                                        - Intermediate elements are a path of shape IDs from the first to the last shape ID
    * @return TokenTree containing a set subtraction clause for the reference shape's Modifies member.
    */
   public TokenTree referenceMemberNotFreshClause(
@@ -2103,11 +2292,12 @@ public class DafnyApiCodegen {
 
   /**
    * Given a list of ShapeIds representing a path from a root shape to a reference shape,
-   *   generates a TokenTree containing a clause starting with {@code prefix} on the reference's Modifies member
+   * generates a TokenTree containing a clause starting with {@code prefix} on the reference's Modifies member
+   *
    * @param managedReferenceMemberShapePath a list of shape IDs where:
-   *  - The first element is the initial shape ID
-   *  - The last element is the shape ID of a reference shape
-   *  - Intermediate elements are a path of shape IDs from the first to the last shape ID
+   *                                        - The first element is the initial shape ID
+   *                                        - The last element is the shape ID of a reference shape
+   *                                        - Intermediate elements are a path of shape IDs from the first to the last shape ID
    * @return TokenTree containing a clause starting with {@code prefix} on the reference's Modifies member
    */
   private TokenTree modifiesClauseForPathToReference(
@@ -2601,7 +2791,7 @@ public class DafnyApiCodegen {
   /**
    * Generates Dafny methods that don't need to accept TypeDescriptors in some versions of Dafny,
    * so that test models can have a single copy of Java code across multiple versions of Dafny.
-   *
+   * <p>
    * See also TestModels/dafny-dependencies/StandardLibrary/src/WrappersInterop.dfy.
    */
   private static TokenTree generateResultOfClientHelperFunctions(
@@ -2647,7 +2837,7 @@ public class DafnyApiCodegen {
    * <pre>
    * type TypeName = x: BaseType | (c1) && (c2) && ... && (cN) witness *
    * </pre>
-   *
+   * <p>
    * If no constraint expressions are provided, then instead generates a type synonym like
    * <pre>
    * type TypeName = BaseType

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyNameResolver.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyNameResolver.java
@@ -336,8 +336,16 @@ public record DafnyNameResolver(
     return "Modifies";
   }
 
+  public String dynamicMutableStateFunctionName() {
+    return "InternalModifies";
+  }
+
   public String validStateInvariantName() {
     return "ValidState";
+  }
+
+  public String dynamicValidStateInvariantName() {
+    return "InternalValidState";
   }
 
   public String callHistoryFieldName() {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/traits/MutableLocalStateTraitValidator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/traits/MutableLocalStateTraitValidator.java
@@ -1,0 +1,72 @@
+package software.amazon.polymorph.traits;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.polymorph.traits.MutableLocalStateTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.OperationIndex;
+import software.amazon.smithy.model.selector.Selector;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+public class MutableLocalStateTraitValidator extends AbstractValidator {
+
+  @Override
+  public List<ValidationEvent> validate(Model model) {
+    List<ValidationEvent> events = new ArrayList<>();
+    for (Shape shape : model.getShapesWithTrait(MutableLocalStateTrait.class)) {
+      // Generate danger for any use of this trait.
+      // See the danger message for details.
+      events.add(
+        danger(
+          shape,
+          """
+          aws.polymorph#mutableLocalState may allow callers to introduce soundness issues.
+
+          At this time to support dynamic mutable state smithy-dafny creates a "separated class" by using an {:axiom}.
+          The idea for these seperated classes is that the resource has access to an internal modifies set.
+          This is sometimes referred to as an Repr set.
+          The resources internal operations are allowed to modify this InternalModifies,
+          but the public operations are not.
+          A Dafny `assume {:axiom}` is used to create this separation between the InternalModifies and the Modifies sets.
+
+          Smithy-dafny operations that return these resources will always return the `trait`
+          which does not have any concrete implementation of state.
+          However, a clever caller could cast this trait into its concrete class.
+          Such a caller now has access to observe the internal state of the resource.
+
+          Dafny may allow such a caller to prove that this state is unchanged.
+          Because the called operations do not contain these elements inside their `modifies` clause.
+          But these elements would indeed be modified.
+          Thus Dafny might prove false.
+
+          ```dafny
+
+          var Output(resource) :- expect client.GetResource();
+
+          expect resource is ConcreteResource;
+          var concreteResource := resource as ConcreteResource;
+
+          // Get a copy of state before state changes
+          var state := concreteResource.state;
+
+          var output2 :- expect concreteResource.ChangeState();
+
+          // State will have changed, because we called for a state change.
+          // however, Dafny may be able prove that state MUST NOT have changed.
+          assert state == concreteResource.state;
+          expect state != concreteResource.state;
+          ```
+
+          This can be mitigated with export sets
+          See TestModels/Resource/src/MutableResource.dfy for an example.
+          """
+        )
+      );
+    }
+
+    return events;
+  }
+}

--- a/codegen/smithy-dafny-codegen/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/codegen/smithy-dafny-codegen/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -1,2 +1,3 @@
 software.amazon.polymorph.traits.NoReferencesInSmokeTestsValidator
 software.amazon.polymorph.traits.NoMarkupInDocumentationTraitsValidator
+software.amazon.polymorph.traits.MutableLocalStateTraitValidator


### PR DESCRIPTION
Because reference types can have mutable state,
they need to have ValidState and Modifies
threaded through on the Dafny side.

Constructors for the service already supported this,
but this adds support for specific operations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
