### PR TITLE
fix: polymorph_rust accidentally also invoking patch_after_transpile

### DIFF
--- a/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
+++ b/codegen/smithy-dafny-codegen-cli/src/main/java/software/amazon/polymorph/CodegenCli.java
@@ -145,10 +145,8 @@ public class CodegenCli {
     cliArguments.patchFilesDir.ifPresent(engineBuilder::withPatchFilesDir);
     final CodegenEngine engine = engineBuilder.build();
     switch (cliArguments.command) {
-      case GENERATE:
-        engine.run();
-      case PATCH_AFTER_TRANSPILE:
-        engine.patchAfterTranspiling();
+      case GENERATE -> engine.run();
+      case PATCH_AFTER_TRANSPILE -> engine.patchAfterTranspiling();
     }
   }
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -885,10 +885,6 @@ public class CodegenEngine {
       final List<String> lines = Files.readAllLines(
         implementationFromDafnyPath
       );
-      // TODO fix root cause of duplicate extra declarations
-      if (lines.contains("// (extra-declarations)")) {
-        return;
-      }
       final int firstModDeclIndex = IntStream
         .range(0, lines.size())
         .filter(i -> lines.get(i).trim().startsWith("pub mod"))


### PR DESCRIPTION
*Description of changes:*

Classic case of forgetting `break;` statements in my switch statement. But switching (ha!) to a switch expression makes it a non-issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
