### PR TITLE
fix(go): generate type conversion for resource shape with no operation

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -367,6 +367,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                 );
               }
             }
+          });
             if (
               !alreadyVisited.contains(resourceShape.toShapeId()) &&
               resourceShape
@@ -416,7 +417,6 @@ public class DafnyLocalServiceTypeConversionProtocol
                 }
               );
             }
-          });
       }
     }
     generateErrorSerializer(context, alreadyVisited);
@@ -878,6 +878,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                 );
               }
             }
+          });
             if (
               !alreadyVisited.contains(resourceShape.toShapeId()) &&
               resourceShape
@@ -921,7 +922,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                 }
               );
             }
-          });
+          
       }
     }
     generateErrorDeserializer(context, alreadyVisited);

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -368,55 +368,55 @@ public class DafnyLocalServiceTypeConversionProtocol
               }
             }
           });
-            if (
-              !alreadyVisited.contains(resourceShape.toShapeId()) &&
-              resourceShape
-                .toShapeId()
-                .getNamespace()
-                .equals(serviceShape.toShapeId().getNamespace())
-            ) {
-              alreadyVisited.add(resourceShape.toShapeId());
-              writerDelegator.useFileWriter(
-                "%s/%s".formatted(
-                    SmithyNameResolver.shapeNamespace(serviceShape),
-                    TO_DAFNY
-                  ),
+        if (
+          !alreadyVisited.contains(resourceShape.toShapeId()) &&
+          resourceShape
+            .toShapeId()
+            .getNamespace()
+            .equals(serviceShape.toShapeId().getNamespace())
+        ) {
+          alreadyVisited.add(resourceShape.toShapeId());
+          writerDelegator.useFileWriter(
+            "%s/%s".formatted(
                 SmithyNameResolver.shapeNamespace(serviceShape),
-                writer -> {
-                  var goBody =
-                    """
-                    return nativeResource.(*%s).Impl
-                    """.formatted(resourceShape.getId().getName());
-                  if (resourceShape.hasTrait(ExtendableTrait.class)) {
-                    goBody =
-                      """
-                                                         val, ok := nativeResource.(*%s)
-                      if ok {
-                      	return val.Impl
-                      }
-                      return %s{&%sNativeWrapper{Impl: nativeResource}}.Impl
-                                                         """.formatted(
-                          resourceShape.getId().getName(),
-                          resourceShape.getId().getName(),
-                          resourceShape.getId().getName()
-                        );
+                TO_DAFNY
+              ),
+            SmithyNameResolver.shapeNamespace(serviceShape),
+            writer -> {
+              var goBody =
+                """
+                return nativeResource.(*%s).Impl
+                """.formatted(resourceShape.getId().getName());
+              if (resourceShape.hasTrait(ExtendableTrait.class)) {
+                goBody =
+                  """
+                                                     val, ok := nativeResource.(*%s)
+                  if ok {
+                  	return val.Impl
                   }
-                  writer.write(
-                    """
-                    func $L_ToDafny(nativeResource $L.I$L) $L.I$L {
-                        $L
-                    }
-                    """,
-                    resourceShape.getId().getName(),
-                    SmithyNameResolver.smithyTypesNamespace(resourceShape),
-                    resourceShape.getId().getName(),
-                    DafnyNameResolver.dafnyTypesNamespace(resourceShape),
-                    resourceShape.getId().getName(),
-                    goBody
-                  );
+                  return %s{&%sNativeWrapper{Impl: nativeResource}}.Impl
+                                                     """.formatted(
+                      resourceShape.getId().getName(),
+                      resourceShape.getId().getName(),
+                      resourceShape.getId().getName()
+                    );
+              }
+              writer.write(
+                """
+                func $L_ToDafny(nativeResource $L.I$L) $L.I$L {
+                    $L
                 }
+                """,
+                resourceShape.getId().getName(),
+                SmithyNameResolver.smithyTypesNamespace(resourceShape),
+                resourceShape.getId().getName(),
+                DafnyNameResolver.dafnyTypesNamespace(resourceShape),
+                resourceShape.getId().getName(),
+                goBody
               );
             }
+          );
+        }
       }
     }
     generateErrorSerializer(context, alreadyVisited);
@@ -879,50 +879,49 @@ public class DafnyLocalServiceTypeConversionProtocol
               }
             }
           });
