### PR TITLE
fix(Go): always generate code in an order

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
@@ -64,6 +64,8 @@ public class DafnyAwsSdkClientTypeConversionProtocol
     final var writerDelegator = context.writerDelegator();
     serviceShape
       .getOperations()
+      .stream()
+      .sorted()
       .forEach(eachOperation -> {
         final var awsNormalizedOperation = awsNormalizedModel.expectShape(
           eachOperation,
@@ -215,6 +217,8 @@ public class DafnyAwsSdkClientTypeConversionProtocol
 
     serviceShape
       .getOperations()
+      .stream()
+      .sorted()
       .forEach(eachOperation -> {
         final var awsNormalizedOperationShape = awsNormalizedModel.expectShape(
           eachOperation,

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
@@ -4,7 +4,6 @@ import static software.amazon.polymorph.smithygo.localservice.DafnyLocalServiceT
 import static software.amazon.polymorph.smithygo.localservice.DafnyLocalServiceTypeConversionProtocol.TO_NATIVE;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
 
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -646,7 +645,7 @@ public class DafnyAwsSdkClientTypeConversionProtocol
     final var errorShapes = awsNormalizedModel
       .getShapesWithTrait(ErrorTrait.class)
       .stream()
-      .sorted(Comparator.comparing(shape -> shape.getId().getName()))
+      .sorted()
       .collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var errorShape : errorShapes) {
       if (

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
@@ -496,7 +496,7 @@ public class DafnyAwsSdkClientTypeConversionProtocol
     final var errorShapes = awsNormalizedModel.getShapesWithTrait(
       ErrorTrait.class
     ).stream()
-    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
+    .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
 
     for (final var errorShape : errorShapes) {
       if (

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
@@ -3,9 +3,11 @@ package software.amazon.polymorph.smithygo.awssdk;
 import static software.amazon.polymorph.smithygo.localservice.DafnyLocalServiceTypeConversionProtocol.TO_DAFNY;
 import static software.amazon.polymorph.smithygo.localservice.DafnyLocalServiceTypeConversionProtocol.TO_NATIVE;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
-
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 import software.amazon.polymorph.smithygo.awssdk.shapevisitor.AwsSdkToDafnyShapeVisitor;
 import software.amazon.polymorph.smithygo.awssdk.shapevisitor.DafnyToAwsSdkShapeVisitor;
 import software.amazon.polymorph.smithygo.awssdk.shapevisitor.ShapeVisitorHelper;
@@ -489,7 +491,8 @@ public class DafnyAwsSdkClientTypeConversionProtocol
     final Set<ShapeId> alreadyVisited = new HashSet<>();
     final var errorShapes = awsNormalizedModel.getShapesWithTrait(
       ErrorTrait.class
-    );
+    ).stream()
+    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));;
 
     for (final var errorShape : errorShapes) {
       if (

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
@@ -492,7 +492,7 @@ public class DafnyAwsSdkClientTypeConversionProtocol
     final var errorShapes = awsNormalizedModel.getShapesWithTrait(
       ErrorTrait.class
     ).stream()
-    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));;
+    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
 
     for (final var errorShape : errorShapes) {
       if (
@@ -639,7 +639,8 @@ public class DafnyAwsSdkClientTypeConversionProtocol
     final Set<ShapeId> alreadyVisited = new HashSet<>();
     final var errorShapes = awsNormalizedModel.getShapesWithTrait(
       ErrorTrait.class
-    );
+    ).stream()
+    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var errorShape : errorShapes) {
       if (
         !errorShape

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
@@ -3,6 +3,7 @@ package software.amazon.polymorph.smithygo.awssdk;
 import static software.amazon.polymorph.smithygo.localservice.DafnyLocalServiceTypeConversionProtocol.TO_DAFNY;
 import static software.amazon.polymorph.smithygo.localservice.DafnyLocalServiceTypeConversionProtocol.TO_NATIVE;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
+
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -493,10 +494,11 @@ public class DafnyAwsSdkClientTypeConversionProtocol
 
   private void generateErrorSerializer(final GenerationContext context) {
     final Set<ShapeId> alreadyVisited = new HashSet<>();
-    final var errorShapes = awsNormalizedModel.getShapesWithTrait(
-      ErrorTrait.class
-    ).stream()
-    .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+    final var errorShapes = awsNormalizedModel
+      .getShapesWithTrait(ErrorTrait.class)
+      .stream()
+      .sorted()
+      .collect(Collectors.toCollection(LinkedHashSet::new));
 
     for (final var errorShape : errorShapes) {
       if (
@@ -641,10 +643,11 @@ public class DafnyAwsSdkClientTypeConversionProtocol
 
   private void generateErrorDeserializer(final GenerationContext context) {
     final Set<ShapeId> alreadyVisited = new HashSet<>();
-    final var errorShapes = awsNormalizedModel.getShapesWithTrait(
-      ErrorTrait.class
-    ).stream()
-    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
+    final var errorShapes = awsNormalizedModel
+      .getShapesWithTrait(ErrorTrait.class)
+      .stream()
+      .sorted(Comparator.comparing(shape -> shape.getId().getName()))
+      .collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var errorShape : errorShapes) {
       if (
         !errorShape

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/DafnyAwsSdkClientTypeConversionProtocol.java
@@ -753,9 +753,7 @@ public class DafnyAwsSdkClientTypeConversionProtocol
             """,
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
             writer.consumer(w -> {
-              for (final var error : awsNormalizedModel.getShapesWithTrait(
-                ErrorTrait.class
-              )) {
+              for (final var error : errorShapes) {
                 w.write(
                   """
                   if err.Is_$L() {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/shapevisitor/AwsSdkToDafnyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/shapevisitor/AwsSdkToDafnyShapeVisitor.java
@@ -4,6 +4,7 @@ import static software.amazon.polymorph.smithygo.localservice.nameresolver.Const
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.polymorph.smithygo.awssdk.AwsSdkGoPointableIndex;
@@ -48,7 +49,7 @@ public class AwsSdkToDafnyShapeVisitor extends ShapeVisitor.Default<String> {
   protected boolean isPointerType;
   //TODO: Ideally this shouldn't be static but with current design we need to access this across instances.
   private static final Map<MemberShape, String> memberShapeConversionFuncMap =
-    new HashMap<>();
+    new LinkedHashMap<>();
 
   public AwsSdkToDafnyShapeVisitor(
     final GenerationContext context,

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/shapevisitor/AwsSdkToDafnyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/shapevisitor/AwsSdkToDafnyShapeVisitor.java
@@ -3,7 +3,6 @@ package software.amazon.polymorph.smithygo.awssdk.shapevisitor;
 import static software.amazon.polymorph.smithygo.localservice.nameresolver.Constants.DOT;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/shapevisitor/DafnyToAwsSdkShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/awssdk/shapevisitor/DafnyToAwsSdkShapeVisitor.java
@@ -49,7 +49,7 @@ public class DafnyToAwsSdkShapeVisitor extends ShapeVisitor.Default<String> {
 
   //TODO: Ideally this shouldn't be static but with current design we need to access this across instances.
   private static final Map<MemberShape, String> memberShapeConversionFuncMap =
-    new HashMap<>();
+    new LinkedHashMap<>();
 
   public DafnyToAwsSdkShapeVisitor(
     final GenerationContext context,

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/UnionGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/UnionGenerator.java
@@ -54,6 +54,7 @@ public class UnionGenerator {
     memberShapes
       .stream()
       .map(symbolProvider::toMemberName)
+      .sorted()
       .forEach(name -> {
         writer.write("//  " + name);
       });

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/UnionGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/UnionGenerator.java
@@ -49,6 +49,7 @@ public class UnionGenerator {
       .values()
       .stream()
       .filter(memberShape -> !isEventStreamErrorMember(memberShape))
+      .sorted()
       .collect(Collectors.toCollection(TreeSet::new));
 
     memberShapes

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/ValidationGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/ValidationGenerator.java
@@ -4,6 +4,7 @@ import static software.amazon.polymorph.smithygo.codegen.SymbolUtils.POINTABLE;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.polymorph.smithygo.localservice.nameresolver.SmithyNameResolver;
@@ -45,9 +46,9 @@ public class ValidationGenerator {
     }
     """;
   private static final Map<MemberShape, String> validationFuncMap =
-    new HashMap<>();
+    new LinkedHashMap<>();
   private static final Map<MemberShape, String> validationFuncInputTypeMap =
-    new HashMap<>();
+    new LinkedHashMap<>();
 
   public ValidationGenerator(
     final GenerationContext context,

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/knowledge/GoUsageIndex.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/knowledge/GoUsageIndex.java
@@ -71,6 +71,7 @@ public class GoUsageIndex implements KnowledgeIndex {
                 )
                 .stream()
                 .map(Shape::toShapeId)
+                .sorted()
                 .collect(Collectors.toList())
             );
 
@@ -84,6 +85,7 @@ public class GoUsageIndex implements KnowledgeIndex {
                 )
                 .stream()
                 .map(Shape::toShapeId)
+                .sorted()
                 .collect(Collectors.toList())
             );
           });

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/knowledge/GoValidationIndex.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/knowledge/GoValidationIndex.java
@@ -142,6 +142,7 @@ public class GoValidationIndex implements KnowledgeIndex {
               .values()
               .stream()
               .map(OperationShape::toShapeId)
+              .sorted()
               .collect(Collectors.toSet())
           )
         );

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
@@ -92,6 +92,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
               .getNamespace()
               .equals(service.getId().getNamespace())
           )
+          .sorted()
           .forEach(unionShape -> {
             new UnionGenerator(model, symbolProvider, unionShape)
               .generateUnion(writer1);
@@ -626,7 +627,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
 
   void shimErrors(GoWriter writer) {
     for (final var error : model.getShapesWithTrait(ErrorTrait.class).stream()
-    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new))) {
+    .sorted().collect(Collectors.toCollection(LinkedHashSet::new))) {
       writer.write(
         """
         case $L.$L:
@@ -645,7 +646,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
 
   void resourceErrors(GoWriter writer) {
     for (final var error : model.getShapesWithTrait(ErrorTrait.class).stream()
-    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new))) {
+    .sorted().collect(Collectors.toCollection(LinkedHashSet::new))) {
       writer.write(
         """
         case $L:
@@ -715,7 +716,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
 
   void generateReferencedResources(final GenerationContext context) {
     final var refResources = model.getShapesWithTrait(ReferenceTrait.class).stream()
-    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
+    .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var refResource : refResources) {
       if (!refResource.expectTrait(ReferenceTrait.class).isService()) {
         final var resource = refResource

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
@@ -5,6 +5,7 @@ package software.amazon.polymorph.smithygo.localservice;
 
 import static software.amazon.polymorph.smithygo.codegen.SymbolUtils.POINTABLE;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
+
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
@@ -626,8 +627,11 @@ public class DafnyLocalServiceGenerator implements Runnable {
   }
 
   void shimErrors(GoWriter writer) {
-    for (final var error : model.getShapesWithTrait(ErrorTrait.class).stream()
-    .sorted().collect(Collectors.toCollection(LinkedHashSet::new))) {
+    for (final var error : model
+      .getShapesWithTrait(ErrorTrait.class)
+      .stream()
+      .sorted()
+      .collect(Collectors.toCollection(LinkedHashSet::new))) {
       writer.write(
         """
         case $L.$L:
@@ -645,8 +649,11 @@ public class DafnyLocalServiceGenerator implements Runnable {
   }
 
   void resourceErrors(GoWriter writer) {
-    for (final var error : model.getShapesWithTrait(ErrorTrait.class).stream()
-    .sorted().collect(Collectors.toCollection(LinkedHashSet::new))) {
+    for (final var error : model
+      .getShapesWithTrait(ErrorTrait.class)
+      .stream()
+      .sorted()
+      .collect(Collectors.toCollection(LinkedHashSet::new))) {
       writer.write(
         """
         case $L:
@@ -715,8 +722,11 @@ public class DafnyLocalServiceGenerator implements Runnable {
   }
 
   void generateReferencedResources(final GenerationContext context) {
-    final var refResources = model.getShapesWithTrait(ReferenceTrait.class).stream()
-    .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+    final var refResources = model
+      .getShapesWithTrait(ReferenceTrait.class)
+      .stream()
+      .sorted()
+      .collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var refResource : refResources) {
       if (!refResource.expectTrait(ReferenceTrait.class).isService()) {
         final var resource = refResource

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
@@ -6,7 +6,6 @@ package software.amazon.polymorph.smithygo.localservice;
 import static software.amazon.polymorph.smithygo.codegen.SymbolUtils.POINTABLE;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
 
-import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
 import software.amazon.polymorph.smithygo.codegen.GenerationContext;
@@ -31,10 +30,8 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
-import software.amazon.smithy.utils.StringUtils;
 
 public class DafnyLocalServiceGenerator implements Runnable {
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
@@ -5,7 +5,9 @@ package software.amazon.polymorph.smithygo.localservice;
 
 import static software.amazon.polymorph.smithygo.codegen.SymbolUtils.POINTABLE;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
-
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.stream.Collectors;
 import software.amazon.polymorph.smithygo.codegen.GenerationContext;
 import software.amazon.polymorph.smithygo.codegen.GoDelegator;
 import software.amazon.polymorph.smithygo.codegen.GoWriter;
@@ -623,7 +625,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
   }
 
   void shimErrors(GoWriter writer) {
-    for (final var error : model.getShapesWithTrait(ErrorTrait.class)) {
+    for (final var error : model.getShapesWithTrait(ErrorTrait.class).stream()
+    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new))) {
       writer.write(
         """
         case $L.$L:
@@ -641,7 +644,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
   }
 
   void resourceErrors(GoWriter writer) {
-    for (final var error : model.getShapesWithTrait(ErrorTrait.class)) {
+    for (final var error : model.getShapesWithTrait(ErrorTrait.class).stream()
+    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new))) {
       writer.write(
         """
         case $L:
@@ -710,7 +714,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
   }
 
   void generateReferencedResources(final GenerationContext context) {
-    final var refResources = model.getShapesWithTrait(ReferenceTrait.class);
+    final var refResources = model.getShapesWithTrait(ReferenceTrait.class).stream()
+    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var refResource : refResources) {
       if (!refResource.expectTrait(ReferenceTrait.class).isService()) {
         final var resource = refResource

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -366,56 +366,56 @@ public class DafnyLocalServiceTypeConversionProtocol
                 );
               }
             }
-          });
-        if (
-          !alreadyVisited.contains(resourceShape.toShapeId()) &&
-          resourceShape
-            .toShapeId()
-            .getNamespace()
-            .equals(serviceShape.toShapeId().getNamespace())
-        ) {
-          alreadyVisited.add(resourceShape.toShapeId());
-          writerDelegator.useFileWriter(
-            "%s/%s".formatted(
+            if (
+              !alreadyVisited.contains(resourceShape.toShapeId()) &&
+              resourceShape
+                .toShapeId()
+                .getNamespace()
+                .equals(serviceShape.toShapeId().getNamespace())
+            ) {
+              alreadyVisited.add(resourceShape.toShapeId());
+              writerDelegator.useFileWriter(
+                "%s/%s".formatted(
+                    SmithyNameResolver.shapeNamespace(serviceShape),
+                    TO_DAFNY
+                  ),
                 SmithyNameResolver.shapeNamespace(serviceShape),
-                TO_DAFNY
-              ),
-            SmithyNameResolver.shapeNamespace(serviceShape),
-            writer -> {
-              var goBody =
-                """
-                return nativeResource.(*%s).Impl
-                """.formatted(resourceShape.getId().getName());
-              if (resourceShape.hasTrait(ExtendableTrait.class)) {
-                goBody =
-                  """
-                                                     val, ok := nativeResource.(*%s)
-                  if ok {
-                  	return val.Impl
+                writer -> {
+                  var goBody =
+                    """
+                    return nativeResource.(*%s).Impl
+                    """.formatted(resourceShape.getId().getName());
+                  if (resourceShape.hasTrait(ExtendableTrait.class)) {
+                    goBody =
+                      """
+                                                         val, ok := nativeResource.(*%s)
+                      if ok {
+                      	return val.Impl
+                      }
+                      return %s{&%sNativeWrapper{Impl: nativeResource}}.Impl
+                                                         """.formatted(
+                          resourceShape.getId().getName(),
+                          resourceShape.getId().getName(),
+                          resourceShape.getId().getName()
+                        );
                   }
-                  return %s{&%sNativeWrapper{Impl: nativeResource}}.Impl
-                                                     """.formatted(
-                      resourceShape.getId().getName(),
-                      resourceShape.getId().getName(),
-                      resourceShape.getId().getName()
-                    );
-              }
-              writer.write(
-                """
-                func $L_ToDafny(nativeResource $L.I$L) $L.I$L {
-                    $L
+                  writer.write(
+                    """
+                    func $L_ToDafny(nativeResource $L.I$L) $L.I$L {
+                        $L
+                    }
+                    """,
+                    resourceShape.getId().getName(),
+                    SmithyNameResolver.smithyTypesNamespace(resourceShape),
+                    resourceShape.getId().getName(),
+                    DafnyNameResolver.dafnyTypesNamespace(resourceShape),
+                    resourceShape.getId().getName(),
+                    goBody
+                  );
                 }
-                """,
-                resourceShape.getId().getName(),
-                SmithyNameResolver.smithyTypesNamespace(resourceShape),
-                resourceShape.getId().getName(),
-                DafnyNameResolver.dafnyTypesNamespace(resourceShape),
-                resourceShape.getId().getName(),
-                goBody
               );
             }
-          );
-        }
+          });
       }
     }
     generateErrorSerializer(context);

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -358,6 +358,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                 );
               }
             }
+          });
             if (
               !alreadyVisited.contains(resourceShape.toShapeId()) &&
               resourceShape
@@ -407,7 +408,6 @@ public class DafnyLocalServiceTypeConversionProtocol
                 }
               );
             }
-          });
       }
     }
     generateErrorSerializer(context);

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -65,6 +65,8 @@ public class DafnyLocalServiceTypeConversionProtocol
     final var writerDelegator = context.writerDelegator();
     serviceShape
       .getOperations()
+      .stream()
+      .sorted()
       .forEach(eachOperation -> {
         final var operation = model.expectShape(
           eachOperation,
@@ -215,6 +217,8 @@ public class DafnyLocalServiceTypeConversionProtocol
         );
         resourceShape
           .getOperations()
+          .stream()
+          .sorted()
           .forEach(eachOperation -> {
             final var operation = model.expectShape(
               eachOperation,
@@ -425,6 +429,8 @@ public class DafnyLocalServiceTypeConversionProtocol
 
     serviceShape
       .getOperations()
+      .stream()
+      .sorted()
       .forEach(eachOperation -> {
         final var operation = context
           .model()
@@ -590,6 +596,8 @@ public class DafnyLocalServiceTypeConversionProtocol
           .expectShape(resource, ResourceShape.class);
         resourceShape
           .getOperations()
+          .stream()
+          .sorted()
           .forEach(eachOperation -> {
             final var operation = context
               .model()

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -208,7 +208,7 @@ public class DafnyLocalServiceTypeConversionProtocol
     final var refResources = context
       .model()
       .getShapesWithTrait(ReferenceTrait.class).stream()
-    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
+    .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var refResource : refResources) {
       final var resource = refResource
         .expectTrait(ReferenceTrait.class)
@@ -588,7 +588,7 @@ public class DafnyLocalServiceTypeConversionProtocol
     final var refResources = context
       .model()
       .getShapesWithTrait(ReferenceTrait.class).stream()
-      .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
+      .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var refResource : refResources) {
       final var resource = refResource
         .expectTrait(ReferenceTrait.class)
@@ -989,7 +989,7 @@ public class DafnyLocalServiceTypeConversionProtocol
     final var errorShapes = context
       .model()
       .getShapesWithTrait(ErrorTrait.class).stream()
-      .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
+      .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
 
     for (final var errorShape : errorShapes) {
       if (
@@ -1089,6 +1089,7 @@ public class DafnyLocalServiceTypeConversionProtocol
       .filter(shape ->
         ModelUtils.isInServiceNamespace(shape.getId(), serviceShape)
       )
+      .sorted()
       .collect(Collectors.toSet());
 
     context
@@ -1346,7 +1347,7 @@ public class DafnyLocalServiceTypeConversionProtocol
     final var errorShapes = context
       .model()
       .getShapesWithTrait(ErrorTrait.class).stream()
-      .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
+      .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var errorShape : errorShapes) {
       if (
         !errorShape
@@ -1471,6 +1472,7 @@ public class DafnyLocalServiceTypeConversionProtocol
       .filter(shape ->
         ModelUtils.isInServiceNamespace(shape.getId(), serviceShape)
       )
+      .sorted()
       .collect(Collectors.toSet());
 
     context

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -1090,7 +1090,7 @@ public class DafnyLocalServiceTypeConversionProtocol
         ModelUtils.isInServiceNamespace(shape.getId(), serviceShape)
       )
       .sorted()
-      .collect(Collectors.toSet());
+      .collect(Collectors.toCollection(LinkedHashSet::new));
 
     context
       .writerDelegator()
@@ -1473,7 +1473,7 @@ public class DafnyLocalServiceTypeConversionProtocol
         ModelUtils.isInServiceNamespace(shape.getId(), serviceShape)
       )
       .sorted()
-      .collect(Collectors.toSet());
+      .collect(Collectors.toCollection(LinkedHashSet::new));
 
     context
       .writerDelegator()

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -207,8 +207,10 @@ public class DafnyLocalServiceTypeConversionProtocol
 
     final var refResources = context
       .model()
-      .getShapesWithTrait(ReferenceTrait.class).stream()
-    .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+      .getShapesWithTrait(ReferenceTrait.class)
+      .stream()
+      .sorted()
+      .collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var refResource : refResources) {
       final var resource = refResource
         .expectTrait(ReferenceTrait.class)
@@ -366,55 +368,55 @@ public class DafnyLocalServiceTypeConversionProtocol
               }
             }
           });
-            if (
-              !alreadyVisited.contains(resourceShape.toShapeId()) &&
-              resourceShape
-                .toShapeId()
-                .getNamespace()
-                .equals(serviceShape.toShapeId().getNamespace())
-            ) {
-              alreadyVisited.add(resourceShape.toShapeId());
-              writerDelegator.useFileWriter(
-                "%s/%s".formatted(
-                    SmithyNameResolver.shapeNamespace(serviceShape),
-                    TO_DAFNY
-                  ),
+        if (
+          !alreadyVisited.contains(resourceShape.toShapeId()) &&
+          resourceShape
+            .toShapeId()
+            .getNamespace()
+            .equals(serviceShape.toShapeId().getNamespace())
+        ) {
+          alreadyVisited.add(resourceShape.toShapeId());
+          writerDelegator.useFileWriter(
+            "%s/%s".formatted(
                 SmithyNameResolver.shapeNamespace(serviceShape),
-                writer -> {
-                  var goBody =
-                    """
-                    return nativeResource.(*%s).Impl
-                    """.formatted(resourceShape.getId().getName());
-                  if (resourceShape.hasTrait(ExtendableTrait.class)) {
-                    goBody =
-                      """
-                                                         val, ok := nativeResource.(*%s)
-                      if ok {
-                      	return val.Impl
-                      }
-                      return %s{&%sNativeWrapper{Impl: nativeResource}}.Impl
-                                                         """.formatted(
-                          resourceShape.getId().getName(),
-                          resourceShape.getId().getName(),
-                          resourceShape.getId().getName()
-                        );
+                TO_DAFNY
+              ),
+            SmithyNameResolver.shapeNamespace(serviceShape),
+            writer -> {
+              var goBody =
+                """
+                return nativeResource.(*%s).Impl
+                """.formatted(resourceShape.getId().getName());
+              if (resourceShape.hasTrait(ExtendableTrait.class)) {
+                goBody =
+                  """
+                                                     val, ok := nativeResource.(*%s)
+                  if ok {
+                  	return val.Impl
                   }
-                  writer.write(
-                    """
-                    func $L_ToDafny(nativeResource $L.I$L) $L.I$L {
-                        $L
-                    }
-                    """,
-                    resourceShape.getId().getName(),
-                    SmithyNameResolver.smithyTypesNamespace(resourceShape),
-                    resourceShape.getId().getName(),
-                    DafnyNameResolver.dafnyTypesNamespace(resourceShape),
-                    resourceShape.getId().getName(),
-                    goBody
-                  );
+                  return %s{&%sNativeWrapper{Impl: nativeResource}}.Impl
+                                                     """.formatted(
+                      resourceShape.getId().getName(),
+                      resourceShape.getId().getName(),
+                      resourceShape.getId().getName()
+                    );
+              }
+              writer.write(
+                """
+                func $L_ToDafny(nativeResource $L.I$L) $L.I$L {
+                    $L
                 }
+                """,
+                resourceShape.getId().getName(),
+                SmithyNameResolver.smithyTypesNamespace(resourceShape),
+                resourceShape.getId().getName(),
+                DafnyNameResolver.dafnyTypesNamespace(resourceShape),
+                resourceShape.getId().getName(),
+                goBody
               );
             }
+          );
+        }
       }
     }
     generateErrorSerializer(context);
@@ -587,8 +589,10 @@ public class DafnyLocalServiceTypeConversionProtocol
 
     final var refResources = context
       .model()
-      .getShapesWithTrait(ReferenceTrait.class).stream()
-      .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+      .getShapesWithTrait(ReferenceTrait.class)
+      .stream()
+      .sorted()
+      .collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var refResource : refResources) {
       final var resource = refResource
         .expectTrait(ReferenceTrait.class)
@@ -988,8 +992,10 @@ public class DafnyLocalServiceTypeConversionProtocol
     final var serviceShape = context.settings().getService(context.model());
     final var errorShapes = context
       .model()
-      .getShapesWithTrait(ErrorTrait.class).stream()
-      .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+      .getShapesWithTrait(ErrorTrait.class)
+      .stream()
+      .sorted()
+      .collect(Collectors.toCollection(LinkedHashSet::new));
 
     for (final var errorShape : errorShapes) {
       if (
@@ -1346,8 +1352,10 @@ public class DafnyLocalServiceTypeConversionProtocol
     final var serviceShape = context.settings().getService(context.model());
     final var errorShapes = context
       .model()
-      .getShapesWithTrait(ErrorTrait.class).stream()
-      .sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+      .getShapesWithTrait(ErrorTrait.class)
+      .stream()
+      .sorted()
+      .collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var errorShape : errorShapes) {
       if (
         !errorShape

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -4,7 +4,9 @@ import static software.amazon.polymorph.smithygo.codegen.SymbolUtils.POINTABLE;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -205,7 +207,8 @@ public class DafnyLocalServiceTypeConversionProtocol
 
     final var refResources = context
       .model()
-      .getShapesWithTrait(ReferenceTrait.class);
+      .getShapesWithTrait(ReferenceTrait.class).stream()
+    .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var refResource : refResources) {
       final var resource = refResource
         .expectTrait(ReferenceTrait.class)
@@ -584,7 +587,8 @@ public class DafnyLocalServiceTypeConversionProtocol
 
     final var refResources = context
       .model()
-      .getShapesWithTrait(ReferenceTrait.class);
+      .getShapesWithTrait(ReferenceTrait.class).stream()
+      .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var refResource : refResources) {
       final var resource = refResource
         .expectTrait(ReferenceTrait.class)
@@ -984,7 +988,8 @@ public class DafnyLocalServiceTypeConversionProtocol
     final var serviceShape = context.settings().getService(context.model());
     final var errorShapes = context
       .model()
-      .getShapesWithTrait(ErrorTrait.class);
+      .getShapesWithTrait(ErrorTrait.class).stream()
+      .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
 
     for (final var errorShape : errorShapes) {
       if (
@@ -1340,7 +1345,8 @@ public class DafnyLocalServiceTypeConversionProtocol
     final var serviceShape = context.settings().getService(context.model());
     final var errorShapes = context
       .model()
-      .getShapesWithTrait(ErrorTrait.class);
+      .getShapesWithTrait(ErrorTrait.class).stream()
+      .sorted(Comparator.comparing(shape -> shape.getId().getName())).collect(Collectors.toCollection(LinkedHashSet::new));
     for (final var errorShape : errorShapes) {
       if (
         !errorShape

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -4,7 +4,6 @@ import static software.amazon.polymorph.smithygo.codegen.SymbolUtils.POINTABLE;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
 
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
@@ -2,7 +2,6 @@ package software.amazon.polymorph.smithygo.localservice.shapevisitor;
 
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
@@ -3,6 +3,7 @@ package software.amazon.polymorph.smithygo.localservice.shapevisitor;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.polymorph.smithygo.codegen.GenerationContext;
@@ -52,7 +53,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
   private final boolean isOptional;
   //TODO: Ideally this shouldn't be static but with current design we need to access this across instances.
   private static final Map<MemberShape, String> memberShapeConversionFuncMap =
-    new HashMap<>();
+    new LinkedHashMap<>();
 
   public DafnyToSmithyShapeVisitor(
     final GenerationContext context,

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/SmithyToDafnyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/SmithyToDafnyShapeVisitor.java
@@ -4,6 +4,7 @@ import static software.amazon.polymorph.smithygo.codegen.SymbolUtils.POINTABLE;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.polymorph.smithygo.codegen.GenerationContext;
@@ -52,7 +53,7 @@ public class SmithyToDafnyShapeVisitor extends ShapeVisitor.Default<String> {
   protected boolean isPointerType;
   //TODO: Ideally this shouldn't be static but with current design we need to access this across instances.
   private static final Map<MemberShape, String> memberShapeConversionFuncMap =
-    new HashMap<>();
+    new LinkedHashMap<>();
 
   public SmithyToDafnyShapeVisitor(
     final GenerationContext context,

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/SmithyToDafnyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/SmithyToDafnyShapeVisitor.java
@@ -3,7 +3,6 @@ package software.amazon.polymorph.smithygo.localservice.shapevisitor;
 import static software.amazon.polymorph.smithygo.codegen.SymbolUtils.POINTABLE;
 import static software.amazon.polymorph.smithygo.utils.Constants.DAFNY_RUNTIME_GO_LIBRARY_MODULE;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We want smithy dafny generated code to have same order so that we can check git diff. To have same order, we need to avoid hashmap and hashsets. This PR sorts the top level shape before getting into shape visitor in a natural order (like A-Z for strings, or 1,2,3 for numbers). Once inside shape visitor, all the shapes will be sorted in the order they are getting visited.

Reference:
> This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.

https://docs.oracle.com/javase/8/docs/api/?java/util/HashMap.html

> It makes no guarantees as to the iteration order of the set; in particular, it does not guarantee that the order will remain constant over time.

https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html

Similar PR in for Smithy Dafny Java: **https://github.com/smithy-lang/smithy-dafny/pull/238**

*Testing*
Tested these changes in MPL on https://github.com/aws/aws-cryptographic-material-providers-library/tree/check-go-polymorph-diff. See the github action triggered from the latest commit on this branch (I made changes to workflow file to run CI to check diff when I commit on this branch)
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
