### PR TITLE
feat(go): handle unhandled orphanShapes

### DIFF
--- a/TestModels/OrphanedShapes/runtimes/go/ImplementationFromDafny-go/go.mod
+++ b/TestModels/OrphanedShapes/runtimes/go/ImplementationFromDafny-go/go.mod
@@ -3,8 +3,8 @@ module github.com/smithy-lang/smithy-dafny/TestModels/OrphanedShapes
 go 1.23.0
 
 require (
-	github.com/dafny-lang/DafnyRuntimeGo/v4 v4.9.1
-	github.com/dafny-lang/DafnyStandardLibGo v0.0.0
+	github.com/dafny-lang/DafnyRuntimeGo/v4 v4.9.2
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library v0.0.0
 )
 
-replace github.com/dafny-lang/DafnyStandardLibGo => ../../../../dafny-dependencies/StandardLibrary/runtimes/go/ImplementationFromDafny-go/
+replace github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library => ../../../../dafny-dependencies/StandardLibrary/runtimes/go/ImplementationFromDafny-go/

--- a/TestModels/OrphanedShapes/runtimes/go/TestsFromDafny-go/ExternDefinitions/extern.go
+++ b/TestModels/OrphanedShapes/runtimes/go/TestsFromDafny-go/ExternDefinitions/extern.go
@@ -1,9 +1,7 @@
 package ExternDefinitions
 
 import (
-	"fmt"
-
-	Wrappers "github.com/dafny-lang/DafnyStandardLibGo/Wrappers"
+	Wrappers "github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library/Wrappers"
 	OrphanedResource "github.com/smithy-lang/smithy-dafny/TestModels/OrphanedShapes/OrphanedResource"
 	SimpleOrphanedTypes "github.com/smithy-lang/smithy-dafny/TestModels/OrphanedShapes/SimpleOrphanedTypes"
 	simpleorphanedsmithygenerated "github.com/smithy-lang/smithy-dafny/TestModels/OrphanedShapes/simpleorphanedsmithygenerated"
@@ -12,12 +10,16 @@ import (
 
 var _ Wrappers.Dummy__
 
-// TODO: Finish implementation.
-// This is missing structure converter.
+// TODO: Remove this once Dafny bug is fixed.
+// Dafny bug: https://t.corp.amazon.com/9a9028fd-2711-4843-b8f0-09965f7e61a7/communication#f03694be-7410-47f9-866d-e43093b018f9
+var m_ExternDefinitions = CompanionStruct_Default___{}
 
 func (CompanionStruct_Default___) InitializeOrphanedStructure(input SimpleOrphanedTypes.OrphanedStructure) SimpleOrphanedTypes.OrphanedStructure {
-	// Missing Structure converter
-	return input
+	nativeInput := simpleorphanedsmithygenerated.OrphanedStructure_FromDafny(input)
+	stringToReplace := "the extern MUST use Smithy-generated conversions to set this value in the native structure"
+	nativeInput.StringValue = &stringToReplace
+	dafnyInitializedStructure := simpleorphanedsmithygenerated.OrphanedStructure_ToDafny(nativeInput)
+	return dafnyInitializedStructure
 }
 
 func (CompanionStruct_Default___) CallNativeOrphanedResource(input *OrphanedResource.OrphanedResource) Wrappers.Result {
@@ -32,7 +34,7 @@ func (CompanionStruct_Default___) CallNativeOrphanedResource(input *OrphanedReso
 }
 
 func (CompanionStruct_Default___) CallNativeOrphanedError(input SimpleOrphanedTypes.Error) SimpleOrphanedTypes.Error {
-	native_error := simpleorphanedsmithygenerated.Error_FromDafny(input)
+	native_error := simpleorphanedsmithygenerated.Error_FromDafny(input).(simpleorphanedsmithygeneratedtypes.OrphanedError)
 	native_error.Message = "the extern MUST set this string using the catch-all error converter, NOT the orphaned error-specific converter"
 	dafny_error_again := simpleorphanedsmithygenerated.Error_ToDafny(native_error)
 	return dafny_error_again

--- a/TestModels/OrphanedShapes/runtimes/go/TestsFromDafny-go/go.mod
+++ b/TestModels/OrphanedShapes/runtimes/go/TestsFromDafny-go/go.mod
@@ -2,13 +2,12 @@ module github.com/smithy-lang/smithy-dafny/TestModels/OrphanedShapes/test
 
 go 1.23.0
 
-require github.com/dafny-lang/DafnyStandardLibGo v0.0.0
-
 require (
-	github.com/dafny-lang/DafnyRuntimeGo/v4 v4.9.1
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library v0.0.0
+	github.com/dafny-lang/DafnyRuntimeGo/v4 v4.9.2
 	github.com/smithy-lang/smithy-dafny/TestModels/OrphanedShapes v0.0.0
 )
 
 replace github.com/smithy-lang/smithy-dafny/TestModels/OrphanedShapes v0.0.0 => ../ImplementationFromDafny-go
 
-replace github.com/dafny-lang/DafnyStandardLibGo => ../../../../dafny-dependencies/StandardLibrary/runtimes/go/ImplementationFromDafny-go/
+replace github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library => ../../../../dafny-dependencies/StandardLibrary/runtimes/go/ImplementationFromDafny-go/

--- a/codegen/smithy-dafny-codegen-test/src/test/java/software/amazon/polymorph/smithygo/GoTestModels.java
+++ b/codegen/smithy-dafny-codegen-test/src/test/java/software/amazon/polymorph/smithygo/GoTestModels.java
@@ -21,8 +21,6 @@ class GoTestModels extends TestModelTest {
     DISABLED_TESTS.add("AggregateReferences");
     DISABLED_TESTS.add("Documentation");
     DISABLED_TESTS.add("LanguageSpecificLogic");
-    // Needs work to generate some missing orphaned shape conversion methods
-    DISABLED_TESTS.add("OrphanedShapes");
     DISABLED_TESTS.add("SimpleTypes/BigDecimal");
     DISABLED_TESTS.add("SimpleTypes/BigInteger");
     DISABLED_TESTS.add("SimpleTypes/SimpleByte");

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceDirectedCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceDirectedCodegen.java
@@ -213,7 +213,9 @@ public class DafnyLocalServiceDirectedCodegen
       ShapeType.INTEGER,
       ShapeType.UNION,
       ShapeType.STRING,
-      ShapeType.LONG
+      ShapeType.LONG,
+      ShapeType.MAP,
+      ShapeType.LIST
     );
 
     for (final var shapeToGenerate : orderedShapes) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceDirectedCodegen.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceDirectedCodegen.java
@@ -215,7 +215,9 @@ public class DafnyLocalServiceDirectedCodegen
       ShapeType.STRING,
       ShapeType.LONG,
       ShapeType.MAP,
-      ShapeType.LIST
+      ShapeType.LIST,
+      ShapeType.BOOLEAN,
+      ShapeType.BLOB
     );
 
     for (final var shapeToGenerate : orderedShapes) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -214,7 +214,7 @@ public class DafnyLocalServiceTypeConversionProtocol
       final var resource = refResource
         .expectTrait(ReferenceTrait.class)
         .getReferentId();
-      alreadyVisited.add(resource);
+      alreadyVisited.add(refResource.toShapeId());
       if (!refResource.expectTrait(ReferenceTrait.class).isService()) {
         final var resourceShape = model.expectShape(
           resource,
@@ -473,7 +473,7 @@ public class DafnyLocalServiceTypeConversionProtocol
         .expectShape(referenceTrait.getReferentId());
       if (resourceOrService.isResourceShape()) {
         throw new IllegalStateException(
-          "Reference to resource shapes are already handled in generateDeserializers function."
+          "Reference to resource shapes are already handled in generateSerializers function."
         );
       }
       if (resourceOrService.hasTrait(ServiceTrait.class)) {
@@ -716,7 +716,7 @@ public class DafnyLocalServiceTypeConversionProtocol
       final var resource = refResource
         .expectTrait(ReferenceTrait.class)
         .getReferentId();
-      alreadyVisited.add(resource);
+      alreadyVisited.add(refResource.toShapeId());
       if (!refResource.expectTrait(ReferenceTrait.class).isService()) {
         final var resourceShape = context
           .model()

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -423,6 +423,7 @@ public class DafnyLocalServiceTypeConversionProtocol
     if (serviceShape.hasTrait(LocalServiceTrait.class)) {
       generateConfigSerializer(context, alreadyVisited);
     }
+    generateSerializerFunctions(context, alreadyVisited);
     final var orphanShapes =
       ModelUtils.getTopologicallyOrderedOrphanedShapesForService(
         serviceShape,
@@ -437,7 +438,6 @@ public class DafnyLocalServiceTypeConversionProtocol
         serviceShape
       );
     }
-    generateSerializerFunctions(context, alreadyVisited);
   }
 
   public void generateOrphanShapeSerializer(
@@ -929,6 +929,7 @@ public class DafnyLocalServiceTypeConversionProtocol
     if (serviceShape.hasTrait(LocalServiceTrait.class)) {
       generateConfigDeserializer(context, alreadyVisited);
     }
+    generateDeserializerFunctions(context, alreadyVisited);
     final var orphanShapes =
       ModelUtils.getTopologicallyOrderedOrphanedShapesForService(
         serviceShape,
@@ -943,7 +944,6 @@ public class DafnyLocalServiceTypeConversionProtocol
         serviceShape
       );
     }
-    generateDeserializerFunctions(context, alreadyVisited);
   }
 
   public void generateOrphanShapeDeserializer(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -446,7 +446,10 @@ public class DafnyLocalServiceTypeConversionProtocol
     final Set<ShapeId> alreadyVisited,
     ServiceShape serviceShape
   ) {
-    if (GoCodegenUtils.shapeShouldHaveConversionFunction(shape) == false || alreadyVisited.contains(shape.toShapeId())) {
+    if (
+      GoCodegenUtils.shapeShouldHaveConversionFunction(shape) == false ||
+      alreadyVisited.contains(shape.toShapeId())
+    ) {
       return;
     }
     if (shape.hasTrait(UnitTypeTrait.class)) {
@@ -948,7 +951,10 @@ public class DafnyLocalServiceTypeConversionProtocol
     final Set<ShapeId> alreadyVisited,
     ServiceShape serviceShape
   ) {
-    if (GoCodegenUtils.shapeShouldHaveConversionFunction(shape) == false || alreadyVisited.contains(shape.toShapeId())) {
+    if (
+      GoCodegenUtils.shapeShouldHaveConversionFunction(shape) == false ||
+      alreadyVisited.contains(shape.toShapeId())
+    ) {
       return;
     }
     if (shape.hasTrait(UnitTypeTrait.class)) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -446,11 +446,7 @@ public class DafnyLocalServiceTypeConversionProtocol
     final Set<ShapeId> alreadyVisited,
     ServiceShape serviceShape
   ) {
-    if (alreadyVisited.contains(shape.toShapeId())) {
-      return;
-    }
-    // We don't need type conversion for operation shape and resource shape
-    if (shape.isOperationShape() || shape.isResourceShape()) {
+    if (GoCodegenUtils.shapeShouldHaveConversionFunction(shape) == false || alreadyVisited.contains(shape.toShapeId())) {
       return;
     }
     if (shape.hasTrait(UnitTypeTrait.class)) {
@@ -952,10 +948,7 @@ public class DafnyLocalServiceTypeConversionProtocol
     final Set<ShapeId> alreadyVisited,
     ServiceShape serviceShape
   ) {
-    if (alreadyVisited.contains(shape.toShapeId())) {
-      return;
-    }
-    if (shape.isOperationShape() || shape.isResourceShape()) {
+    if (GoCodegenUtils.shapeShouldHaveConversionFunction(shape) == false || alreadyVisited.contains(shape.toShapeId())) {
       return;
     }
     if (shape.hasTrait(UnitTypeTrait.class)) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -423,7 +423,6 @@ public class DafnyLocalServiceTypeConversionProtocol
     if (serviceShape.hasTrait(LocalServiceTrait.class)) {
       generateConfigSerializer(context, alreadyVisited);
     }
-    generateSerializerFunctions(context, alreadyVisited);
     final var orphanShapes =
       ModelUtils.getTopologicallyOrderedOrphanedShapesForService(
         serviceShape,
@@ -438,6 +437,7 @@ public class DafnyLocalServiceTypeConversionProtocol
         serviceShape
       );
     }
+    generateSerializerFunctions(context, alreadyVisited);
   }
 
   public void generateOrphanShapeSerializer(
@@ -929,7 +929,6 @@ public class DafnyLocalServiceTypeConversionProtocol
     if (serviceShape.hasTrait(LocalServiceTrait.class)) {
       generateConfigDeserializer(context, alreadyVisited);
     }
-    generateDeserializerFunctions(context, alreadyVisited);
     final var orphanShapes =
       ModelUtils.getTopologicallyOrderedOrphanedShapesForService(
         serviceShape,
@@ -944,6 +943,7 @@ public class DafnyLocalServiceTypeConversionProtocol
         serviceShape
       );
     }
+    generateDeserializerFunctions(context, alreadyVisited);
   }
 
   public void generateOrphanShapeDeserializer(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -214,6 +214,7 @@ public class DafnyLocalServiceTypeConversionProtocol
       final var resource = refResource
         .expectTrait(ReferenceTrait.class)
         .getReferentId();
+      alreadyVisited.add(resource);
       if (!refResource.expectTrait(ReferenceTrait.class).isService()) {
         final var resourceShape = model.expectShape(
           resource,
@@ -715,7 +716,7 @@ public class DafnyLocalServiceTypeConversionProtocol
       final var resource = refResource
         .expectTrait(ReferenceTrait.class)
         .getReferentId();
-
+      alreadyVisited.add(resource);
       if (!refResource.expectTrait(ReferenceTrait.class).isService()) {
         final var resourceShape = context
           .model()

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/utils/GoCodegenUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/utils/GoCodegenUtils.java
@@ -7,7 +7,6 @@ import software.amazon.polymorph.smithygo.codegen.SymbolUtils;
 import software.amazon.polymorph.smithygo.localservice.nameresolver.DafnyNameResolver;
 import software.amazon.polymorph.smithygo.localservice.nameresolver.SmithyNameResolver;
 import software.amazon.polymorph.smithypython.awssdk.nameresolver.AwsSdkNameResolver;
-import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.polymorph.traits.PositionalTrait;
 import software.amazon.polymorph.traits.ReferenceTrait;
 import software.amazon.smithy.aws.traits.ServiceTrait;
@@ -22,6 +21,7 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
 
 public class GoCodegenUtils {
@@ -190,7 +190,7 @@ public class GoCodegenUtils {
       );
     }
   }
-  
+
   /**
    * Returns true if a conversion function should be written for the shape, false otherwise.
    * Conversion functions are only written for "complex" shapes:

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/utils/GoCodegenUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/utils/GoCodegenUtils.java
@@ -6,6 +6,8 @@ import software.amazon.polymorph.smithygo.codegen.GoWriter;
 import software.amazon.polymorph.smithygo.codegen.SymbolUtils;
 import software.amazon.polymorph.smithygo.localservice.nameresolver.DafnyNameResolver;
 import software.amazon.polymorph.smithygo.localservice.nameresolver.SmithyNameResolver;
+import software.amazon.polymorph.smithypython.awssdk.nameresolver.AwsSdkNameResolver;
+import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.polymorph.traits.PositionalTrait;
 import software.amazon.polymorph.traits.ReferenceTrait;
 import software.amazon.smithy.aws.traits.ServiceTrait;
@@ -187,5 +189,35 @@ public class GoCodegenUtils {
           : shape.getId().getName()
       );
     }
+  }
+  
+  /**
+   * Returns true if a conversion function should be written for the shape, false otherwise.
+   * Conversion functions are only written for "complex" shapes:
+   *  - StructureShapes ("complex" because StructureShapes can be recursive)
+   *    - except for non-AWS SDK StructureShapes with ErrorTrait; these aren't "complex"
+   *  - UnionShapes ("complex" because the conversion is not a one-liner)
+   *  - EnumShapes or StringShapes with EnumTrait ("complex" because the conversion is not a one-liner)
+   * @param shape
+   * @return
+   */
+  public static boolean shapeShouldHaveConversionFunction(Shape shape) {
+    if (shape.isStructureShape()) {
+      if (
+        !SmithyNameResolver.isShapeFromAWSSDK(shape) &&
+        shape.hasTrait(ErrorTrait.class)
+      ) {
+        return false;
+      }
+      return true;
+    } else if (shape.isUnionShape()) {
+      return true;
+    } else if (
+      (shape.isStringShape() && shape.hasTrait(EnumTrait.class)) ||
+      shape.isEnumShape()
+    ) {
+      return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Enable orphan shape test model for Go
- Support map. list, boolean and blob orphan shapes
- Generate shape conversion for orphan shapes if needed

For extra credit this is the diff in MPL from this branch https://github.com/aws/aws-cryptographic-material-providers-library/pull/1225/files. This PR in MPL created only to run CI and see diff

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
