### PR TITLE
fix(codegen): Allow multiple paths for a shape

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ModelUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ModelUtils.java
@@ -469,15 +469,14 @@ public class ModelUtils {
     while (!toTraverse.isEmpty()) {
       final List<ShapeId> currentShapeIdWithPath = toTraverse.remove();
 
-      ShapeId last = currentShapeIdWithPath.get(
-        currentShapeIdWithPath.size() - 1
-      );
       if (pathsToShapes.add(currentShapeIdWithPath)) {
         final Shape currentShape = model.expectShape(
           currentShapeIdWithPath.get(currentShapeIdWithPath.size() - 1)
         );
         final List<List<ShapeId>> dependencyShapeIdsWithPaths =
           getDependencyShapeIds(currentShape)
+            // to avoid cycles, append only those dependencyShapeId which are not already in the path currentShapeIdWithPath
+            .filter(dependencyShapeId -> !currentShapeIdWithPath.contains(dependencyShapeId))
             .map(dependencyShapeId ->
               Stream
                 .concat(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ModelUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ModelUtils.java
@@ -461,7 +461,6 @@ public class ModelUtils {
     Set<List<ShapeId>> pathsToShapes = new LinkedHashSet<>(
       new LinkedHashSet<>()
     );
-    Set<ShapeId> visited = new HashSet<>();
 
     // Breadth-first search via getDependencyShapeIds
     final Queue<List<ShapeId>> toTraverse = new LinkedList<>(
@@ -470,11 +469,10 @@ public class ModelUtils {
     while (!toTraverse.isEmpty()) {
       final List<ShapeId> currentShapeIdWithPath = toTraverse.remove();
 
-      // to avoid cycles, only keep the first list with a given last element
       ShapeId last = currentShapeIdWithPath.get(
         currentShapeIdWithPath.size() - 1
       );
-      if (visited.add(last) && pathsToShapes.add(currentShapeIdWithPath)) {
+      if (pathsToShapes.add(currentShapeIdWithPath)) {
         final Shape currentShape = model.expectShape(
           currentShapeIdWithPath.get(currentShapeIdWithPath.size() - 1)
         );

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ModelUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/utils/ModelUtils.java
@@ -476,7 +476,9 @@ public class ModelUtils {
         final List<List<ShapeId>> dependencyShapeIdsWithPaths =
           getDependencyShapeIds(currentShape)
             // to avoid cycles, append only those dependencyShapeId which are not already in the path currentShapeIdWithPath
-            .filter(dependencyShapeId -> !currentShapeIdWithPath.contains(dependencyShapeId))
+            .filter(dependencyShapeId ->
+              !currentShapeIdWithPath.contains(dependencyShapeId)
+            )
             .map(dependencyShapeId ->
               Stream
                 .concat(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Earlier there was only one path allowed for a shape. With this change, we allow multiple paths for a single shape.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
