### PR TITLE
fix(rust-polymorph): sort rust shapes

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/AbstractRustShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/AbstractRustShimGenerator.java
@@ -107,7 +107,6 @@ public abstract class AbstractRustShimGenerator {
       .getAllBindingShapes()
       .stream()
       .filter(s -> ModelUtils.isInServiceNamespace(s, service))
-      .sorted()
       .flatMap(s -> operationBindingIndex.getOperations(s).stream());
   }
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/AbstractRustShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/AbstractRustShimGenerator.java
@@ -115,7 +115,8 @@ public abstract class AbstractRustShimGenerator {
       .getStructureShapes()
       .stream()
       .filter(s -> s.hasTrait(ErrorTrait.class))
-      .filter(o -> ModelUtils.isInServiceNamespace(o, service));
+      .filter(o -> ModelUtils.isInServiceNamespace(o, service))
+      .sorted();
   }
 
   protected final boolean isInputOrOutputStructure(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/AbstractRustShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/AbstractRustShimGenerator.java
@@ -107,6 +107,7 @@ public abstract class AbstractRustShimGenerator {
       .getAllBindingShapes()
       .stream()
       .filter(s -> ModelUtils.isInServiceNamespace(s, service))
+      .sorted()
       .flatMap(s -> operationBindingIndex.getOperations(s).stream());
   }
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -694,6 +694,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
       .filter(bindingShape ->
         ModelUtils.isInServiceNamespace(bindingShape, service)
       )
+      .sorted()
       .flatMap(this::operationModuleDeclarationForBindingShape)
       .collect(Collectors.joining("\n\n"));
     return new RustFile(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -694,8 +694,8 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
       .filter(bindingShape ->
         ModelUtils.isInServiceNamespace(bindingShape, service)
       )
-      .sorted()
       .flatMap(this::operationModuleDeclarationForBindingShape)
+      .sorted()
       .collect(Collectors.joining("\n\n"));
     return new RustFile(
       rootPathForShape(service).resolve("operation.rs"),

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -367,6 +367,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
 
     final String resourceModules = streamResourcesToGenerateTraitsFor()
       .filter(o -> o.getId().getNamespace().equals(namespace))
+      .sorted()
       .map(resourceShape ->
         evalTemplate(
           """
@@ -381,6 +382,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
 
     final String structureModules = streamStructuresToGenerateStructsFor()
       .filter(o -> o.getId().getNamespace().equals(namespace))
+      .sorted()
       .map(structureShape ->
         evalTemplate(
           """
@@ -396,6 +398,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
     final String enumModules = ModelUtils
       .streamEnumShapes(model, service.getId().getNamespace())
       .filter(o -> o.getId().getNamespace().equals(namespace))
+      .sorted()
       .map(enumShape ->
         evalTemplate(
           """
@@ -413,6 +416,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
       .stream()
       .filter(this::shouldGenerateEnumForUnion)
       .filter(o -> o.getId().getNamespace().equals(namespace))
+      .sorted()
       .map(unionShape ->
         evalTemplate(
           """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, smithy generated Rust shapes are not being sorted. This results in non deterministic polymorph code generation. This PR fixes sorting for error.rs, types.rs and operation.rs files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
