### PR TITLE
fix: Add import for aws sdk types

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/StructureGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/StructureGenerator.java
@@ -152,7 +152,15 @@ public final class StructureGenerator implements Runnable {
             );
           }
         } else {
-          if (
+          if (SmithyNameResolver.isShapeFromAWSSDK(targetShape)) {
+            writer.addImportFromModule(
+              SmithyNameResolver.getGoModuleNameForSdkNamespace(
+                targetShape.getId().getNamespace()
+              ),
+              "types",
+              SmithyNameResolver.smithyTypesNamespace(targetShape)
+            );
+          } else if (
             !member
               .toShapeId()
               .getNamespace()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Structure generator was not generating aws sdk types import. This PR will fix codegen to import aws sdk types if those aws sdk shape exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
