### PR TITLE
feat(rust): validate nested constraints

### DIFF
--- a/TestModels/Aggregate/runtimes/rust/src/lib.rs
+++ b/TestModels/Aggregate/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/CallingAWSSDKFromLocalService/Makefile
+++ b/TestModels/CallingAWSSDKFromLocalService/Makefile
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CORES=2
+TRANSPILE_TESTS_IN_RUST=1
 
 ENABLE_EXTERN_PROCESSING=1
 
@@ -9,6 +10,8 @@ include ../SharedMakefile.mk
 
 PROJECT_SERVICES := \
 	SimpleCallingawssdkfromlocalservice
+
+MAIN_SERVICE_FOR_RUST := SimpleCallingawssdkfromlocalservice
 
 PROJECT_DEPENDENCIES := \
 	aws-sdks/kmsv2 \

--- a/TestModels/CallingAWSSDKFromLocalService/runtimes/rust/Cargo.toml
+++ b/TestModels/CallingAWSSDKFromLocalService/runtimes/rust/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "calling_aws_sdk_from_local_service"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+wrapped-client = []
+
+[dependencies]
+aws-config = "1.5.8"
+aws-smithy-runtime = {version = "1.7.1", features=["client"]}
+aws-smithy-runtime-api = {version = "1.7.2", features=["client"]}
+aws-smithy-types = "1.2.4"
+dafny_runtime = { path = "../../../dafny-dependencies/dafny_runtime_rust"}
+aws-sdk-dynamodb = "1.50.0"
+aws-sdk-kms = "1.47.0"
+
+[dependencies.tokio]
+version = "1.26.0"
+features = ["full"]
+
+[dev-dependencies]
+calling_aws_sdk_from_local_service = { path = ".", features = ["wrapped-client"] }

--- a/TestModels/CallingAWSSDKFromLocalService/runtimes/rust/src/ddb.rs
+++ b/TestModels/CallingAWSSDKFromLocalService/runtimes/rust/src/ddb.rs
@@ -1,0 +1,43 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![deny(warnings, unconditional_panic)]
+#![deny(nonstandard_style)]
+#![deny(clippy::all)]
+
+use aws_config::Region;
+use std::sync::LazyLock;
+
+static DAFNY_TOKIO_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+});
+
+#[allow(non_snake_case)]
+impl crate::r#software::amazon::cryptography::services::dynamodb::internaldafny::_default {
+  pub fn DynamoDBClient() -> ::std::rc::Rc<
+  crate::r#_Wrappers_Compile::Result<
+    ::dafny_runtime::Object<dyn crate::r#software::amazon::cryptography::services::dynamodb::internaldafny::types::IDynamoDBClient>,
+    ::std::rc::Rc<crate::r#software::amazon::cryptography::services::dynamodb::internaldafny::types::Error>
+    >
+    >{
+        let shared_config = match tokio::runtime::Handle::try_current() {
+            Ok(curr) => tokio::task::block_in_place(|| {
+                curr.block_on(async {
+                    aws_config::load_defaults(aws_config::BehaviorVersion::v2024_03_28()).await
+                })
+            }),
+            Err(_) => DAFNY_TOKIO_RUNTIME.block_on(aws_config::load_defaults(
+                aws_config::BehaviorVersion::v2024_03_28(),
+            )),
+        };
+        let inner = aws_sdk_dynamodb::Client::new(&shared_config);
+        let client = crate::deps::com_amazonaws_dynamodb::client::Client { inner };
+        let dafny_client = ::dafny_runtime::upcast_object()(::dafny_runtime::object::new(client));
+        std::rc::Rc::new(crate::r#_Wrappers_Compile::Result::Success {
+            value: dafny_client,
+        })
+    }
+}

--- a/TestModels/CallingAWSSDKFromLocalService/runtimes/rust/src/kms.rs
+++ b/TestModels/CallingAWSSDKFromLocalService/runtimes/rust/src/kms.rs
@@ -1,0 +1,39 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![deny(warnings, unconditional_panic)]
+#![deny(nonstandard_style)]
+#![deny(clippy::all)]
+
+use aws_config::Region;
+use std::sync::LazyLock;
+
+static DAFNY_TOKIO_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+});
+
+impl crate::r#software::amazon::cryptography::services::kms::internaldafny::_default {
+    #[allow(non_snake_case)]
+    pub fn KMSClient() -> ::std::rc::Rc<crate::r#_Wrappers_Compile::Result<::dafny_runtime::Object<dyn crate::software::amazon::cryptography::services::kms::internaldafny::types::IKMSClient>, ::std::rc::Rc<crate::software::amazon::cryptography::services::kms::internaldafny::types::Error>>>{
+        let shared_config = match tokio::runtime::Handle::try_current() {
+            Ok(curr) => tokio::task::block_in_place(|| {
+                curr.block_on(async {
+                    aws_config::load_defaults(aws_config::BehaviorVersion::v2024_03_28()).await
+                })
+            }),
+            Err(_) => DAFNY_TOKIO_RUNTIME.block_on(aws_config::load_defaults(
+                aws_config::BehaviorVersion::v2024_03_28(),
+            )),
+        };
+
+        let inner = aws_sdk_kms::Client::new(&shared_config);
+        let client = crate::deps::com_amazonaws_kms::client::Client { inner };
+        let dafny_client = ::dafny_runtime::upcast_object()(::dafny_runtime::object::new(client));
+        std::rc::Rc::new(crate::r#_Wrappers_Compile::Result::Success {
+            value: dafny_client,
+        })
+    }
+}

--- a/TestModels/CallingAWSSDKFromLocalService/runtimes/rust/src/lib.rs
+++ b/TestModels/CallingAWSSDKFromLocalService/runtimes/rust/src/lib.rs
@@ -1,0 +1,33 @@
+#![allow(
+  deprecated,
+  non_upper_case_globals,
+  unused,
+  non_snake_case,
+  non_camel_case_types
+)]
+
+pub mod client;
+pub mod conversions;
+pub mod deps;
+/// Common errors and error handling utilities.
+pub mod error;
+pub(crate) mod implementation_from_dafny;
+/// All operations that this crate can perform.
+pub mod operation;
+pub mod validation;
+mod standard_library_conversions;
+mod standard_library_externs;
+pub mod types;
+pub mod wrapped;
+pub(crate) use crate::implementation_from_dafny::r#_Wrappers_Compile;
+pub(crate) use crate::implementation_from_dafny::simple;
+pub use crate::types::simple_callingawssdkfromlocalservice_config::SimpleCallingawssdkfromlocalserviceConfig;
+pub use client::Client;
+
+pub use crate::deps::com_amazonaws_dynamodb;
+pub use crate::deps::com_amazonaws_kms;
+
+pub mod ddb;
+pub mod kms;
+
+pub(crate) use crate::implementation_from_dafny::software;

