### PR TITLE
fix: Just emit a comment for validating SDK output structures in Rust

### DIFF
--- a/.github/workflows/test_models_rust_tests.yml
+++ b/.github/workflows/test_models_rust_tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: "1.80.0"
+          toolchain: "1.81.0"
           rustflags: ""
           components: rustfmt
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyrust/generator/RustLibraryShimGenerator.java
@@ -1058,14 +1058,21 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
         // which makes it harder to argue it should be fixed.
         // See https://github.com/smithy-lang/smithy-dafny/issues/751
         var generator = mergedGenerator.generatorForShape(shape);
-        if (generator instanceof RustAwsSdkShimGenerator && operationIndex.isOutputStructure(shape)) {
-          validationBlocks.add("// Validation intentionally suppressed for AWS SDK response structures");
+        if (
+          generator instanceof RustAwsSdkShimGenerator &&
+          operationIndex.isOutputStructure(shape)
+        ) {
+          validationBlocks.add(
+            "// Validation intentionally suppressed for AWS SDK response structures"
+          );
         } else {
           var isPositionalOutput =
             (operation == null ||
               operation.getOutputShape().equals(shape.getId())) &&
-              structureShape.hasTrait(PositionalTrait.class);
-          for (final var memberShape : structureShape.getAllMembers().values()) {
+            structureShape.hasTrait(PositionalTrait.class);
+          for (final var memberShape : structureShape
+            .getAllMembers()
+            .values()) {
             final var memberVariables = structureMemberVariables(memberShape);
             memberVariables.put(
               "memberValidationFunctionName",
@@ -1083,9 +1090,9 @@ public class RustLibraryShimGenerator extends AbstractRustShimGenerator {
               mergedGenerator
                 .generatorForShape(structureShape)
                 .isRustFieldRequired(structureShape, memberShape) &&
-                // TODO: This may be more correct than the current isRustFieldRequired in general
-                !(operationIndex.isOutputStructure(structureShape) &&
-                  model.expectShape(memberShape.getTarget()).isListShape())
+              // TODO: This may be more correct than the current isRustFieldRequired in general
+              !(operationIndex.isOutputStructure(structureShape) &&
+                model.expectShape(memberShape.getTarget()).isListShape())
             ) {
               validationBlocks.add(
                 evalTemplate(


### PR DESCRIPTION
*Issue #, if available:*
See #751

Also bumps the Rust toolchain version since the SDKs require 1.81 now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
