### PR TITLE
fix: Assert datasource in to native conversion of dafny client

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolVisitor.java
@@ -537,10 +537,6 @@ public class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
   @Override
   public Symbol stringShape(StringShape shape) {
     if (shape.hasTrait(EnumTrait.class)) {
-      // System.out.println("");
-      // System.out.println(shape);
-      // System.out.println(SmithyNameResolver.smithyTypesNamespace(shape));
-      // System.out.println(shape.getId().getNamespace());
       String name = getDefaultShapeName(shape);
       return symbolBuilderFor(
         shape,

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
@@ -171,11 +171,12 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
           );
       }
       if (!this.isOptional) {
-        return "return &%s{%s}".formatted(
+        return "return &%s{%s.(*%s)}".formatted(
             namespace.concat(
               context.symbolProvider().toSymbol(serviceShape).getName()
             ),
-            dataSource
+            dataSource,
+            DafnyNameResolver.getDafnyClient(serviceShape.toShapeId().getName())
           );
       }
       return """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Assertion was missing in to native conversion of Dafny client when it is non optional. This PR adds it. 

Fixes following MPL error:
```
../../../../../aws-cryptographic-material-providers-library/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographymaterialproviderssmithygenerated/to_native.go:2548:56: 
cannot use input (variable of type interface{}) as *KeyStore.KeyStoreClient value in struct literal: need type assertion
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