--- a/TestModels/Constraints/Makefile
+++ b/TestModels/Constraints/Makefile
@@ -44,6 +44,16 @@ remove_unsupported_rust_tests:
 		SED_BEFORE_STRING='let mut allowBadUtf8BytesFromDafny: bool = true' \
 		SED_AFTER_STRING='let mut allowBadUtf8BytesFromDafny: bool = false'
 
+# Patch out tests that Java codegen doesn't support
+
+transpile_java: | transpile_implementation_java transpile_dependencies_java remove_unsupported_java_tests
+
+remove_unsupported_java_tests:
+	$(MAKE) _sed_file \
+		SED_FILE_PATH=$(LIBRARY_ROOT)/runtimes/java/src/test/dafny-generated/WrappedSimpleConstraintsTest_Compile/__default.java \
+		SED_BEFORE_STRING='_3_supportsOptionalPrimitiveFields = true' \
+		SED_AFTER_STRING='_3_supportsOptionalPrimitiveFields = false'
+
 # Python
 
 PYTHON_MODULE_NAME=simple_constraints

--- a/TestModels/Constraints/Model/Constraints.smithy
+++ b/TestModels/Constraints/Model/Constraints.smithy
@@ -116,6 +116,11 @@ list ListLessThanOrEqualToTen {
 }
 
 @length(min: 1, max: 10)
