### PR TITLE
chore(ci): Downgrade unreleased Dafny versions to fix nightly build

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -75,6 +75,11 @@ public class CodegenEngine {
   private static final DafnyVersion MIN_DAFNY_VERSION = DafnyVersion.parse(
     "4.5"
   );
+  // The highest released version of Dafny.
+  // Needed to handle pre-releases differently.
+  private static final DafnyVersion MAX_DAFNY_VERSION = DafnyVersion.parse(
+    "4.9"
+  );
 
   // Used to distinguish different conventions between the CLI
   // and the Smithy build plugin, such as where .NET project files live.
@@ -1245,7 +1250,7 @@ public class CodegenEngine {
       final Map<TargetLanguage, Path> targetLangTestOutputDirs =
         ImmutableMap.copyOf(targetLangTestOutputDirsRaw);
 
-      final DafnyVersion dafnyVersion = Optional
+      DafnyVersion dafnyVersion = Optional
         .ofNullable(this.dafnyVersion)
         .orElseGet(CodegenEngine::getDafnyVersionFromDafny);
       if (dafnyVersion.compareTo(MIN_DAFNY_VERSION) < 0) {
@@ -1255,6 +1260,15 @@ public class CodegenEngine {
           " is required, but found " +
           dafnyVersion.unparse()
         );
+      }
+      // If the version has not been released yet,
+      // downgrade it. Otherwise, the system will not find runtime libraries
+      // with the same version.
+      // The better fix for this is for Dafny to pre-release
+      if (dafnyVersion.compareTo(MAX_DAFNY_VERSION) > 0) {
+        LOGGER.warn("Dafny version {} appears to be unreleased, downgrading to {} to ensure runtimes are available",
+          dafnyVersion.unparse(), MAX_DAFNY_VERSION.unparse());
+        dafnyVersion = MAX_DAFNY_VERSION;
       }
 
       final Optional<Path> propertiesFile = Optional

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -1266,8 +1266,11 @@ public class CodegenEngine {
       // with the same version.
       // The better fix for this is for Dafny to pre-release
       if (dafnyVersion.compareTo(MAX_DAFNY_VERSION) > 0) {
-        LOGGER.warn("Dafny version {} appears to be unreleased, downgrading to {} to ensure runtimes are available",
-          dafnyVersion.unparse(), MAX_DAFNY_VERSION.unparse());
+        LOGGER.warn(
+          "Dafny version {} appears to be unreleased, downgrading to {} to ensure runtimes are available",
+          dafnyVersion.unparse(),
+          MAX_DAFNY_VERSION.unparse()
+        );
         dafnyVersion = MAX_DAFNY_VERSION;
       }
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyVersion.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithydafny/DafnyVersion.java
@@ -6,13 +6,7 @@ import java.util.Comparator;
 import java.util.Objects;
 
 /**
- * Representation of a Dafny version number, according to SemVer 1.0 semantics.
- *
- * Note that Dafny pre-releases historically have used pre-release suffixes slightly wrong:
- * after releasing 4.2 for example, the nightly pre-releases will have version numbers like
- * "4.2.0-nightly-2023-08-04-656a114", but that should actually be interpreted as a pre-release
- * for 4.2 rather than 4.3. So far that's immaterial for this code base,
- * but if it becomes relevant the better solution is for Dafny pre-releases to correct this instead.
+ * Representation of a Dafny version number, according to SemVer 2.0 semantics.
  */
 public class DafnyVersion implements Comparable<DafnyVersion> {
 


### PR DESCRIPTION
*Description of changes:*
Dafny HEAD now has a newer version than the latest release (4.9.1), and since Dafny isn't yet prereleasing the runtimes, this leads to failing to resolve references to runtimes. Made a simple fix to downgrade if we don't recognize the version. Will be another step to do when Dafny releases new versions, but hopefully Dafny will start prereleasing runtimes soon.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
