### PR TITLE
fix: Allow @default despite not supporting it for now

### DIFF
--- a/TestModels/Constraints/Model/Constraints.smithy
+++ b/TestModels/Constraints/Model/Constraints.smithy
@@ -1,4 +1,4 @@
-$version: "2.0"
+$version: "1.0"
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/traits/UnsupportedFeaturesValidator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/traits/UnsupportedFeaturesValidator.java
@@ -73,6 +73,13 @@ public class UnsupportedFeaturesValidator extends AbstractValidator {
       COMMON_SUPPORTED_TRAITS.stream(),
       Stream
         .of(
+          // This is not actually true at all,
+          // but Smithy liberally injects @default into Smithy 1.0 models
+          // to make implicit semantics explicit.
+          // Rather than require a ton of suppressions and risk alarm fatigue,
+          // this is tracked as a soundness bug instead:
+          // https://github.com/smithy-lang/smithy-dafny/issues/544
+          "smithy.api#default",
           // For those that literally can't be used for non-local services,
           // we probably want model validation to forbid them instead,
           "aws.polymorph#extendable",


### PR DESCRIPTION
*Description of changes:*
#257 implemented a mechanism to reject unsupported traits. `@default` was one of them since we don't support its semantics for local services yet (#544), but the Smithy pipeline injects this trait all over the place when auto-converting a Smithy 1.0 model. Rather than require a ton of suppressions and risk alarm fatigue, I've upgraded #544 to a soundness bug for tracking instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
