### PR TITLE
chore(Python): Unknown union variants are labelled as "Unknown"

### DIFF
--- a/codegen/smithy-dafny-codegen-modules/smithy-python/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/UnionGenerator.java
+++ b/codegen/smithy-dafny-codegen-modules/smithy-python/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/UnionGenerator.java
@@ -138,6 +138,7 @@ public class UnionGenerator implements Runnable {
         // Since the underlying value is unknown and un-comparable, that is the only
         // realistic implementation.
         var unknownSymbol = symbolProvider.toSymbol(shape).expectProperty("unknown", Symbol.class);
+        String unknownSymbolName = unknownSymbol.getName() + "Unknown";
         writer.write("""
                 class $1L():
                     \"""Represents an unknown variant.
@@ -162,8 +163,8 @@ public class UnionGenerator implements Runnable {
 
                     def __repr__(self) -> str:
                         return f"$1L(tag={self.tag})"
-                """, unknownSymbol.getName());
-        memberNames.add(unknownSymbol.getName());
+                """, unknownSymbolName);
+        memberNames.add(unknownSymbolName);
 
         shape.getTrait(DocumentationTrait.class).ifPresent(trait -> writer.writeComment(trait.getValue()));
         writer.addStdlibImport("typing", "Union");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


Example:

Before

```
class AlgorithmSuiteId:
    """Represents an unknown variant.

    If you receive this value, you will need to update your library to receive the
    parsed value.

    This value may not be deliberately sent.
    """

    def __init__(self, tag: str):
        self.tag = tag

    def as_dict(self) -> Dict[str, Any]:
        return {"SDK_UNKNOWN_MEMBER": {"name": self.tag}}

    @staticmethod
    def from_dict(d: Dict[str, Any]) -> "AlgorithmSuiteId":
        if len(d) != 1:
            raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
        return AlgorithmSuiteId(d["SDK_UNKNOWN_MEMBER"]["name"])

    def __repr__(self) -> str:
        return f"AlgorithmSuiteId(tag={self.tag})"


AlgorithmSuiteId = Union[AlgorithmSuiteIdESDK, AlgorithmSuiteIdDBE, AlgorithmSuiteId]
```

After

```
class AlgorithmSuiteIdUnknown:
    """Represents an unknown variant.

    If you receive this value, you will need to update your library to receive the
    parsed value.

    This value may not be deliberately sent.
    """

    def __init__(self, tag: str):
        self.tag = tag

    def as_dict(self) -> Dict[str, Any]:
        return {"SDK_UNKNOWN_MEMBER": {"name": self.tag}}

    @staticmethod
    def from_dict(d: Dict[str, Any]) -> "AlgorithmSuiteIdUnknown":
        if len(d) != 1:
            raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
        return AlgorithmSuiteIdUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])

    def __repr__(self) -> str:
        return f"AlgorithmSuiteIdUnknown(tag={self.tag})"


AlgorithmSuiteId = Union[
    AlgorithmSuiteIdESDK, AlgorithmSuiteIdDBE, AlgorithmSuiteIdUnknown
]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