+list ListWithConstraint {
+  member: MyString
+}
+
+@length(min: 1, max: 10)
 map MyMap {
   key: String,
   value: String,
@@ -131,6 +136,12 @@ map NonEmptyMap {
 map MapLessThanOrEqualToTen {
   key: String,
   value: String,
+}
+
+@length(min: 1, max: 10)
+map MapWithConstraint {
+  key: MyString,
+  value: MyString,
 }
 
 // we don't do patterns yet
@@ -160,10 +171,21 @@ integer LessThanTen
 //   member: ComplexListElement
 // }
 
-// structure ComplexListElement {
-//   value: String,
-//   blob: Blob,
-// }
+union UnionWithConstraint {
+  IntegerValue: OneToTen,
+  StringValue: MyString,
+}
+
+structure ComplexStructure {
+  InnerString: MyString,
+  @required
+  InnerBlob: MyBlob,
+}
+
+@length(min: 1)
+list ComplexStructureList {
+  member: ComplexStructure,
+}
 
 structure GetConstraintsInput {
   MyString: MyString,
@@ -175,9 +197,11 @@ structure GetConstraintsInput {
   MyList: MyList,
   NonEmptyList: NonEmptyList,
   ListLessThanOrEqualToTen: ListLessThanOrEqualToTen,
+  ListWithConstraint: ListWithConstraint,
   MyMap: MyMap,
   NonEmptyMap: NonEmptyMap,
   MapLessThanOrEqualToTen: MapLessThanOrEqualToTen,
+  MapWithConstraint: MapWithConstraint,
   // Alphabetic: Alphabetic,
   OneToTen: OneToTen,
   myTenToTen: TenToTen,
@@ -187,6 +211,8 @@ structure GetConstraintsInput {
   // MyComplexUniqueList: MyComplexUniqueList,
   MyUtf8Bytes: Utf8Bytes,
   MyListOfUtf8Bytes: ListOfUtf8Bytes,
+  UnionWithConstraint: UnionWithConstraint,
+  ComplexStructureList: ComplexStructureList,
 }
 
 structure GetConstraintsOutput {
@@ -199,9 +225,11 @@ structure GetConstraintsOutput {
   MyList: MyList,
   NonEmptyList: NonEmptyList,
   ListLessThanOrEqualToTen: ListLessThanOrEqualToTen,
+  ListWithConstraint: ListWithConstraint,
   MyMap: MyMap,
   NonEmptyMap: NonEmptyMap,
   MapLessThanOrEqualToTen: MapLessThanOrEqualToTen,
+  MapWithConstraint: MapWithConstraint,
   // Alphabetic: Alphabetic,
   OneToTen: OneToTen,
   thatTenToTen: TenToTen,
@@ -211,6 +239,8 @@ structure GetConstraintsOutput {
   // MyComplexUniqueList: MyComplexUniqueList,
   MyUtf8Bytes: Utf8Bytes,
   MyListOfUtf8Bytes: ListOfUtf8Bytes,
+  UnionWithConstraint: UnionWithConstraint,
+  ComplexStructureList: ComplexStructureList,
 }
 
 // See Comment in traits.smithy

--- a/TestModels/Constraints/runtimes/rust/src/lib.rs
+++ b/TestModels/Constraints/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/Constraints/runtimes/rust/src/lib.rs
+++ b/TestModels/Constraints/runtimes/rust/src/lib.rs
@@ -17,6 +17,7 @@ pub mod operation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;
+mod validation;
 pub mod wrapped;
 pub(crate) use crate::implementation_from_dafny::r#_Wrappers_Compile;
 pub(crate) use crate::implementation_from_dafny::simple;

--- a/TestModels/Constraints/runtimes/rust/src/lib.rs
+++ b/TestModels/Constraints/runtimes/rust/src/lib.rs
@@ -18,7 +18,6 @@ pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;
-mod validation;
 pub mod wrapped;
 pub(crate) use crate::implementation_from_dafny::r#_Wrappers_Compile;
 pub(crate) use crate::implementation_from_dafny::simple;

--- a/TestModels/Constraints/src/SimpleConstraintsImpl.dfy
+++ b/TestModels/Constraints/src/SimpleConstraintsImpl.dfy
@@ -25,9 +25,11 @@ module SimpleConstraintsImpl refines AbstractSimpleConstraintsOperations  {
       MyList := input.MyList,
       NonEmptyList := input.NonEmptyList,
       ListLessThanOrEqualToTen := input.ListLessThanOrEqualToTen,
+      ListWithConstraint := input.ListWithConstraint,
       MyMap := input.MyMap,
       NonEmptyMap := input.NonEmptyMap,
       MapLessThanOrEqualToTen := input.MapLessThanOrEqualToTen,
+      MapWithConstraint := input.MapWithConstraint,
       // Alphabetic := input.Alphabetic,
       OneToTen := input.OneToTen,
       GreaterThanOne := input.GreaterThanOne,
@@ -35,7 +37,9 @@ module SimpleConstraintsImpl refines AbstractSimpleConstraintsOperations  {
       // MyUniqueList := input.MyUniqueList,
       // MyComplexUniqueList := input.MyComplexUniqueList,
       MyUtf8Bytes := input.MyUtf8Bytes,
-      MyListOfUtf8Bytes := input.MyListOfUtf8Bytes
+      MyListOfUtf8Bytes := input.MyListOfUtf8Bytes,
+      UnionWithConstraint := input.UnionWithConstraint,
+      ComplexStructureList := input.ComplexStructureList
     );
 
     return Success(res);

--- a/TestModels/Constraints/test/Helpers.dfy
+++ b/TestModels/Constraints/test/Helpers.dfy
@@ -33,9 +33,11 @@ module Helpers {
       MyList := Some(["00", "11"]),
       NonEmptyList := Some(["00", "11"]),
       ListLessThanOrEqualToTen := Some(["00", "11"]),
+      ListWithConstraint := Some(["0", "123", "MaxTenChar"]),
       MyMap := Some(map["0" := "1", "2" := "3"]),
       NonEmptyMap := Some(map["0" := "1", "2" := "3"]),
       MapLessThanOrEqualToTen := Some(map["0" := "1", "2" := "3"]),
+      MapWithConstraint := Some(map["0" := "0123456789", "abcdefghij" := "z"]),
       // Alphabetic := Some("alphabetic"),
       OneToTen := Some(3),
       myTenToTen := Some(3),
@@ -44,7 +46,12 @@ module Helpers {
       // MyUniqueList := Some(["one", "two"]),
       // MyComplexUniqueList := Some(myComplexUniqueList),
       MyUtf8Bytes := Some(PROVIDER_ID),
-      MyListOfUtf8Bytes := Some([PROVIDER_ID, PROVIDER_ID])
+      MyListOfUtf8Bytes := Some([PROVIDER_ID, PROVIDER_ID]),
+      UnionWithConstraint := Some(IntegerValue(1)),
+      ComplexStructureList := Some([
+        ComplexStructure(InnerString := Some("s1"), InnerBlob := [1, 1]),
+        ComplexStructure(InnerString := Some("s2"), InnerBlob := [2, 3, 4])
+      ])
     )
   }
 

--- a/TestModels/Constraints/test/WrappedSimpleConstraintsTest.dfy
+++ b/TestModels/Constraints/test/WrappedSimpleConstraintsTest.dfy
@@ -25,12 +25,16 @@ module WrappedSimpleConstraintsTest {
     TestGetConstraintWithMyList(client);
     TestGetConstraintWithNonEmptyList(client);
     TestGetConstraintWithListLessThanOrEqualToTen(client);
+    TestGetConstraintWithListWithConstraint(client);
     TestGetConstraintWithMyMap(client);
     TestGetConstraintWithNonEmptyMap(client);
     TestGetConstraintWithMapLessThanOrEqualToTen(client);
+    TestGetConstraintWithMapWithConstraint(client);
     TestGetConstraintWithGreaterThanOne(client);
     TestGetConstraintWithUtf8Bytes(client);
     TestGetConstraintWithListOfUtf8Bytes(client);
+    TestGetConstraintWithUnionWithConstraint(client);
+    TestGetConstraintWithComplexStructureList(client);
 
     var allowBadUtf8BytesFromDafny := true;
     if (allowBadUtf8BytesFromDafny) {
@@ -373,6 +377,20 @@ module WrappedSimpleConstraintsTest {
     expect ret.Failure?;
   }
 
+  // both list and member have @length(min: 1, max: 10)
+  method TestGetConstraintWithListWithConstraint(client: ISimpleConstraintsClient)
+    requires client.ValidState()
+    modifies client.Modifies
+    ensures client.ValidState()
+  {
+    var input := GetValidInput();
+    input := input.(ListWithConstraint := Some(["1", "2", "3"]));
+    var ret := client.GetConstraints(input := input);
+    expect ret.Success?;
+
+    // TODO: Add negative tests once all languages support it
+  }
+
   // @length(min: 1, max: 10)
   method TestGetConstraintWithMyMap(client: ISimpleConstraintsClient)
     requires client.ValidState()
@@ -443,6 +461,20 @@ module WrappedSimpleConstraintsTest {
     input := input.(MapLessThanOrEqualToTen := Some(ForceMapLessThanOrEqualToTen(map["1" := "a", "2" := "a", "3" := "a", "4" := "a", "5" := "a", "6" := "a", "7" := "a", "8" := "a", "9" := "a", "0" := "a", "a" := "a"])));
     ret := client.GetConstraints(input := input);
     expect ret.Failure?;
+  }
+
+  // both map and member have @length(min: 1, max: 10)
+  method TestGetConstraintWithMapWithConstraint(client: ISimpleConstraintsClient)
+    requires client.ValidState()
+    modifies client.Modifies
+    ensures client.ValidState()
+  {
+    var input := GetValidInput();
+    input := input.(MapWithConstraint := Some(map["0" := "1234", "abcd" := "j"]));
+    var ret := client.GetConstraints(input := input);
+    expect ret.Success?;
+
+    // TODO: Add negative tests once all languages support it
   }
 
   // @range(min: 1)
@@ -588,5 +620,39 @@ module WrappedSimpleConstraintsTest {
     input := input.(MyListOfUtf8Bytes := Some(ForceListOfUtf8Bytes([good, bad])));
     ret := client.GetConstraints(input := input);
     expect ret.Failure?;
+  }
+
+  method TestGetConstraintWithUnionWithConstraint(client: ISimpleConstraintsClient)
+    requires client.ValidState()
+    modifies client.Modifies
+    ensures client.ValidState()
+  {
+    var input := GetValidInput();
+    input := input.(UnionWithConstraint := Some(IntegerValue(1)));
+    var ret := client.GetConstraints(input := input);
+    expect ret.Success?;
+
+    input := GetValidInput();
+    input := input.(UnionWithConstraint := Some(StringValue("foo")));
+    ret := client.GetConstraints(input := input);
+    expect ret.Success?;
+
+    // TODO: Add negative tests once all languages support it
+  }
+
+  method TestGetConstraintWithComplexStructureList(client: ISimpleConstraintsClient)
+    requires client.ValidState()
+    modifies client.Modifies
+    ensures client.ValidState()
+  {
+    var input := GetValidInput();
+    input := input.(ComplexStructureList := Some([
+      ComplexStructure(InnerString := Some("a"), InnerBlob := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+      ComplexStructure(InnerString := Some("abcdefghij"), InnerBlob := [0])
+    ]));
+    var ret := client.GetConstraints(input := input);
+    expect ret.Success?;
+
+    // TODO: Add negative tests once all languages support it
   }
 }

--- a/TestModels/Constraints/test/WrappedSimpleConstraintsTest.dfy
+++ b/TestModels/Constraints/test/WrappedSimpleConstraintsTest.dfy
@@ -33,13 +33,19 @@ module WrappedSimpleConstraintsTest {
     TestGetConstraintWithGreaterThanOne(client);
     TestGetConstraintWithUtf8Bytes(client);
     TestGetConstraintWithListOfUtf8Bytes(client);
-    TestGetConstraintWithUnionWithConstraint(client);
     TestGetConstraintWithComplexStructureList(client);
 
     var allowBadUtf8BytesFromDafny := true;
     if (allowBadUtf8BytesFromDafny) {
       TestGetConstraintWithBadUtf8Bytes(client);
       TestGetConstraintWithListOfBadUtf8Bytes(client);
+    }
+
+    // This doesn't work in Java.
+    // See https://github.com/smithy-lang/smithy-dafny/issues/278
+    var supportsOptionalPrimitiveFields := true;
+    if (supportsOptionalPrimitiveFields) {
+      TestGetConstraintWithUnionWithConstraint(client);
     }
   }
 

--- a/TestModels/Constructor/runtimes/rust/src/lib.rs
+++ b/TestModels/Constructor/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/Dependencies/runtimes/rust/src/lib.rs
+++ b/TestModels/Dependencies/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/Documentation/runtimes/rust/src/lib.rs
+++ b/TestModels/Documentation/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/Errors/runtimes/rust/src/lib.rs
+++ b/TestModels/Errors/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/Extendable/runtimes/rust/src/lib.rs
+++ b/TestModels/Extendable/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/LanguageSpecificLogic/runtimes/rust/src/lib.rs
+++ b/TestModels/LanguageSpecificLogic/runtimes/rust/src/lib.rs
@@ -15,7 +15,6 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
-pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/LanguageSpecificLogic/runtimes/rust/src/lib.rs
+++ b/TestModels/LanguageSpecificLogic/runtimes/rust/src/lib.rs
@@ -15,6 +15,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/LocalService/runtimes/rust/src/lib.rs
+++ b/TestModels/LocalService/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/MultipleModels/runtimes/rust/src/lib.rs
+++ b/TestModels/MultipleModels/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/Positional/runtimes/rust/src/lib.rs
+++ b/TestModels/Positional/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/Refinement/runtimes/rust/src/lib.rs
+++ b/TestModels/Refinement/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/Refinement/runtimes/rust/src/lib.rs
+++ b/TestModels/Refinement/runtimes/rust/src/lib.rs
@@ -14,7 +14,6 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
-pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/Resource/runtimes/rust/src/lib.rs
+++ b/TestModels/Resource/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/SimpleTypes/SimpleBlob/runtimes/rust/src/lib.rs
+++ b/TestModels/SimpleTypes/SimpleBlob/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/SimpleTypes/SimpleBoolean/runtimes/rust/src/lib.rs
+++ b/TestModels/SimpleTypes/SimpleBoolean/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/SimpleTypes/SimpleDouble/runtimes/rust/src/lib.rs
+++ b/TestModels/SimpleTypes/SimpleDouble/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/SimpleTypes/SimpleEnum/runtimes/rust/src/lib.rs
+++ b/TestModels/SimpleTypes/SimpleEnum/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/SimpleTypes/SimpleEnumV2/runtimes/rust/src/lib.rs
+++ b/TestModels/SimpleTypes/SimpleEnumV2/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/SimpleTypes/SimpleInteger/runtimes/rust/src/lib.rs
+++ b/TestModels/SimpleTypes/SimpleInteger/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/SimpleTypes/SimpleLong/runtimes/rust/src/lib.rs
+++ b/TestModels/SimpleTypes/SimpleLong/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/SimpleTypes/SimpleString/runtimes/rust/src/lib.rs
+++ b/TestModels/SimpleTypes/SimpleString/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/SimpleTypes/SimpleTimestamp/runtimes/rust/src/lib.rs
+++ b/TestModels/SimpleTypes/SimpleTimestamp/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/TestModels/Union/runtimes/rust/src/lib.rs
+++ b/TestModels/Union/runtimes/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub(crate) mod implementation_from_dafny;
 /// All operations that this crate can perform.
 pub mod operation;
+pub mod validation;
 mod standard_library_conversions;
 mod standard_library_externs;
 pub mod types;

--- a/codegen/smithy-dafny-codegen-test/src/test/java/software/amazon/polymorph/smithyjava/JavaTestModels.java
+++ b/codegen/smithy-dafny-codegen-test/src/test/java/software/amazon/polymorph/smithyjava/JavaTestModels.java
@@ -11,7 +11,9 @@ import java.util.Set;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.polymorph.CodegenEngine;
 import software.amazon.polymorph.TestModelTest;
+import software.amazon.polymorph.smithydafny.DafnyVersion;
 
 class JavaTestModels extends TestModelTest {
 
@@ -58,6 +60,15 @@ class JavaTestModels extends TestModelTest {
   @ParameterizedTest
   @MethodSource("discoverTestModels")
   void testModelsForJava(String relativeTestModelPath) {
+    // This test is hacked up to pass for Java in a way that doesn't work
+    // for older Dafny versions.
+    if (relativeTestModelPath.endsWith("Constraints")) {
+      DafnyVersion dafnyVersion = CodegenEngine.getDafnyVersionFromDafny();
+      if (dafnyVersion.compareTo(DafnyVersion.parse("4.9.0")) < 0) {
+        Assumptions.assumeTrue(false);
+      }
+    }
+
     Assumptions.assumeFalse(DISABLED_TESTS.contains(relativeTestModelPath));
 
     Path testModelPath = getTestModelPath(relativeTestModelPath);

--- a/codegen/smithy-dafny-codegen-test/src/test/java/software/amazon/polymorph/smithyrust/RustTestModels.java
+++ b/codegen/smithy-dafny-codegen-test/src/test/java/software/amazon/polymorph/smithyrust/RustTestModels.java
@@ -19,7 +19,6 @@ class RustTestModels extends TestModelTest {
 
   static {
     DISABLED_TESTS.add("AggregateReferences");
-    DISABLED_TESTS.add("CallingAWSSDKFromLocalService");
     DISABLED_TESTS.add("CodegenPatches");
     DISABLED_TESTS.add("Dependencies");
     DISABLED_TESTS.add("Extern");

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/CodegenEngine.java
@@ -1378,7 +1378,7 @@ public class CodegenEngine {
     }
   }
 
-  private static DafnyVersion getDafnyVersionFromDafny() {
+  public static DafnyVersion getDafnyVersionFromDafny() {
     String versionString = runCommandOrThrow(
       Path.of("."),
       "dafny",

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/AbstractRustShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/AbstractRustShimGenerator.java
@@ -48,6 +48,7 @@ import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.StringTrait;
+import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
 
 public abstract class AbstractRustShimGenerator {
@@ -132,8 +133,8 @@ public abstract class AbstractRustShimGenerator {
     StructureShape structureShape
   ) {
     return (
+      !structureShape.hasTrait(TraitDefinition.class) &&
       !structureShape.hasTrait(ErrorTrait.class) &&
-      !structureShape.hasTrait(ShapeId.from("smithy.api#trait")) &&
       !structureShape.hasTrait(ReferenceTrait.class) &&
       ModelUtils.isInServiceNamespace(structureShape, service)
     );

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustAwsSdkShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustAwsSdkShimGenerator.java
@@ -824,6 +824,8 @@ public class RustAwsSdkShimGenerator extends AbstractRustShimGenerator {
       bindingShape,
       operationShape
     );
+    variables.put("operationInputType", rustTypeForShape(operationIndex.getInputShape(operationShape).get()));
+    variables.put("operationOutputType", rustTypeForShape(operationIndex.getOutputShape(operationShape).get()));
     variables.put(
       "sdkOperationInputStruct",
       sdkOperationInputStruct(operationShape)

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustAwsSdkShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustAwsSdkShimGenerator.java
@@ -824,8 +824,14 @@ public class RustAwsSdkShimGenerator extends AbstractRustShimGenerator {
       bindingShape,
       operationShape
     );
-    variables.put("operationInputType", rustTypeForShape(operationIndex.getInputShape(operationShape).get()));
-    variables.put("operationOutputType", rustTypeForShape(operationIndex.getOutputShape(operationShape).get()));
+    variables.put(
+      "operationInputType",
+      rustTypeForShape(operationIndex.getInputShape(operationShape).get())
+    );
+    variables.put(
+      "operationOutputType",
+      rustTypeForShape(operationIndex.getOutputShape(operationShape).get())
+    );
     variables.put(
       "sdkOperationInputStruct",
       sdkOperationInputStruct(operationShape)

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1176,6 +1176,14 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
             shapeType = operationVariables.get("operationOutputType");
           }
           variables.put("shapeType", shapeType);
+        } else if (ModelUtils.getConfigShape(model, service).getId().equals(shape.getId())) {
+          // The config shape is a bit special, because even if it's declared in a dependent service
+          // we still re-declare it for this one.
+          variables.put("shapeType", "%s::%s::%s".formatted(
+            getRustTypesModuleName(),
+            toSnakeCase(rustStructureName((StructureShape)shape)),
+            rustStructureName((StructureShape)shape)
+          ));
         } else {
           variables.put("shapeType", mergedGeneratorRustTypeForShape(shape));
         }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1047,6 +1047,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
           );
         }
       } else if (shape instanceof StructureShape structureShape) {
+        var isPositiional = structureShape.hasTrait(PositionalTrait.class);
         for (final var memberShape : structureShape.getAllMembers().values()) {
           final var memberVariables = structureMemberVariables(memberShape);
           memberVariables.put(
@@ -1055,6 +1056,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
           );
           validationBlocks.add(
             evalTemplate(
+              isPositiional ? "$memberValidationFunctionName:L(&input)?;" :
               "$memberValidationFunctionName:L(&input.$fieldName:L)?;",
               memberVariables
             )

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -175,6 +175,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
     /// All operations that this crate can perform.
     pub mod operation;
     pub mod conversions;
+    pub mod validation;
     pub mod deps;
     """;
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1047,7 +1047,8 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
           );
         }
       } else if (shape instanceof StructureShape structureShape) {
-        var isPositionalOutput = operation != null && structureShape.hasTrait(PositionalTrait.class);
+        var isPositionalOutput = (operation == null || operation.getOutputShape().equals(shape.getId()))
+          && structureShape.hasTrait(PositionalTrait.class);
         for (final var memberShape : structureShape.getAllMembers().values()) {
           final var memberVariables = structureMemberVariables(memberShape);
           memberVariables.put(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1047,8 +1047,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
           );
         }
       } else if (shape instanceof StructureShape structureShape) {
-        var isPositionalOutput = operation != null && operation.getOutputShape().equals(shape.getId())
-          && structureShape.hasTrait(PositionalTrait.class);
+        var isPositionalOutput = operation != null && structureShape.hasTrait(PositionalTrait.class);
         for (final var memberShape : structureShape.getAllMembers().values()) {
           final var memberVariables = structureMemberVariables(memberShape);
           memberVariables.put(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -996,9 +996,11 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
     ) {
       final var validationBlocks = new ArrayList<String>();
 
-      final var parentShape = shape instanceof MemberShape memberShape ?
-        model.expectShape(memberShape.getContainer()) : null;
-      final var isStructureMember = parentShape != null && parentShape.isStructureShape();
+      final var parentShape = shape instanceof MemberShape memberShape
+        ? model.expectShape(memberShape.getContainer())
+        : null;
+      final var isStructureMember =
+        parentShape != null && parentShape.isStructureShape();
 
       if (shape instanceof MemberShape memberShape) {
         memberShape
@@ -1047,8 +1049,10 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
           );
         }
       } else if (shape instanceof StructureShape structureShape) {
-        var isPositionalOutput = (operation == null || operation.getOutputShape().equals(shape.getId()))
-          && structureShape.hasTrait(PositionalTrait.class);
+        var isPositionalOutput =
+          (operation == null ||
+            operation.getOutputShape().equals(shape.getId())) &&
+          structureShape.hasTrait(PositionalTrait.class);
         for (final var memberShape : structureShape.getAllMembers().values()) {
           final var memberVariables = structureMemberVariables(memberShape);
           memberVariables.put(
@@ -1063,9 +1067,14 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
                 memberVariables
               )
             );
-          } else if (mergedGenerator.generatorForShape(structureShape).isRustFieldRequired(structureShape, memberShape)
-              // TODO: This may be more correct than the current isRustFieldRequired in general
-              && !(operationIndex.isOutputStructure(structureShape) && model.expectShape(memberShape.getTarget()).isListShape())) {
+          } else if (
+            mergedGenerator
+              .generatorForShape(structureShape)
+              .isRustFieldRequired(structureShape, memberShape) &&
+            // TODO: This may be more correct than the current isRustFieldRequired in general
+            !(operationIndex.isOutputStructure(structureShape) &&
+              model.expectShape(memberShape.getTarget()).isListShape())
+          ) {
             validationBlocks.add(
               evalTemplate(
                 "$memberValidationFunctionName:L(&Some(input.$fieldName:L.clone()))?;",
@@ -1165,10 +1174,9 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
             variables.put("shapeType", targetType);
           }
         } else if (operation != null) {
-          final var operationVariables = mergedGenerator.generatorForShape(bindingShape).operationVariables(
-            bindingShape,
-            operation
-          );
+          final var operationVariables = mergedGenerator
+            .generatorForShape(bindingShape)
+            .operationVariables(bindingShape, operation);
           final String shapeType;
           if (operation.getInputShape().equals(shape.getId())) {
             shapeType = operationVariables.get("operationInputType");
@@ -1176,14 +1184,22 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
             shapeType = operationVariables.get("operationOutputType");
           }
           variables.put("shapeType", shapeType);
-        } else if (ModelUtils.getConfigShape(model, service).getId().equals(shape.getId())) {
+        } else if (
+          ModelUtils
+            .getConfigShape(model, service)
+            .getId()
+            .equals(shape.getId())
+        ) {
           // The config shape is a bit special, because even if it's declared in a dependent service
           // we still re-declare it for this one.
-          variables.put("shapeType", "%s::%s::%s".formatted(
-            getRustTypesModuleName(),
-            toSnakeCase(rustStructureName((StructureShape)shape)),
-            rustStructureName((StructureShape)shape)
-          ));
+          variables.put(
+            "shapeType",
+            "%s::%s::%s".formatted(
+                getRustTypesModuleName(),
+                toSnakeCase(rustStructureName((StructureShape) shape)),
+                rustStructureName((StructureShape) shape)
+              )
+          );
         } else {
           variables.put("shapeType", mergedGeneratorRustTypeForShape(shape));
         }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1138,7 +1138,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
         if (shape instanceof MemberShape memberShape) {
           final var targetShape = model.expectShape(memberShape.getTarget());
           final var targetType = mergedGeneratorRustTypeForShape(targetShape);
-          if (isStructureMember && isRustFieldRequired((StructureShape)parentShape, memberShape)) {
+          if (isStructureMember && !isRustFieldRequired((StructureShape)parentShape, memberShape)) {
             variables.put(
               "shapeType",
               "::std::option::Option<%s>".formatted(targetType)

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -996,9 +996,9 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
     ) {
       final var validationBlocks = new ArrayList<String>();
 
-      final var isStructureMember =
-        shape instanceof MemberShape memberShape &&
-        model.expectShape(memberShape.getContainer()).isStructureShape();
+      final var parentShape = shape instanceof MemberShape memberShape ?
+        model.expectShape(memberShape.getContainer()) : null;
+      final var isStructureMember = parentShape != null && parentShape.isStructureShape();
 
       if (shape instanceof MemberShape memberShape) {
         memberShape
@@ -1138,7 +1138,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
         if (shape instanceof MemberShape memberShape) {
           final var targetShape = model.expectShape(memberShape.getTarget());
           final var targetType = mergedGeneratorRustTypeForShape(targetShape);
-          if (isStructureMember) {
+          if (isStructureMember && isRustFieldRequired((StructureShape)parentShape, memberShape)) {
             variables.put(
               "shapeType",
               "::std::option::Option<%s>".formatted(targetType)

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1063,7 +1063,9 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
                 memberVariables
               )
             );
-          } else if (mergedGenerator.generatorForShape(structureShape).isRustFieldRequired(structureShape, memberShape)) {
+          } else if (mergedGenerator.generatorForShape(structureShape).isRustFieldRequired(structureShape, memberShape)
+              // TODO: This may be more correct than the current isRustFieldRequired in general
+              && !(operationIndex.isOutputStructure(structureShape) && model.expectShape(memberShape.getTarget()).isListShape())) {
             validationBlocks.add(
               evalTemplate(
                 "$memberValidationFunctionName:L(&Some(input.$fieldName:L.clone()))?;",
@@ -1163,7 +1165,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
             variables.put("shapeType", targetType);
           }
         } else if (operation != null) {
-          final var operationVariables = operationVariables(
+          final var operationVariables = mergedGenerator.generatorForShape(bindingShape).operationVariables(
             bindingShape,
             operation
           );
@@ -1175,7 +1177,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
           }
           variables.put("shapeType", shapeType);
         } else {
-          variables.put("shapeType", rustTypeForShape(shape));
+          variables.put("shapeType", mergedGeneratorRustTypeForShape(shape));
         }
       } catch (Exception e) {
         throw new RuntimeException(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1047,7 +1047,8 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
           );
         }
       } else if (shape instanceof StructureShape structureShape) {
-        var isPositiional = structureShape.hasTrait(PositionalTrait.class);
+        var isPositionalOutput = operation != null && operation.getOutputShape().equals(shape.getId())
+          && structureShape.hasTrait(PositionalTrait.class);
         for (final var memberShape : structureShape.getAllMembers().values()) {
           final var memberVariables = structureMemberVariables(memberShape);
           memberVariables.put(
@@ -1056,7 +1057,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
           );
           validationBlocks.add(
             evalTemplate(
-              isPositiional ? "$memberValidationFunctionName:L(&Some(input.clone()))?;" :
+              isPositionalOutput ? "$memberValidationFunctionName:L(&Some(input.clone()))?;" :
               "$memberValidationFunctionName:L(&input.$fieldName:L)?;",
               memberVariables
             )

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -927,20 +927,21 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
     }
 
     private String generateValidationFunctions(final Shape shape) {
+      var result = generateValidationFunction(null, null, shape);
       if (operationIndex.isInputStructure(shape)) {
-        return operationIndex.getInputBindings(shape)
+        return result + "\n" + operationIndex.getInputBindings(shape)
           .stream()
           .flatMap(operation -> operationBindingIndex.getBoundOperations(operation).stream())
           .map(boundOperation -> generateValidationFunction(boundOperation.bindingShape(), boundOperation.operationShape(), shape))
           .collect(Collectors.joining("\n"));
       } else if (operationIndex.isOutputStructure(shape)) {
-        return operationIndex.getOutputBindings(shape)
+        return result + "\n" + operationIndex.getOutputBindings(shape)
           .stream()
           .flatMap(operation -> operationBindingIndex.getBoundOperations(operation).stream())
           .map(boundOperation -> generateValidationFunction(boundOperation.bindingShape(), boundOperation.operationShape(), shape))
           .collect(Collectors.joining("\n"));
       } else {
-        return generateValidationFunction(null, null, shape);
+        return result;
       }
     }
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1056,7 +1056,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
           );
           validationBlocks.add(
             evalTemplate(
-              isPositiional ? "$memberValidationFunctionName:L(&input)?;" :
+              isPositiional ? "$memberValidationFunctionName:L(&Some(input.clone()))?;" :
               "$memberValidationFunctionName:L(&input.$fieldName:L)?;",
               memberVariables
             )

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1137,7 +1137,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
       try {
         if (shape instanceof MemberShape memberShape) {
           final var targetShape = model.expectShape(memberShape.getTarget());
-          final var targetType = rustTypeForShape(targetShape);
+          final var targetType = mergedGeneratorRustTypeForShape(targetShape);
           if (isStructureMember) {
             variables.put(
               "shapeType",

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -253,7 +253,11 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
     );
     variables.put(
       "inputValidationFunctionName",
-      RustValidationGenerator.shapeValidationFunctionName(null, null, configShape)
+      RustValidationGenerator.shapeValidationFunctionName(
+        null,
+        null,
+        configShape
+      )
     );
 
     final String content = evalTemplateResource(
@@ -781,7 +785,11 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
     );
     variables.put(
       "inputValidationFunctionName",
-      RustValidationGenerator.shapeValidationFunctionName(bindingShape, operationShape, inputShape)
+      RustValidationGenerator.shapeValidationFunctionName(
+        bindingShape,
+        operationShape,
+        inputShape
+      )
     );
     if (bindingShape.isServiceShape()) {
       if (inputShape.hasTrait(PositionalTrait.class)) {
@@ -929,17 +937,43 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
     private String generateValidationFunctions(final Shape shape) {
       var result = generateValidationFunction(null, null, shape);
       if (operationIndex.isInputStructure(shape)) {
-        return result + "\n" + operationIndex.getInputBindings(shape)
-          .stream()
-          .flatMap(operation -> operationBindingIndex.getBoundOperations(operation).stream())
-          .map(boundOperation -> generateValidationFunction(boundOperation.bindingShape(), boundOperation.operationShape(), shape))
-          .collect(Collectors.joining("\n"));
+        return (
+          result +
+          "\n" +
+          operationIndex
+            .getInputBindings(shape)
+            .stream()
+            .flatMap(operation ->
+              operationBindingIndex.getBoundOperations(operation).stream()
+            )
+            .map(boundOperation ->
+              generateValidationFunction(
+                boundOperation.bindingShape(),
+                boundOperation.operationShape(),
+                shape
+              )
+            )
+            .collect(Collectors.joining("\n"))
+        );
       } else if (operationIndex.isOutputStructure(shape)) {
-        return result + "\n" + operationIndex.getOutputBindings(shape)
-          .stream()
-          .flatMap(operation -> operationBindingIndex.getBoundOperations(operation).stream())
-          .map(boundOperation -> generateValidationFunction(boundOperation.bindingShape(), boundOperation.operationShape(), shape))
-          .collect(Collectors.joining("\n"));
+        return (
+          result +
+          "\n" +
+          operationIndex
+            .getOutputBindings(shape)
+            .stream()
+            .flatMap(operation ->
+              operationBindingIndex.getBoundOperations(operation).stream()
+            )
+            .map(boundOperation ->
+              generateValidationFunction(
+                boundOperation.bindingShape(),
+                boundOperation.operationShape(),
+                shape
+              )
+            )
+            .collect(Collectors.joining("\n"))
+        );
       } else {
         return result;
       }
@@ -955,7 +989,11 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
      * <p>
      * Other modules should therefore only call validation functions for aggregate shapes.
      */
-    private String generateValidationFunction(final Shape bindingShape, final OperationShape operation, final Shape shape) {
+    private String generateValidationFunction(
+      final Shape bindingShape,
+      final OperationShape operation,
+      final Shape shape
+    ) {
       final var validationBlocks = new ArrayList<String>();
 
       final var isStructureMember =
@@ -1140,16 +1178,23 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
       );
     }
 
-    public static String shapeValidationFunctionName(final Shape bindingShape, final OperationShape operationShape, final Shape shape) {
+    public static String shapeValidationFunctionName(
+      final Shape bindingShape,
+      final OperationShape operationShape,
+      final Shape shape
+    ) {
       // the ID foo.bar_baz.quux#My_ShapeName$the_member
       // becomes foo_Pbar__baz_Pquux_HMy__ShapeName_Dthe__member
       // If bindingShape/operationShape is not null (because the shape is the input/output for this operation)
       // the unqualified name is added as a ..._for_<escaped binding name>_<escaped operation name> suffix
       var escapedId = escapedName(shape.getId().toString());
       if (operationShape != null) {
-        escapedId = escapedId + "_for_"
-          + escapedName(bindingShape.getId().getName()) + "_"
-          + escapedName(operationShape.getId().getName());
+        escapedId =
+          escapedId +
+          "_for_" +
+          escapedName(bindingShape.getId().getName()) +
+          "_" +
+          escapedName(operationShape.getId().getName());
       }
 
       return "validate_" + escapedId;

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1063,7 +1063,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
                 memberVariables
               )
             );
-          } else if (isRustFieldRequired(structureShape, memberShape)) {
+          } else if (mergedGenerator.generatorForShape(structureShape).isRustFieldRequired(structureShape, memberShape)) {
             validationBlocks.add(
               evalTemplate(
                 "$memberValidationFunctionName:L(&Some(input.$fieldName:L))?;",

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1066,7 +1066,7 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
           } else if (mergedGenerator.generatorForShape(structureShape).isRustFieldRequired(structureShape, memberShape)) {
             validationBlocks.add(
               evalTemplate(
-                "$memberValidationFunctionName:L(&Some(input.$fieldName:L))?;",
+                "$memberValidationFunctionName:L(&Some(input.$fieldName:L.clone()))?;",
                 memberVariables
               )
             );

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ConstrainTraitUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ConstrainTraitUtils.java
@@ -8,12 +8,10 @@ import java.util.stream.Stream;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.LengthTrait;
 import software.amazon.smithy.model.traits.RangeTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.Trait;
-import software.amazon.smithy.utils.Pair;
 
 // TODO: Support idRef, pattern, uniqueItems
 public class ConstrainTraitUtils {
@@ -34,75 +32,6 @@ public class ConstrainTraitUtils {
     return (
       hasRequiredTrait(shape) || hasRangeTrait(shape) || hasLengthTrait(shape)
     );
-  }
-
-  /**
-   * Utility class to generate validation expressions for all members of a structure.
-   *
-   * @param <V> type of validation expressions, typically {@link String} or {@link TokenTree}
-   */
-  public abstract static class ValidationGenerator<V> {
-
-    protected abstract V validateRequired(MemberShape memberShape);
-
-    protected abstract V validateRange(
-      MemberShape memberShape,
-      RangeTrait rangeTrait
-    );
-
-    protected abstract V validateLength(
-      MemberShape memberShape,
-      LengthTrait lengthTrait
-    );
-
-    /**
-     * Returns a stream of constraint traits that Polymorph-generated code should enforce
-     * on any code path that invokes a service or resource operation,
-     * from either the given shape or the targeted shape (if the given shape is a member shape).
-     */
-    private Stream<? extends Trait> enforcedConstraints(
-      final Model model,
-      final Shape shape
-    ) {
-      return Stream
-        .of(
-          shape.getMemberTrait(model, RequiredTrait.class),
-          shape.getMemberTrait(model, RangeTrait.class),
-          shape.getMemberTrait(model, LengthTrait.class)
-        )
-        .flatMap(Optional::stream);
-    }
-
-    public Stream<V> generateValidations(
-      final Model model,
-      final StructureShape structureShape
-    ) {
-      return structureShape
-        .getAllMembers()
-        .values()
-        .stream()
-        .flatMap(memberShape ->
-          enforcedConstraints(model, memberShape)
-            .map(trait -> Pair.of(memberShape, trait))
-        )
-        .map(memberTrait -> {
-          final MemberShape memberShape = memberTrait.left;
-          final Trait trait = memberTrait.right;
-          if (trait instanceof RequiredTrait) {
-            return validateRequired(memberShape);
-          } else if (trait instanceof RangeTrait rangeTrait) {
-            return validateRange(memberShape, rangeTrait);
-          } else if (trait instanceof LengthTrait lengthTrait) {
-            return validateLength(memberShape, lengthTrait);
-          }
-          throw new UnsupportedOperationException(
-            "Unsupported constraint trait %s on shape %s".formatted(
-                trait,
-                structureShape.getId()
-              )
-          );
-        });
-    }
   }
 
   public static class RangeTraitUtils {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/OperationBindingIndex.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/OperationBindingIndex.java
@@ -6,6 +6,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.KnowledgeIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -18,6 +20,7 @@ import software.amazon.smithy.utils.SetUtils;
 
 public class OperationBindingIndex implements KnowledgeIndex {
 
+  private final Model model;
   private final Set<Shape> bindingShapes = new HashSet<>();
   private final Map<ShapeId, Set<Shape>> bindingShapesForOperation =
     new HashMap();
@@ -25,6 +28,8 @@ public class OperationBindingIndex implements KnowledgeIndex {
     new HashMap();
 
   public OperationBindingIndex(Model model) {
+    this.model = model;
+
     for (final ServiceShape service : model.getServiceShapes()) {
       bindingShapes.add(service);
       for (final ShapeId operationId : service.getOperations()) {
@@ -69,6 +74,16 @@ public class OperationBindingIndex implements KnowledgeIndex {
         Collections.emptySet()
       )
     );
+  }
+
+  public Set<BoundOperationShape> getBoundOperations(ToShapeId operation) {
+    return getBindingShapes(operation)
+      .stream()
+      .map(bindingShape -> new BoundOperationShape(bindingShape, model.expectShape(
+        operation.toShapeId(),
+        OperationShape.class
+      )))
+      .collect(Collectors.toSet());
   }
 
   public Set<BoundOperationShape> getOperations(ToShapeId bindingShape) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/OperationBindingIndex.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/OperationBindingIndex.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.KnowledgeIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -79,10 +78,12 @@ public class OperationBindingIndex implements KnowledgeIndex {
   public Set<BoundOperationShape> getBoundOperations(ToShapeId operation) {
     return getBindingShapes(operation)
       .stream()
-      .map(bindingShape -> new BoundOperationShape(bindingShape, model.expectShape(
-        operation.toShapeId(),
-        OperationShape.class
-      )))
+      .map(bindingShape ->
+        new BoundOperationShape(
+          bindingShape,
+          model.expectShape(operation.toShapeId(), OperationShape.class)
+        )
+      )
       .collect(Collectors.toSet());
   }
 

--- a/codegen/smithy-dafny-codegen/src/main/resources/templates/runtimes/rust/client.rs
+++ b/codegen/smithy-dafny-codegen/src/main/resources/templates/runtimes/rust/client.rs
@@ -12,7 +12,7 @@ impl Client {
     pub fn from_conf(
         input: $qualifiedRustConfigName:L,
     ) -> Result<Self, $qualifiedRustServiceErrorType:L> {
-        crate::validation::$inputValidationFunctionName:L(&input)
+        $rustRootModuleName:L::validation::$inputValidationFunctionName:L(&input)
             .map_err($qualifiedRustServiceErrorType:L::wrap_validation_err)?;
         let inner =
             crate::$dafnyInternalModuleName:L::_default::$sdkId:L(

--- a/codegen/smithy-dafny-codegen/src/main/resources/templates/runtimes/rust/client.rs
+++ b/codegen/smithy-dafny-codegen/src/main/resources/templates/runtimes/rust/client.rs
@@ -12,7 +12,8 @@ impl Client {
     pub fn from_conf(
         input: $qualifiedRustConfigName:L,
     ) -> Result<Self, $qualifiedRustServiceErrorType:L> {
-        $inputValidations:L
+        crate::validation::$inputValidationFunctionName:L(&input)
+            .map_err($qualifiedRustServiceErrorType:L::wrap_validation_err)?;
         let inner =
             crate::$dafnyInternalModuleName:L::_default::$sdkId:L(
                 &$rustConversionsModuleName:L::$snakeCaseConfigName:L::_$snakeCaseConfigName:L::to_dafny(input),

--- a/codegen/smithy-dafny-codegen/src/main/resources/templates/runtimes/rust/operation/outer.rs
+++ b/codegen/smithy-dafny-codegen/src/main/resources/templates/runtimes/rust/operation/outer.rs
@@ -15,7 +15,8 @@ impl $pascalCaseOperationName:L {
         $operationOutputType:L,
         $qualifiedRustServiceErrorType:L,
     > {
-        $inputValidations:L
+        crate::validation::$inputValidationFunctionName:L(&input)
+            .map_err($qualifiedRustServiceErrorType:L::wrap_validation_err)?;
         $operationSendBody:L
     }
 }

--- a/codegen/smithy-dafny-codegen/src/main/resources/templates/runtimes/rust/operation/outer.rs
+++ b/codegen/smithy-dafny-codegen/src/main/resources/templates/runtimes/rust/operation/outer.rs
@@ -15,7 +15,7 @@ impl $pascalCaseOperationName:L {
         $operationOutputType:L,
         $qualifiedRustServiceErrorType:L,
     > {
-        crate::validation::$inputValidationFunctionName:L(&input)
+        $rustRootModuleName:L::validation::$inputValidationFunctionName:L(&input)
             .map_err($qualifiedRustServiceErrorType:L::wrap_validation_err)?;
         $operationSendBody:L
     }

--- a/codegen/smithy-dafny-codegen/src/main/resources/templates/runtimes/rust/types.rs
+++ b/codegen/smithy-dafny-codegen/src/main/resources/templates/runtimes/rust/types.rs
@@ -1,5 +1,6 @@
 /// Types for the `$configName:L`
 pub mod $snakeCaseConfigName:L;
+pub use $qualifiedRustConfigName:L;
 
 pub mod builders;
 


### PR DESCRIPTION
*Description of changes:*
The Rust codegen previously didn't validated nested constraints - it would check the direct members of structures, but not any deeper. This PR implements nested constraint validation for all the supported aggregate types.

Some notes and open questions:

* The current implementation assumes that a (synthetic) operation input or output shape is only ever used by a single operation, but #593 suggests that may not be true in the DB ESDK. We should determine whether the assumption is safe, and if not, refactor `RustValidationGenerator` accordingly.
  * Robin's note: I ended up refactoring a bit to not assume this, if nothing else because the SimpleString test model already violates it.  
* The error messages only mention the particular member shape that failed validation. It would be more helpful to provide the full path to the failing shape, or at least the name of the member's container. The latter is probably just a matter of refactoring some templates/variables, but reused input/output structures might complicate that (see previous item).
* Since nested constraint validation isn't implemented in all of the runtimes (at least not in Java and .NET, AFAICT), I've added both positive and negative Rust tests, but only positive Dafny tests (to at least confirm this PR hasn't broken anything in other runtimes).
  * Robin's note: one of the positive tests ended up failing on Java as well because of #278, so I took the same sed-based approach to disable it only for Java. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
