### PR TITLE
fix(go): use shape from the symbol properties in getType utils function

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolUtils.java
@@ -29,6 +29,7 @@ public final class SymbolUtils {
   public static final String GO_SLICE = "goSlice";
   public static final String GO_MAP = "goMap";
   public static final String GO_ELEMENT_TYPE = "goElementType";
+  public static final String SHAPE = "shape";
 
   // Used when a given shape must be represented differently on input.
   public static final String INPUT_VARIANT = "inputVariant";
@@ -66,7 +67,7 @@ public final class SymbolUtils {
     Shape shape,
     String typeName
   ) {
-    return createValueSymbolBuilder(typeName).putProperty("shape", shape);
+    return createValueSymbolBuilder(typeName).putProperty(SHAPE, shape);
   }
 
   /**
@@ -80,7 +81,7 @@ public final class SymbolUtils {
     Shape shape,
     String typeName
   ) {
-    return createPointableSymbolBuilder(typeName).putProperty("shape", shape);
+    return createPointableSymbolBuilder(typeName).putProperty(SHAPE, shape);
   }
 
   /**

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/ValidationGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/ValidationGenerator.java
@@ -514,7 +514,6 @@ public class ValidationGenerator {
         );
         final var inputType = GoCodegenUtils.getType(
           symbolProvider.toSymbol(currentShape),
-          currentShape,
           isExternalShape
         );
         if (isExternalShape) {
@@ -611,7 +610,6 @@ public class ValidationGenerator {
         );
         final var inputType = GoCodegenUtils.getType(
           symbolProvider.toSymbol(currentShape),
-          currentShape,
           isExternalShape
         );
         if (isExternalShape) {
@@ -684,7 +682,6 @@ public class ValidationGenerator {
         !currShapeNamespace.startsWith("smithy");
       final var inputType = GoCodegenUtils.getType(
         symbolProvider.toSymbol(currentShape),
-        currentShape,
         isExternalShape
       );
       if (isExternalShape) {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -484,7 +484,6 @@ public class DafnyLocalServiceTypeConversionProtocol
         inputType =
           GoCodegenUtils.getType(
             context.symbolProvider().toSymbol(resourceOrService),
-            resourceOrService,
             true
           );
       } else {
@@ -497,7 +496,7 @@ public class DafnyLocalServiceTypeConversionProtocol
             .concat(context.symbolProvider().toSymbol(serviceShape).getName());
       }
     } else {
-      inputType = GoCodegenUtils.getType(curSymbol, shape, true);
+      inputType = GoCodegenUtils.getType(curSymbol, true);
       outputType = DafnyNameResolver.getDafnyType(shape, curSymbol);
     }
     writerDelegator.useFileWriter(
@@ -992,11 +991,7 @@ public class DafnyLocalServiceTypeConversionProtocol
       }
     } else {
       outputType =
-        GoCodegenUtils.getType(
-          context.symbolProvider().toSymbol(shape),
-          shape,
-          true
-        );
+        GoCodegenUtils.getType(context.symbolProvider().toSymbol(shape), true);
     }
     writerDelegator.useFileWriter(
       "%s/%s".formatted(
@@ -1858,7 +1853,6 @@ public class DafnyLocalServiceTypeConversionProtocol
           inputType =
             GoCodegenUtils.getType(
               context.symbolProvider().toSymbol(visitingShape),
-              visitingShape,
               true
             );
           Boolean isPointable = context
@@ -1891,7 +1885,6 @@ public class DafnyLocalServiceTypeConversionProtocol
                 inputType =
                   GoCodegenUtils.getType(
                     context.symbolProvider().toSymbol(resourceOrService),
-                    resourceOrService,
                     true
                   );
               } else {
@@ -1962,7 +1955,6 @@ public class DafnyLocalServiceTypeConversionProtocol
           alreadyVisited.add(visitingMemberShape.toShapeId());
           var outputType = GoCodegenUtils.getType(
             context.symbolProvider().toSymbol(visitingShape),
-            visitingShape,
             true
           );
           Boolean isPointable = context

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
@@ -459,7 +459,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
       	}
       	fieldValue = append(fieldValue, %s)}
       	""".formatted(
-          GoCodegenUtils.getType(symbol, shape, true),
+          GoCodegenUtils.getType(symbol, true),
           dataSource,
           ShapeVisitorHelper.toNativeShapeVisitorWriter(
             memberShape,

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/utils/GoCodegenUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/utils/GoCodegenUtils.java
@@ -54,19 +54,20 @@ public class GoCodegenUtils {
 
   public static String getType(
     final Symbol symbol,
-    final Shape shape,
     final Boolean includeNamespace
   ) {
     if (
       symbol.getProperty(SymbolUtils.GO_ELEMENT_TYPE, Symbol.class).isEmpty()
     ) {
       return includeNamespace
-        ? SmithyNameResolver.getSmithyType(shape, symbol)
+        ? SmithyNameResolver.getSmithyType(
+          symbol.expectProperty(SymbolUtils.SHAPE, Shape.class),
+          symbol
+        )
         : symbol.getName();
     }
     var type = getType(
       symbol.expectProperty(SymbolUtils.GO_ELEMENT_TYPE, Symbol.class),
-      shape,
       includeNamespace
     );
     if (symbol.getProperty(SymbolUtils.GO_MAP).isPresent()) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`getType` function recursively moves symbol top to down to get the type of symbol but shape is always constant right now. This PR uses shape property from the symbol which will fix it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
