### PR TITLE
chore(ci): make all pull.yml jobs required in branch protection automatically

### DIFF
--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -50,7 +50,7 @@ jobs:
         dafny-nightly-java,
         dafny-nightly-net,
         dafny-nightly-rust,
-        dafny-nightly-python
+        dafny-nightly-python,
       ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     env:

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -50,6 +50,7 @@ jobs:
         dafny-nightly-java,
         dafny-nightly-net,
         dafny-nightly-rust,
+        dafny-nightly-python
       ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     env:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -66,3 +66,18 @@ jobs:
     uses: ./.github/workflows/test_models_python_tests.yml
     with:
       dafny: ${{ matrix.dafny-version }}
+  
+  pr-ci-all-required:
+    if: always()
+    needs: 
+      - pr-ci-verification
+      - pr-ci-java
+      - pr-ci-net
+      - pr-ci-rust
+      - pr-ci-python
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs passed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -66,10 +66,10 @@ jobs:
     uses: ./.github/workflows/test_models_python_tests.yml
     with:
       dafny: ${{ matrix.dafny-version }}
-  
+
   pr-ci-all-required:
     if: always()
-    needs: 
+    needs:
       - pr-ci-verification
       - pr-ci-java
       - pr-ci-net


### PR DESCRIPTION
*Description of changes:*

As is the case for many suites of GitHub actions, it's a huge pain to manually maintain the list of required checks in the branch protection. This change leverages https://github.com/re-actors/alls-green to add a single capstone action that only passes if all dependent jobs pass (see repo README for details on why the naive approach doesn't work).

Once this is approved I'll update the required checks before merging.

Also adding Python tests to the list of triggers in the nightly build since I noticed it was missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
