### PR TITLE
fix: Provide default implementation for Native.classNameForAwsSdkShape()

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Native.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Native.java
@@ -374,8 +374,12 @@ public class Native extends NameResolver {
   }
 
   protected ClassName classNameForAwsSdkShape(final Shape shape) {
-    throw new UnsupportedOperationException(
-      "classNameForAwsSdkShape should only be called on AWS SDK-specific subclasses"
-    );
+    // This is inefficient, but we currently instantiate Native for local services
+    // but then call this method that should only be relevant for AWS SDK wrappers.
+    // It would be better to make Native abstract in the future.
+    return switch (awsSdkVersion) {
+      case V1 -> new AwsSdkNativeV1(serviceShape, model).classNameForAwsSdkShape(shape);
+      case V2 -> new AwsSdkNativeV2(serviceShape, model).classNameForAwsSdkShape(shape);
+    };
   }
 }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Native.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/nameresolver/Native.java
@@ -378,8 +378,10 @@ public class Native extends NameResolver {
     // but then call this method that should only be relevant for AWS SDK wrappers.
     // It would be better to make Native abstract in the future.
     return switch (awsSdkVersion) {
-      case V1 -> new AwsSdkNativeV1(serviceShape, model).classNameForAwsSdkShape(shape);
-      case V2 -> new AwsSdkNativeV2(serviceShape, model).classNameForAwsSdkShape(shape);
+      case V1 -> new AwsSdkNativeV1(serviceShape, model)
+        .classNameForAwsSdkShape(shape);
+      case V2 -> new AwsSdkNativeV2(serviceShape, model)
+        .classNameForAwsSdkShape(shape);
     };
   }
 }


### PR DESCRIPTION
*Description of changes:*
#504 breaks the MPL because it calls this method for an enum from KMS.

Hopefully the pending `CallingAWSSDKFromLocal` test model will cover this case in the future (cc @rishav-karanjit)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