-            if (
-              !alreadyVisited.contains(resourceShape.toShapeId()) &&
-              resourceShape
-                .toShapeId()
-                .getNamespace()
-                .equals(serviceShape.toShapeId().getNamespace())
-            ) {
-              alreadyVisited.add(resourceShape.toShapeId());
-              delegator.useFileWriter(
-                "%s/%s".formatted(
-                    SmithyNameResolver.shapeNamespace(serviceShape),
-                    TO_NATIVE
-                  ),
+        if (
+          !alreadyVisited.contains(resourceShape.toShapeId()) &&
+          resourceShape
+            .toShapeId()
+            .getNamespace()
+            .equals(serviceShape.toShapeId().getNamespace())
+        ) {
+          alreadyVisited.add(resourceShape.toShapeId());
+          delegator.useFileWriter(
+            "%s/%s".formatted(
                 SmithyNameResolver.shapeNamespace(serviceShape),
-                writer -> {
-                  var extendableResourceWrapperCheck = "";
-                  if (resourceShape.hasTrait(ExtendableTrait.class)) {
-                    extendableResourceWrapperCheck =
-                      """
-                      val, ok := dafnyResource.(*%sNativeWrapper)
-                      if ok {
-                          return val.Impl
-                      }
-                      """.formatted(resourceShape.getId().getName());
+                TO_NATIVE
+              ),
+            SmithyNameResolver.shapeNamespace(serviceShape),
+            writer -> {
+              var extendableResourceWrapperCheck = "";
+              if (resourceShape.hasTrait(ExtendableTrait.class)) {
+                extendableResourceWrapperCheck =
+                  """
+                  val, ok := dafnyResource.(*%sNativeWrapper)
+                  if ok {
+                      return val.Impl
                   }
-                  writer.write(
-                    """
-                    func $L_FromDafny(dafnyResource $L.I$L)($L.I$L) {
-                        $L
-                        return &$L{dafnyResource}
-                    }
-                    """,
-                    resourceShape.getId().getName(),
-                    DafnyNameResolver.dafnyTypesNamespace(resourceShape),
-                    resourceShape.getId().getName(),
-                    SmithyNameResolver.smithyTypesNamespace(resourceShape),
-                    resourceShape.getId().getName(),
-                    extendableResourceWrapperCheck,
-                    resourceShape.getId().getName()
-                  );
+                  """.formatted(resourceShape.getId().getName());
+              }
+              writer.write(
+                """
+                func $L_FromDafny(dafnyResource $L.I$L)($L.I$L) {
+                    $L
+                    return &$L{dafnyResource}
                 }
+                """,
+                resourceShape.getId().getName(),
+                DafnyNameResolver.dafnyTypesNamespace(resourceShape),
+                resourceShape.getId().getName(),
+                SmithyNameResolver.smithyTypesNamespace(resourceShape),
+                resourceShape.getId().getName(),
+                extendableResourceWrapperCheck,
+                resourceShape.getId().getName()
               );
             }
-          
+          );
+        }
       }
     }
     generateErrorDeserializer(context, alreadyVisited);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Workflow in main-1.x:
- For each operation in resource shape:
    1. Visit its input and output for type conversion
    1. Check if the resource shape is not visited and visit it. 
        - In this step: ***If the resource shape does not have any operation its type conversion will NOT be created***

With this PR:
- For each operation in resource shape:
    1. Visit its input and output for type conversion
- Check if the resource shape is not visited and visit it. 

With this update: ***If the resource shape does not have any operation its type conversion will still be created.***

The only change in MPL we are expecting is the type conversion for resource shape gets created only after shapes inside input and output of the operation is visited. Test PR in MPL: https://github.com/aws/aws-cryptographic-material-providers-library/pull/1252

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
