### PR TITLE
chore(Python): Restrict poetry-core to <2.0.0

### DIFF
--- a/TestModels/Aggregate/runtimes/python/pyproject.toml
+++ b/TestModels/Aggregate/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ smithy-dafny-standard-library = {path = "../../../dafny-dependencies/StandardLib
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/CodegenPatches/runtimes/python/pyproject.toml
+++ b/TestModels/CodegenPatches/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/Constraints/runtimes/python/pyproject.toml
+++ b/TestModels/Constraints/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/Constraints/src/Index.dfy
+++ b/TestModels/Constraints/src/Index.dfy
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 include "SimpleConstraintsImpl.dfy"
 
-module {:extern "simple.constraints.internaldafny" } SimpleConstraints refines AbstractSimpleConstraintsService {
+module SimpleConstraints refines AbstractSimpleConstraintsService {
   import Operations = SimpleConstraintsImpl
 
   function method DefaultSimpleConstraintsConfig(): SimpleConstraintsConfig {

--- a/TestModels/Constraints/src/Index.dfy
+++ b/TestModels/Constraints/src/Index.dfy
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 include "SimpleConstraintsImpl.dfy"
 
-module SimpleConstraints refines AbstractSimpleConstraintsService {
+module {:extern "simple.constraints.internaldafny" } SimpleConstraints refines AbstractSimpleConstraintsService {
   import Operations = SimpleConstraintsImpl
 
   function method DefaultSimpleConstraintsConfig(): SimpleConstraintsConfig {

--- a/TestModels/Constraints/src/WrappedSimpleConstraintsImpl.dfy
+++ b/TestModels/Constraints/src/WrappedSimpleConstraintsImpl.dfy
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 include "../Model/SimpleConstraintsTypesWrapped.dfy"
 
-module WrappedSimpleConstraintsService refines WrappedAbstractSimpleConstraintsService {
+module {:extern "simple.constraints.internaldafny.wrapped"} WrappedSimpleConstraintsService refines WrappedAbstractSimpleConstraintsService {
     import WrappedService = SimpleConstraints
     function method WrappedDefaultSimpleConstraintsConfig(): SimpleConstraintsConfig {
         SimpleConstraintsConfig(RequiredString := "default")

--- a/TestModels/Constraints/src/WrappedSimpleConstraintsImpl.dfy
+++ b/TestModels/Constraints/src/WrappedSimpleConstraintsImpl.dfy
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 include "../Model/SimpleConstraintsTypesWrapped.dfy"
 
-module {:extern "simple.constraints.internaldafny.wrapped"} WrappedSimpleConstraintsService refines WrappedAbstractSimpleConstraintsService {
+module WrappedSimpleConstraintsService refines WrappedAbstractSimpleConstraintsService {
     import WrappedService = SimpleConstraints
     function method WrappedDefaultSimpleConstraintsConfig(): SimpleConstraintsConfig {
         SimpleConstraintsConfig(RequiredString := "default")

--- a/TestModels/Constructor/runtimes/python/pyproject.toml
+++ b/TestModels/Constructor/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ smithy-dafny-standard-library = { path = "../../../dafny-dependencies/StandardLi
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/Dependencies/runtimes/python/pyproject.toml
+++ b/TestModels/Dependencies/runtimes/python/pyproject.toml
@@ -26,5 +26,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/Documentation/runtimes/python/pyproject.toml
+++ b/TestModels/Documentation/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/Errors/runtimes/python/pyproject.toml
+++ b/TestModels/Errors/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/Extendable/runtimes/python/pyproject.toml
+++ b/TestModels/Extendable/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/Extern/runtimes/python/pyproject.toml
+++ b/TestModels/Extern/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/LanguageSpecificLogic/runtimes/python/pyproject.toml
+++ b/TestModels/LanguageSpecificLogic/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/LocalService/runtimes/python/pyproject.toml
+++ b/TestModels/LocalService/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/MultipleModels/runtimes/python/pyproject.toml
+++ b/TestModels/MultipleModels/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/Positional/runtimes/python/pyproject.toml
+++ b/TestModels/Positional/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/Refinement/runtimes/python/pyproject.toml
+++ b/TestModels/Refinement/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/Resource/runtimes/python/pyproject.toml
+++ b/TestModels/Resource/runtimes/python/pyproject.toml
@@ -21,5 +21,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/SimpleTypes/SimpleBlob/runtimes/python/pyproject.toml
+++ b/TestModels/SimpleTypes/SimpleBlob/runtimes/python/pyproject.toml
@@ -21,5 +21,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/SimpleTypes/SimpleBoolean/runtimes/python/pyproject.toml
+++ b/TestModels/SimpleTypes/SimpleBoolean/runtimes/python/pyproject.toml
@@ -20,5 +20,5 @@ smithy-dafny-standard-library = {path = "../../../../dafny-dependencies/Standard
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/SimpleTypes/SimpleDouble/runtimes/python/pyproject.toml
+++ b/TestModels/SimpleTypes/SimpleDouble/runtimes/python/pyproject.toml
@@ -21,6 +21,6 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"
 

--- a/TestModels/SimpleTypes/SimpleEnum/runtimes/python/pyproject.toml
+++ b/TestModels/SimpleTypes/SimpleEnum/runtimes/python/pyproject.toml
@@ -21,5 +21,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/SimpleTypes/SimpleEnumV2/runtimes/python/pyproject.toml
+++ b/TestModels/SimpleTypes/SimpleEnumV2/runtimes/python/pyproject.toml
@@ -21,5 +21,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/SimpleTypes/SimpleInteger/runtimes/python/pyproject.toml
+++ b/TestModels/SimpleTypes/SimpleInteger/runtimes/python/pyproject.toml
@@ -21,5 +21,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/SimpleTypes/SimpleLong/runtimes/python/pyproject.toml
+++ b/TestModels/SimpleTypes/SimpleLong/runtimes/python/pyproject.toml
@@ -21,5 +21,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/SimpleTypes/SimpleString/runtimes/python/pyproject.toml
+++ b/TestModels/SimpleTypes/SimpleString/runtimes/python/pyproject.toml
@@ -21,5 +21,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/Union/runtimes/python/pyproject.toml
+++ b/TestModels/Union/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/aws-sdks/ddb/runtimes/python/pyproject.toml
+++ b/TestModels/aws-sdks/ddb/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/aws-sdks/ddbv2/runtimes/python/pyproject.toml
+++ b/TestModels/aws-sdks/ddbv2/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/aws-sdks/kms/runtimes/python/pyproject.toml
+++ b/TestModels/aws-sdks/kms/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/aws-sdks/kmsv2/runtimes/python/pyproject.toml
+++ b/TestModels/aws-sdks/kmsv2/runtimes/python/pyproject.toml
@@ -22,5 +22,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/aws-sdks/s3/runtimes/python/pyproject.toml
+++ b/TestModels/aws-sdks/s3/runtimes/python/pyproject.toml
@@ -19,5 +19,5 @@ smithy-dafny-standard-library = {path = "../../../../dafny-dependencies/Standard
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestModels/dafny-dependencies/StandardLibrary/runtimes/python/pyproject.toml
+++ b/TestModels/dafny-dependencies/StandardLibrary/runtimes/python/pyproject.toml
@@ -18,5 +18,5 @@ DafnyRuntimePython = "^4.7.0"
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

poetry released a new major version: https://pypi.org/project/poetry/2.0.0/
Python projects picked this up automatically because they didn't specify a maximum version for poetry.
This is bad, since this is a breaking change, and it broke building new Python libraries.
This doesn't break customers using already-distributed Smithy-Dafny Python projects. This only breaks the build system, and we only rebuild the library in CI and for releases. I can install and use (ex.) the published Crypto Tools MPL without issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
