### PR TITLE
feat(Python): Format docstrings

### DIFF
--- a/codegen/smithy-dafny-codegen-modules/smithy-python/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
+++ b/codegen/smithy-dafny-codegen-modules/smithy-python/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
@@ -344,19 +344,18 @@ public class DirectedPythonCodegen implements DirectedCodegen<GenerationContext,
     private void formatCode(FileManifest fileManifest) {
         try {
             CodegenUtils.runCommand("python3 -m black -h", fileManifest.getBaseDir());
+            LOGGER.info("Running code formatter on generated code");
+            CodegenUtils.runCommand("python3 -m black . --exclude \"\"", fileManifest.getBaseDir());
         } catch (CodegenException e) {
             LOGGER.warning("Unable to find the python package black. Skipping formatting.");
-            return;
         }
-        LOGGER.info("Running code formatter on generated code");
-        CodegenUtils.runCommand("python3 -m black . --exclude \"\"", fileManifest.getBaseDir());
         try {
-            CodegenUtils.runCommand("python3 -m docformatter", fileManifest.getBaseDir());
+          CodegenUtils.runCommand("python3 -m docformatter -h", fileManifest.getBaseDir());
+          LOGGER.info("Running docstring formatter on generated code");
+          CodegenUtils.runCommand("python3 -m docformatter --recursive .", fileManifest.getBaseDir());
         } catch (CodegenException e) {
             LOGGER.warning("Unable to find the python package docformatter. Skipping formatting.");
-            return;
         }
-        CodegenUtils.runCommand("python3 -m docformatter --recursive .", fileManifest.getBaseDir());
     }
 
     private void runMypy(FileManifest fileManifest) {

--- a/codegen/smithy-dafny-codegen-modules/smithy-python/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
+++ b/codegen/smithy-dafny-codegen-modules/smithy-python/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
@@ -350,6 +350,13 @@ public class DirectedPythonCodegen implements DirectedCodegen<GenerationContext,
         }
         LOGGER.info("Running code formatter on generated code");
         CodegenUtils.runCommand("python3 -m black . --exclude \"\"", fileManifest.getBaseDir());
+        try {
+            CodegenUtils.runCommand("python3 -m docformatter", fileManifest.getBaseDir());
+        } catch (CodegenException e) {
+            LOGGER.warning("Unable to find the python package docformatter. Skipping formatting.");
+            return;
+        }
+        CodegenUtils.runCommand("python3 -m docformatter --recursive .", fileManifest.getBaseDir());
     }
 
     private void runMypy(FileManifest fileManifest) {

--- a/codegen/smithy-dafny-codegen-modules/smithy-python/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
+++ b/codegen/smithy-dafny-codegen-modules/smithy-python/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/DirectedPythonCodegen.java
@@ -338,24 +338,28 @@ public class DirectedPythonCodegen implements DirectedCodegen<GenerationContext,
             CodegenUtils.runCommand("python3 " + file, fileManifest.getBaseDir());
         }
         formatCode(fileManifest);
+        formatDocstrings(fileManifest);
         runMypy(fileManifest);
     }
 
     private void formatCode(FileManifest fileManifest) {
         try {
             CodegenUtils.runCommand("python3 -m black -h", fileManifest.getBaseDir());
-            LOGGER.info("Running code formatter on generated code");
-            CodegenUtils.runCommand("python3 -m black . --exclude \"\"", fileManifest.getBaseDir());
         } catch (CodegenException e) {
             LOGGER.warning("Unable to find the python package black. Skipping formatting.");
         }
-        try {
+        LOGGER.info("Running code formatter on generated code");
+        CodegenUtils.runCommand("python3 -m black . --exclude \"\"", fileManifest.getBaseDir());
+    }
+
+    private void formatDocstrings(FileManifest fileManifest) {
+      try {
           CodegenUtils.runCommand("python3 -m docformatter -h", fileManifest.getBaseDir());
-          LOGGER.info("Running docstring formatter on generated code");
-          CodegenUtils.runCommand("python3 -m docformatter --recursive .", fileManifest.getBaseDir());
-        } catch (CodegenException e) {
-            LOGGER.warning("Unable to find the python package docformatter. Skipping formatting.");
-        }
+      } catch (CodegenException e) {
+          LOGGER.warning("Unable to find the python package docformatter. Skipping formatting.");
+      }
+      LOGGER.info("Running docformatter on generated code");
+      CodegenUtils.runCommand("python3 -m docformatter --recursive .", fileManifest.getBaseDir());
     }
 
     private void runMypy(FileManifest fileManifest) {

--- a/codegen/smithy-dafny-codegen-modules/smithy-python/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/StructureGenerator.java
+++ b/codegen/smithy-dafny-codegen-modules/smithy-python/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/StructureGenerator.java
@@ -338,9 +338,6 @@ public class StructureGenerator implements Runnable {
         writer.openBlock("def as_dict(self) -> Dict[str, Any]:", "", () -> {
             writer.writeDocs(() -> {
                 writer.write("Converts the $L to a dictionary.\n", symbolProvider.toSymbol(shape).getName());
-                writer.write(writer.formatDocs("""
-                        The dictionary uses the modeled shape names rather than the parameter names \
-                        as keys to be mostly compatible with boto3."""));
             });
 
             // If there aren't any optional members, it's best to return immediately.
@@ -399,9 +396,6 @@ public class StructureGenerator implements Runnable {
         writer.openBlock("def from_dict(d: Dict[str, Any]) -> $S:", "", shapeName, () -> {
             writer.writeDocs(() -> {
                 writer.write("Creates a $L from a dictionary.\n", shapeName);
-                writer.write(writer.formatDocs("""
-                        The dictionary is expected to use the modeled shape names rather \
-                        than the parameter names as keys to be mostly compatible with boto3."""));
             });
 
             if (shape.members().isEmpty() && !isError) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Python codegen runs `docformatter` if installed.
If not installed, emits a warning.
This formats docstrings so libraries like sphinx and readthedocs can interpret them correctly.
ex. https://aws-cryptographic-material-providers-library.readthedocs.io/en/latest/generated/aws_cryptographic_materialproviders.smithygenerated.aws_cryptography_materialproviders.models.html

Also remove a docstring note in Smithy-Python's as_dict/from_dict methods.
This is inaccurate for Python codegen (and is inaccurate for Smithy-Python codegen).
* Formatting according to docstring note: `SomeMemberName`
  * This is the "boto3" formatting.
* Actual Smithy-Python formatting: `someMemberName`
* Smithy-Dafny Python formatting: `some_member_name`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
