### PR TITLE
fix(ToDafny-ByteBuffer): Do not Modify Input

### DIFF
--- a/smithy-dafny-conversion/src/main/java/software/amazon/smithy/dafny/conversion/ToDafny.java
+++ b/smithy-dafny-conversion/src/main/java/software/amazon/smithy/dafny/conversion/ToDafny.java
@@ -65,7 +65,9 @@ public class ToDafny {
       final int limit
     ) {
       byte[] rawArray = new byte[limit - start];
-      byteBuffer.get(rawArray, start - byteBuffer.position(), limit);
+      for (int i = 0; i < rawArray.length; i++) {
+        rawArray[i] = byteBuffer.get(start + i);
+      }
       return ByteSequence(rawArray);
     }
 

--- a/smithy-dafny-conversion/src/main/java/software/amazon/smithy/dafny/conversion/ToDafny.java
+++ b/smithy-dafny-conversion/src/main/java/software/amazon/smithy/dafny/conversion/ToDafny.java
@@ -65,8 +65,7 @@ public class ToDafny {
       final int limit
     ) {
       byte[] rawArray = new byte[limit - start];
-      byteBuffer.position(start);
-      byteBuffer.get(rawArray, 0, limit);
+      byteBuffer.get(rawArray, start - byteBuffer.position(), limit);
       return ByteSequence(rawArray);
     }
 


### PR DESCRIPTION
*Issue #, if available:*
If two or more threads are handling the same ByteBuffer,
the ToDafny conversion layer can throw a `java.nio.BufferUnderflowException`.

This because the conversion method modifies the ByteBuffer's `position`.
Thus, 
other threads working on the same reference
may end up reading no bytes,
as the position is updated while they copying bytes
to the final output array.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
