### PR TITLE
fix(go): AWS SDK shape namespace

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/StructureGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/StructureGenerator.java
@@ -115,7 +115,10 @@ public final class StructureGenerator implements Runnable {
               .getProperty(SymbolUtils.INPUT_VARIANT, Symbol.class)
               .orElse(memberSymbol);
         }
-        var namespace = SmithyNameResolver.smithyTypesNamespace(targetShape, model);
+        var namespace = SmithyNameResolver.smithyTypesNamespace(
+          targetShape,
+          model
+        );
 
         if (targetShape.hasTrait(ReferenceTrait.class)) {
           memberSymbol =

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/StructureGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/StructureGenerator.java
@@ -115,7 +115,7 @@ public final class StructureGenerator implements Runnable {
               .getProperty(SymbolUtils.INPUT_VARIANT, Symbol.class)
               .orElse(memberSymbol);
         }
-        var namespace = SmithyNameResolver.smithyTypesNamespace(targetShape);
+        var namespace = SmithyNameResolver.smithyTypesNamespace(targetShape, model);
 
         if (targetShape.hasTrait(ReferenceTrait.class)) {
           memberSymbol =
@@ -158,7 +158,7 @@ public final class StructureGenerator implements Runnable {
                 targetShape.getId().getNamespace()
               ),
               "types",
-              SmithyNameResolver.smithyTypesNamespace(targetShape)
+              SmithyNameResolver.smithyTypesNamespace(targetShape, model)
             );
           } else if (
             !member

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolUtils.java
@@ -29,6 +29,7 @@ public final class SymbolUtils {
   public static final String GO_SLICE = "goSlice";
   public static final String GO_MAP = "goMap";
   public static final String GO_ELEMENT_TYPE = "goElementType";
+  public static final String SHAPE = "shape";
 
   // Used when a given shape must be represented differently on input.
   public static final String INPUT_VARIANT = "inputVariant";
@@ -66,7 +67,7 @@ public final class SymbolUtils {
     Shape shape,
     String typeName
   ) {
-    return createValueSymbolBuilder(typeName).putProperty("shape", shape);
+    return createValueSymbolBuilder(typeName).putProperty(SHAPE, shape);
   }
 
   /**
@@ -80,7 +81,7 @@ public final class SymbolUtils {
     Shape shape,
     String typeName
   ) {
-    return createPointableSymbolBuilder(typeName).putProperty("shape", shape);
+    return createPointableSymbolBuilder(typeName).putProperty(SHAPE, shape);
   }
 
   /**

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolUtils.java
@@ -29,7 +29,6 @@ public final class SymbolUtils {
   public static final String GO_SLICE = "goSlice";
   public static final String GO_MAP = "goMap";
   public static final String GO_ELEMENT_TYPE = "goElementType";
-  public static final String SHAPE = "shape";
 
   // Used when a given shape must be represented differently on input.
   public static final String INPUT_VARIANT = "inputVariant";
@@ -67,7 +66,7 @@ public final class SymbolUtils {
     Shape shape,
     String typeName
   ) {
-    return createValueSymbolBuilder(typeName).putProperty(SHAPE, shape);
+    return createValueSymbolBuilder(typeName).putProperty("shape", shape);
   }
 
   /**
@@ -81,7 +80,7 @@ public final class SymbolUtils {
     Shape shape,
     String typeName
   ) {
-    return createPointableSymbolBuilder(typeName).putProperty(SHAPE, shape);
+    return createPointableSymbolBuilder(typeName).putProperty("shape", shape);
   }
 
   /**

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolVisitor.java
@@ -400,9 +400,8 @@ public class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
   private Symbol.Builder symbolBuilderFor(Shape shape, String typeName) {
     final String namespace;
-    if (shape.hasTrait(ServiceTrait.class)) {
-      namespace =
-        shape.expectTrait(ServiceTrait.class).getSdkId().toLowerCase();
+    if (SmithyNameResolver.isShapeFromAWSSDK(shape)) {
+      namespace = SmithyNameResolver.smithyTypesNamespace(shape, model);
     } else {
       namespace = SmithyNameResolver.smithyTypesNamespace(shape);
     }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/SymbolVisitor.java
@@ -403,7 +403,7 @@ public class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     if (SmithyNameResolver.isShapeFromAWSSDK(shape)) {
       namespace = SmithyNameResolver.smithyTypesNamespace(shape, model);
     } else {
-      namespace = SmithyNameResolver.smithyTypesNamespace(shape);
+      namespace = SmithyNameResolver.smithyTypesNamespace(shape, model);
     }
     if (pointableIndex.isPointable(shape)) {
       return SymbolUtils.createPointableSymbolBuilder(
@@ -540,11 +540,11 @@ public class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
       return symbolBuilderFor(
         shape,
         name,
-        SmithyNameResolver.smithyTypesNamespace(shape)
+        SmithyNameResolver.smithyTypesNamespace(shape, model)
       )
         .definitionFile(
           "./%s/enums.go".formatted(
-              SmithyNameResolver.smithyTypesNamespace(shape)
+              SmithyNameResolver.smithyTypesNamespace(shape, model)
             )
         )
         .build();
@@ -575,13 +575,13 @@ public class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     if (shape.hasTrait(ErrorTrait.ID)) {
       builder.definitionFile(
         "./%s/errors.go".formatted(
-            SmithyNameResolver.smithyTypesNamespace(shape)
+            SmithyNameResolver.smithyTypesNamespace(shape, model)
           )
       );
     } else {
       builder.definitionFile(
         "./%s/types.go".formatted(
-            SmithyNameResolver.smithyTypesNamespace(shape)
+            SmithyNameResolver.smithyTypesNamespace(shape, model)
           )
       );
     }
@@ -645,7 +645,7 @@ public class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     return symbolBuilderFor(
       shape,
       name,
-      SmithyNameResolver.smithyTypesNamespace(shape)
+      SmithyNameResolver.smithyTypesNamespace(shape, model)
     )
       .definitionFile("./types/types.go")
       .build();
@@ -671,11 +671,11 @@ public class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     return symbolBuilderFor(
       shape,
       name,
-      SmithyNameResolver.smithyTypesNamespace(settings.getService(model))
+      SmithyNameResolver.smithyTypesNamespace(settings.getService(model), model)
     )
       .definitionFile(
         "./%s/enums.go".formatted(
-            SmithyNameResolver.smithyTypesNamespace(shape)
+            SmithyNameResolver.smithyTypesNamespace(shape, model)
           )
       )
       .build();

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/UnionGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/UnionGenerator.java
@@ -89,7 +89,10 @@ public class UnionGenerator {
             writer.write("Value $T", memberSymbol);
           } else {
             // Handling smithy-dafny Reference Trait begins
-            var namespace = SmithyNameResolver.smithyTypesNamespace(target, model);
+            var namespace = SmithyNameResolver.smithyTypesNamespace(
+              target,
+              model
+            );
             var newMemberSymbol = memberSymbol;
             if (target.hasTrait(ReferenceTrait.class)) {
               newMemberSymbol =

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/UnionGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/UnionGenerator.java
@@ -89,7 +89,7 @@ public class UnionGenerator {
             writer.write("Value $T", memberSymbol);
           } else {
             // Handling smithy-dafny Reference Trait begins
-            var namespace = SmithyNameResolver.smithyTypesNamespace(target);
+            var namespace = SmithyNameResolver.smithyTypesNamespace(target, model);
             var newMemberSymbol = memberSymbol;
             if (target.hasTrait(ReferenceTrait.class)) {
               newMemberSymbol =

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/ValidationGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/ValidationGenerator.java
@@ -515,7 +515,8 @@ public class ValidationGenerator {
         final var inputType = GoCodegenUtils.getType(
           symbolProvider.toSymbol(currentShape),
           currentShape,
-          isExternalShape
+          isExternalShape,
+          context.model()
         );
         if (isExternalShape) {
           if (SmithyNameResolver.isShapeFromAWSSDK(currentShape)) {
@@ -524,14 +525,14 @@ public class ValidationGenerator {
                 currentShape.getId().getNamespace()
               ),
               "types",
-              SmithyNameResolver.smithyTypesNamespace(currentShape)
+              SmithyNameResolver.smithyTypesNamespace(currentShape, model)
             );
           } else {
             writer.addImportFromModule(
               SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                 currentShape.getId().getNamespace()
               ),
-              SmithyNameResolver.smithyTypesNamespace(currentShape)
+              SmithyNameResolver.smithyTypesNamespace(currentShape, model)
             );
           }
         }
@@ -612,7 +613,8 @@ public class ValidationGenerator {
         final var inputType = GoCodegenUtils.getType(
           symbolProvider.toSymbol(currentShape),
           currentShape,
-          isExternalShape
+          isExternalShape,
+          context.model()
         );
         if (isExternalShape) {
           if (SmithyNameResolver.isShapeFromAWSSDK(currentShape)) {
@@ -621,14 +623,14 @@ public class ValidationGenerator {
                 currentShape.getId().getNamespace()
               ),
               "types",
-              SmithyNameResolver.smithyTypesNamespace(currentShape)
+              SmithyNameResolver.smithyTypesNamespace(currentShape, model)
             );
           } else {
             writer.addImportFromModule(
               SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                 currentShape.getId().getNamespace()
               ),
-              SmithyNameResolver.smithyTypesNamespace(currentShape)
+              SmithyNameResolver.smithyTypesNamespace(currentShape, model)
             );
           }
         }
@@ -673,10 +675,10 @@ public class ValidationGenerator {
     var dataSourceForUnion = dataSource;
     final var currServiceShapeNamespace =
       SmithyNameResolver.smithyTypesNamespace(
-        context.settings().getService(model)
+        context.settings().getService(model), model
       );
     final var currShapeNamespace = SmithyNameResolver.smithyTypesNamespace(
-      memberShape
+      memberShape, model
     );
     if (!funcInput.isEmpty()) {
       final Boolean isExternalShape =
@@ -685,7 +687,8 @@ public class ValidationGenerator {
       final var inputType = GoCodegenUtils.getType(
         symbolProvider.toSymbol(currentShape),
         currentShape,
-        isExternalShape
+        isExternalShape,
+        context.model()
       );
       if (isExternalShape) {
         if (SmithyNameResolver.isShapeFromAWSSDK(currentShape)) {
@@ -694,14 +697,14 @@ public class ValidationGenerator {
               currentShape.getId().getNamespace()
             ),
             "types",
-            SmithyNameResolver.smithyTypesNamespace(currentShape)
+            SmithyNameResolver.smithyTypesNamespace(currentShape, model)
           );
         } else {
           writer.addImportFromModule(
             SmithyNameResolver.getGoModuleNameForSmithyNamespace(
               currentShape.getId().getNamespace()
             ),
-            SmithyNameResolver.smithyTypesNamespace(currentShape)
+            SmithyNameResolver.smithyTypesNamespace(currentShape, model)
           );
         }
       }
@@ -724,7 +727,7 @@ public class ValidationGenerator {
       );
       for (final var memberInUnion : currentShape.getAllMembers().values()) {
         final var currMemberNamespace = SmithyNameResolver.smithyTypesNamespace(
-          currentShape
+          currentShape, model
         );
         final Boolean isExternalShape =
           !currServiceShapeNamespace.equals(currMemberNamespace) &&

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/ValidationGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/ValidationGenerator.java
@@ -675,10 +675,12 @@ public class ValidationGenerator {
     var dataSourceForUnion = dataSource;
     final var currServiceShapeNamespace =
       SmithyNameResolver.smithyTypesNamespace(
-        context.settings().getService(model), model
+        context.settings().getService(model),
+        model
       );
     final var currShapeNamespace = SmithyNameResolver.smithyTypesNamespace(
-      memberShape, model
+      memberShape,
+      model
     );
     if (!funcInput.isEmpty()) {
       final Boolean isExternalShape =
@@ -727,7 +729,8 @@ public class ValidationGenerator {
       );
       for (final var memberInUnion : currentShape.getAllMembers().values()) {
         final var currMemberNamespace = SmithyNameResolver.smithyTypesNamespace(
-          currentShape, model
+          currentShape,
+          model
         );
         final Boolean isExternalShape =
           !currServiceShapeNamespace.equals(currMemberNamespace) &&

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
@@ -13,7 +13,6 @@ import software.amazon.polymorph.smithygo.codegen.GenerationContext;
 import software.amazon.polymorph.smithygo.codegen.GoDelegator;
 import software.amazon.polymorph.smithygo.codegen.GoWriter;
 import software.amazon.polymorph.smithygo.codegen.SmithyGoDependency;
-import software.amazon.polymorph.smithygo.codegen.SymbolUtils;
 import software.amazon.polymorph.smithygo.codegen.UnionGenerator;
 import software.amazon.polymorph.smithygo.localservice.nameresolver.DafnyNameResolver;
 import software.amazon.polymorph.smithygo.localservice.nameresolver.SmithyNameResolver;
@@ -32,7 +31,6 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
 
@@ -141,7 +139,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
       """,
       serviceSymbol,
       dafnyClient,
-      SmithyNameResolver.getSmithyType(configSymbol.expectProperty(SymbolUtils.SHAPE, Shape.class), configSymbol),
+      SmithyNameResolver.getSmithyType(service, configSymbol),
       serviceSymbol,
       SmithyNameResolver.getToDafnyMethodName(
         service,

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
@@ -13,6 +13,7 @@ import software.amazon.polymorph.smithygo.codegen.GenerationContext;
 import software.amazon.polymorph.smithygo.codegen.GoDelegator;
 import software.amazon.polymorph.smithygo.codegen.GoWriter;
 import software.amazon.polymorph.smithygo.codegen.SmithyGoDependency;
+import software.amazon.polymorph.smithygo.codegen.SymbolUtils;
 import software.amazon.polymorph.smithygo.codegen.UnionGenerator;
 import software.amazon.polymorph.smithygo.localservice.nameresolver.DafnyNameResolver;
 import software.amazon.polymorph.smithygo.localservice.nameresolver.SmithyNameResolver;
@@ -31,6 +32,7 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
 
@@ -139,7 +141,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
       """,
       serviceSymbol,
       dafnyClient,
-      SmithyNameResolver.getSmithyType(service, configSymbol),
+      SmithyNameResolver.getSmithyType(configSymbol.expectProperty(SymbolUtils.SHAPE, Shape.class), configSymbol),
       serviceSymbol,
       SmithyNameResolver.getToDafnyMethodName(
         service,

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
@@ -136,7 +136,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
         SmithyNameResolver.getGoModuleNameForSmithyNamespace(
           configShape.toShapeId().getNamespace()
         ),
-        SmithyNameResolver.smithyTypesNamespace(configShape)
+        SmithyNameResolver.smithyTypesNamespace(configShape, model)
       );
       writer.addImportFromModule(
         SmithyNameResolver.getGoModuleNameForSmithyNamespace(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
@@ -79,7 +79,9 @@ public class DafnyLocalServiceGenerator implements Runnable {
     );
 
     writerDelegator.useFileWriter(
-      "%s/types.go".formatted(SmithyNameResolver.smithyTypesNamespace(service, model)),
+      "%s/types.go".formatted(
+          SmithyNameResolver.smithyTypesNamespace(service, model)
+        ),
       SmithyNameResolver.smithyTypesNamespace(service, model),
       writer1 -> {
         model
@@ -659,16 +661,26 @@ public class DafnyLocalServiceGenerator implements Runnable {
 
 
         """,
-        SmithyNameResolver.getSmithyType(error, symbolProvider.toSymbol(error), model),
+        SmithyNameResolver.getSmithyType(
+          error,
+          symbolProvider.toSymbol(error),
+          model
+        ),
         SmithyNameResolver.getToDafnyMethodName(service, error, ""),
-        SmithyNameResolver.getSmithyType(error, symbolProvider.toSymbol(error), model)
+        SmithyNameResolver.getSmithyType(
+          error,
+          symbolProvider.toSymbol(error),
+          model
+        )
       );
     }
   }
 
   void generateUnmodelledErrors(GenerationContext context) {
     writerDelegator.useFileWriter(
-      "%s/types.go".formatted(SmithyNameResolver.smithyTypesNamespace(service, model)),
+      "%s/types.go".formatted(
+          SmithyNameResolver.smithyTypesNamespace(service, model)
+        ),
       SmithyNameResolver.smithyTypesNamespace(service, model),
       writer -> {
         writer.write(
@@ -939,7 +951,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
                       SmithyNameResolver
                         .getSmithyType(
                           outputShape,
-                          symbolProvider.toSymbol(outputShape), model
+                          symbolProvider.toSymbol(outputShape),
+                          model
                         )
                         .concat(",");
                     final var typeAssertion = outputShape.isResourceShape()

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceGenerator.java
@@ -79,8 +79,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
     );
 
     writerDelegator.useFileWriter(
-      "%s/types.go".formatted(SmithyNameResolver.smithyTypesNamespace(service)),
-      SmithyNameResolver.smithyTypesNamespace(service),
+      "%s/types.go".formatted(SmithyNameResolver.smithyTypesNamespace(service, model)),
+      SmithyNameResolver.smithyTypesNamespace(service, model),
       writer1 -> {
         model
           .getUnionShapes()
@@ -115,7 +115,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
       SmithyNameResolver.getGoModuleNameForSmithyNamespace(
         context.settings().getService().getNamespace()
       ),
-      SmithyNameResolver.smithyTypesNamespace(service)
+      SmithyNameResolver.smithyTypesNamespace(service, model)
     );
     writer.addUseImports(SmithyGoDependency.CONTEXT);
 
@@ -139,7 +139,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
       """,
       serviceSymbol,
       dafnyClient,
-      SmithyNameResolver.getSmithyType(service, configSymbol),
+      SmithyNameResolver.getSmithyType(service, configSymbol, model),
       serviceSymbol,
       SmithyNameResolver.getToDafnyMethodName(
         service,
@@ -183,7 +183,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
           SmithyNameResolver.getGoModuleNameForSmithyNamespace(
             outputShape.toShapeId().getNamespace()
           ),
-          SmithyNameResolver.smithyTypesNamespace(outputShape)
+          SmithyNameResolver.smithyTypesNamespace(outputShape, model)
         );
         if (
           !outputShape
@@ -201,13 +201,13 @@ public class DafnyLocalServiceGenerator implements Runnable {
         var inputType = inputShape.hasTrait(UnitTypeTrait.class)
           ? ""
           : ", params %s.%s".formatted(
-              SmithyNameResolver.smithyTypesNamespace(inputShape),
+              SmithyNameResolver.smithyTypesNamespace(inputShape, model),
               inputShape.toShapeId().getName()
             );
         var outputType = outputShape.hasTrait(UnitTypeTrait.class)
           ? ""
           : "*%s.%s,".formatted(
-              SmithyNameResolver.smithyTypesNamespace(outputShape),
+              SmithyNameResolver.smithyTypesNamespace(outputShape, model),
               outputShape.toShapeId().getName()
             );
         String baseClientCall;
@@ -238,7 +238,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
               ", params %s".formatted(
                   SmithyNameResolver.getSmithyType(
                     inputShape,
-                    symbolProvider.toSymbol(inputShape)
+                    symbolProvider.toSymbol(inputShape),
+                    model
                   )
                 );
           } else {
@@ -295,7 +296,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
               SmithyNameResolver
                 .getSmithyType(
                   outputShape,
-                  symbolProvider.toSymbol(outputShape)
+                  symbolProvider.toSymbol(outputShape),
+                  model
                 )
                 .concat(",");
             GoCodegenUtils.importNamespace(outputShape, writer);
@@ -316,7 +318,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
               return defaultVal,""".formatted(
                   SmithyNameResolver.getSmithyType(
                     outputShape,
-                    symbolProvider.toSymbol(outputShape)
+                    symbolProvider.toSymbol(outputShape),
+                    model
                   )
                 );
           } else {
@@ -361,7 +364,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
                   %s opaqueErr
                 }
             """.formatted(
-                SmithyNameResolver.smithyTypesNamespace(inputShape),
+                SmithyNameResolver.smithyTypesNamespace(inputShape, model),
                 returnError
               );
         }
@@ -410,7 +413,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
           SmithyNameResolver.getGoModuleNameForSmithyNamespace(
             context.settings().getService().getNamespace()
           ),
-          SmithyNameResolver.smithyTypesNamespace(service)
+          SmithyNameResolver.smithyTypesNamespace(service, model)
         );
         writer.addUseImports(SmithyGoDependency.CONTEXT);
         writer.addImportFromModule(
@@ -634,10 +637,10 @@ public class DafnyLocalServiceGenerator implements Runnable {
 
 
         """,
-        SmithyNameResolver.smithyTypesNamespace(error),
+        SmithyNameResolver.smithyTypesNamespace(error, model),
         symbolProvider.toSymbol(error).getName(),
         SmithyNameResolver.getToDafnyMethodName(service, error, ""),
-        SmithyNameResolver.smithyTypesNamespace(error),
+        SmithyNameResolver.smithyTypesNamespace(error, model),
         symbolProvider.toSymbol(error).getName()
       );
     }
@@ -656,17 +659,17 @@ public class DafnyLocalServiceGenerator implements Runnable {
 
 
         """,
-        SmithyNameResolver.getSmithyType(error, symbolProvider.toSymbol(error)),
+        SmithyNameResolver.getSmithyType(error, symbolProvider.toSymbol(error), model),
         SmithyNameResolver.getToDafnyMethodName(service, error, ""),
-        SmithyNameResolver.getSmithyType(error, symbolProvider.toSymbol(error))
+        SmithyNameResolver.getSmithyType(error, symbolProvider.toSymbol(error), model)
       );
     }
   }
 
   void generateUnmodelledErrors(GenerationContext context) {
     writerDelegator.useFileWriter(
-      "%s/types.go".formatted(SmithyNameResolver.smithyTypesNamespace(service)),
-      SmithyNameResolver.smithyTypesNamespace(service),
+      "%s/types.go".formatted(SmithyNameResolver.smithyTypesNamespace(service, model)),
+      SmithyNameResolver.smithyTypesNamespace(service, model),
       writer -> {
         writer.write(
           """
@@ -683,9 +686,9 @@ public class DafnyLocalServiceGenerator implements Runnable {
     );
     writerDelegator.useFileWriter(
       "%s/unmodelled_errors.go".formatted(
-          SmithyNameResolver.smithyTypesNamespace(service)
+          SmithyNameResolver.smithyTypesNamespace(service, model)
         ),
-      SmithyNameResolver.smithyTypesNamespace(service),
+      SmithyNameResolver.smithyTypesNamespace(service, model),
       writer -> {
         writer.addUseImports(SmithyGoDependency.FMT);
         writer.write(
@@ -736,9 +739,9 @@ public class DafnyLocalServiceGenerator implements Runnable {
         }
         writerDelegator.useFileWriter(
           "%s/types.go".formatted(
-              SmithyNameResolver.smithyTypesNamespace(service)
+              SmithyNameResolver.smithyTypesNamespace(service, model)
             ),
-          SmithyNameResolver.smithyTypesNamespace(service),
+          SmithyNameResolver.smithyTypesNamespace(service, model),
           writer -> {
             writer.write(
               """
@@ -805,7 +808,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
               SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                 context.settings().getService().getNamespace()
               ),
-              SmithyNameResolver.smithyTypesNamespace(service)
+              SmithyNameResolver.smithyTypesNamespace(service, model)
             );
             writer.addImportFromModule(
               SmithyNameResolver.getGoModuleNameForSmithyNamespace(
@@ -846,7 +849,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
                   : "*%s,".formatted(
                       SmithyNameResolver.getSmithyType(
                         outputShape,
-                        symbolProvider.toSymbol(outputShape)
+                        symbolProvider.toSymbol(outputShape),
+                        model
                       )
                     );
 
@@ -874,7 +878,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
                     "params %s".formatted(
                         SmithyNameResolver.getSmithyType(
                           inputShape,
-                          symbolProvider.toSymbol(inputShape)
+                          symbolProvider.toSymbol(inputShape),
+                          model
                         )
                       );
                   baseClientCall =
@@ -934,7 +939,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
                       SmithyNameResolver
                         .getSmithyType(
                           outputShape,
-                          symbolProvider.toSymbol(outputShape)
+                          symbolProvider.toSymbol(outputShape), model
                         )
                         .concat(",");
                     final var typeAssertion = outputShape.isResourceShape()
@@ -962,7 +967,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
                       return defaultVal,""".formatted(
                           SmithyNameResolver.getSmithyType(
                             outputShape,
-                            symbolProvider.toSymbol(outputShape)
+                            symbolProvider.toSymbol(outputShape),
+                            model
                           )
                         );
                   } else {
@@ -1028,7 +1034,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
       writer -> {
         writer.addImportFromModule(
           context.settings().getModuleName(),
-          SmithyNameResolver.smithyTypesNamespace(service)
+          SmithyNameResolver.smithyTypesNamespace(service, model)
         );
         writer.addImportFromModule(SMITHY_DAFNY_STD_LIB_GO, "Wrappers");
         writer.addImportFromModule(
@@ -1048,7 +1054,7 @@ public class DafnyLocalServiceGenerator implements Runnable {
               resourceShape.getId().getName(),
               DafnyNameResolver.dafnyTypesNamespace(resourceShape),
               resourceShape.getId().getName(),
-              SmithyNameResolver.smithyTypesNamespace(resourceShape),
+              SmithyNameResolver.smithyTypesNamespace(resourceShape, model),
               resourceShape.getId().getName()
             )
         );
@@ -1069,7 +1075,8 @@ public class DafnyLocalServiceGenerator implements Runnable {
               : "*%s,".formatted(
                   SmithyNameResolver.getSmithyType(
                     outputShape,
-                    symbolProvider.toSymbol(outputShape)
+                    symbolProvider.toSymbol(outputShape),
+                    model
                   )
                 );
             String fromDafnyConvMethodNameForInput =

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -1947,19 +1947,6 @@ public class DafnyLocalServiceTypeConversionProtocol
               true,
               context.model()
             );
-          if (
-            model
-              .shapes(OperationShape.class)
-              .anyMatch(op ->
-                op
-                  .getInput()
-                  .filter(visitingShape.getId()::equals)
-                  .isPresent() ||
-                op.getOutput().filter(visitingShape.getId()::equals).isPresent()
-              )
-          ) {
-            System.out.println(visitingShape);
-          }
           Boolean isPointable = context
             .symbolProvider()
             .toSymbol(visitingMemberShape)

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -187,7 +187,11 @@ public class DafnyLocalServiceTypeConversionProtocol
                         ${C|}
                     }""",
                     outputToDafnyMethodName,
-                    SmithyNameResolver.getSmithyType(output, outputSymbol, model),
+                    SmithyNameResolver.getSmithyType(
+                      output,
+                      outputSymbol,
+                      model
+                    ),
                     DafnyNameResolver.getDafnyType(output, outputSymbol),
                     writer.consumer(w ->
                       generateResponseSerializer(
@@ -289,7 +293,11 @@ public class DafnyLocalServiceTypeConversionProtocol
                           ${C|}
                       }""",
                       inputToDafnyMethodName,
-                      SmithyNameResolver.getSmithyType(input, inputSymbol, model),
+                      SmithyNameResolver.getSmithyType(
+                        input,
+                        inputSymbol,
+                        model
+                      ),
                       outputType,
                       writer.consumer(w ->
                         generateRequestSerializer(
@@ -352,7 +360,11 @@ public class DafnyLocalServiceTypeConversionProtocol
                             ${C|}
                         }""",
                         outputToDafnyMethodName,
-                        SmithyNameResolver.getSmithyType(output, outputSymbol, model),
+                        SmithyNameResolver.getSmithyType(
+                          output,
+                          outputSymbol,
+                          model
+                        ),
                         DafnyNameResolver.getDafnyType(output, outputSymbol),
                         writer.consumer(w ->
                           generateResponseSerializer(
@@ -407,7 +419,10 @@ public class DafnyLocalServiceTypeConversionProtocol
                     }
                     """,
                     resourceShape.getId().getName(),
-                    SmithyNameResolver.smithyTypesNamespace(resourceShape, model),
+                    SmithyNameResolver.smithyTypesNamespace(
+                      resourceShape,
+                      model
+                    ),
                     resourceShape.getId().getName(),
                     DafnyNameResolver.dafnyTypesNamespace(resourceShape),
                     resourceShape.getId().getName(),
@@ -498,7 +513,8 @@ public class DafnyLocalServiceTypeConversionProtocol
             .concat(context.symbolProvider().toSymbol(serviceShape).getName());
       }
     } else {
-      inputType = GoCodegenUtils.getType(curSymbol, shape, true, context.model());
+      inputType =
+        GoCodegenUtils.getType(curSymbol, shape, true, context.model());
       outputType = DafnyNameResolver.getDafnyType(shape, curSymbol);
     }
     writerDelegator.useFileWriter(
@@ -615,7 +631,10 @@ public class DafnyLocalServiceTypeConversionProtocol
                   SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                     input.toShapeId().getNamespace()
                   ),
-                  SmithyNameResolver.smithyTypesNamespace(input, context.model())
+                  SmithyNameResolver.smithyTypesNamespace(
+                    input,
+                    context.model()
+                  )
                 );
 
                 writer.write(
@@ -625,7 +644,11 @@ public class DafnyLocalServiceTypeConversionProtocol
                   }""",
                   inputFromDafnyMethodName,
                   inputType,
-                  SmithyNameResolver.getSmithyType(input, inputSymbol, context.model()),
+                  SmithyNameResolver.getSmithyType(
+                    input,
+                    inputSymbol,
+                    context.model()
+                  ),
                   writer.consumer(w ->
                     generateRequestDeserializer(
                       context,
@@ -680,7 +703,10 @@ public class DafnyLocalServiceTypeConversionProtocol
                     SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                       output.toShapeId().getNamespace()
                     ),
-                    SmithyNameResolver.smithyTypesNamespace(output, context.model())
+                    SmithyNameResolver.smithyTypesNamespace(
+                      output,
+                      context.model()
+                    )
                   );
 
                   writer.write(
@@ -690,7 +716,11 @@ public class DafnyLocalServiceTypeConversionProtocol
                     }""",
                     outputFromDafnyMethodName,
                     DafnyNameResolver.getDafnyType(output, outputSymbol),
-                    SmithyNameResolver.getSmithyType(output, outputSymbol, context.model()),
+                    SmithyNameResolver.getSmithyType(
+                      output,
+                      outputSymbol,
+                      context.model()
+                    ),
                     writer.consumer(w ->
                       generateResponseDeserializer(
                         context,
@@ -788,7 +818,10 @@ public class DafnyLocalServiceTypeConversionProtocol
                       SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                         input.toShapeId().getNamespace()
                       ),
-                      SmithyNameResolver.smithyTypesNamespace(input, context.model())
+                      SmithyNameResolver.smithyTypesNamespace(
+                        input,
+                        context.model()
+                      )
                     );
 
                     writer.write(
@@ -798,7 +831,11 @@ public class DafnyLocalServiceTypeConversionProtocol
                       }""",
                       inputFromDafnyMethodName,
                       inputType,
-                      SmithyNameResolver.getSmithyType(input, inputSymbol, context.model()),
+                      SmithyNameResolver.getSmithyType(
+                        input,
+                        inputSymbol,
+                        context.model()
+                      ),
                       writer.consumer(w ->
                         generateRequestDeserializer(
                           context,
@@ -855,7 +892,10 @@ public class DafnyLocalServiceTypeConversionProtocol
                         SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                           output.toShapeId().getNamespace()
                         ),
-                        SmithyNameResolver.smithyTypesNamespace(output, context.model())
+                        SmithyNameResolver.smithyTypesNamespace(
+                          output,
+                          context.model()
+                        )
                       );
 
                       writer.write(
@@ -865,7 +905,11 @@ public class DafnyLocalServiceTypeConversionProtocol
                         }""",
                         outputFromDafnyMethodName,
                         DafnyNameResolver.getDafnyType(output, outputSymbol),
-                        SmithyNameResolver.getSmithyType(output, outputSymbol, context.model()),
+                        SmithyNameResolver.getSmithyType(
+                          output,
+                          outputSymbol,
+                          context.model()
+                        ),
                         writer.consumer(w ->
                           generateResponseDeserializer(
                             context,
@@ -914,7 +958,10 @@ public class DafnyLocalServiceTypeConversionProtocol
                     resourceShape.getId().getName(),
                     DafnyNameResolver.dafnyTypesNamespace(resourceShape),
                     resourceShape.getId().getName(),
-                    SmithyNameResolver.smithyTypesNamespace(resourceShape, context.model()),
+                    SmithyNameResolver.smithyTypesNamespace(
+                      resourceShape,
+                      context.model()
+                    ),
                     resourceShape.getId().getName(),
                     extendableResourceWrapperCheck,
                     resourceShape.getId().getName()
@@ -1315,10 +1362,16 @@ public class DafnyLocalServiceTypeConversionProtocol
             func OpaqueError_Input_ToDafny(nativeInput $L.OpaqueError)($L.Error) {
             	return $L.Companion_Error_.Create_Opaque_(nativeInput.ErrObject)
             }""",
-            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
+            SmithyNameResolver.smithyTypesNamespace(
+              serviceShape,
+              context.model()
+            ),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
+            SmithyNameResolver.smithyTypesNamespace(
+              serviceShape,
+              context.model()
+            ),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape)
           );
@@ -1385,7 +1438,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                     context
                       .symbolProvider()
                       .toSymbol(context.model().expectShape(error)),
-                      context.model()
+                    context.model()
                   ),
                   SmithyNameResolver.getToDafnyMethodName(
                     serviceShape,
@@ -1397,7 +1450,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                     context
                       .symbolProvider()
                       .toSymbol(context.model().expectShape(error)),
-                      context.model()
+                    context.model()
                   )
                 );
               }
@@ -1414,9 +1467,18 @@ public class DafnyLocalServiceTypeConversionProtocol
                 handleDepErrorSerializer(context, w, dependencies);
               }
             }),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model())
+            SmithyNameResolver.smithyTypesNamespace(
+              serviceShape,
+              context.model()
+            ),
+            SmithyNameResolver.smithyTypesNamespace(
+              serviceShape,
+              context.model()
+            ),
+            SmithyNameResolver.smithyTypesNamespace(
+              serviceShape,
+              context.model()
+            )
           );
         }
       );
@@ -1561,7 +1623,10 @@ public class DafnyLocalServiceTypeConversionProtocol
             SmithyNameResolver.getGoModuleNameForSmithyNamespace(
               configShape.toShapeId().getNamespace()
             ),
-            SmithyNameResolver.smithyTypesNamespace(configShape, context.model())
+            SmithyNameResolver.smithyTypesNamespace(
+              configShape,
+              context.model()
+            )
           );
           writer.write(
             """
@@ -1717,12 +1782,24 @@ public class DafnyLocalServiceTypeConversionProtocol
                 }
             }""",
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
+            SmithyNameResolver.smithyTypesNamespace(
+              serviceShape,
+              context.model()
+            ),
+            SmithyNameResolver.smithyTypesNamespace(
+              serviceShape,
+              context.model()
+            ),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model())
+            SmithyNameResolver.smithyTypesNamespace(
+              serviceShape,
+              context.model()
+            ),
+            SmithyNameResolver.smithyTypesNamespace(
+              serviceShape,
+              context.model()
+            )
           );
         }
       );

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -420,10 +420,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                 }
                 """,
                 resourceShape.getId().getName(),
-                SmithyNameResolver.smithyTypesNamespace(
-                      resourceShape,
-                      model
-                    ),
+                SmithyNameResolver.smithyTypesNamespace(resourceShape, model),
                 resourceShape.getId().getName(),
                 DafnyNameResolver.dafnyTypesNamespace(resourceShape),
                 resourceShape.getId().getName(),
@@ -512,8 +509,7 @@ public class DafnyLocalServiceTypeConversionProtocol
             .concat(context.symbolProvider().toSymbol(serviceShape).getName());
       }
     } else {
-      inputType =
-        GoCodegenUtils.getType(curSymbol, true, context.model());
+      inputType = GoCodegenUtils.getType(curSymbol, true, context.model());
       outputType = DafnyNameResolver.getDafnyType(shape, curSymbol);
     }
     writerDelegator.useFileWriter(
@@ -959,9 +955,9 @@ public class DafnyLocalServiceTypeConversionProtocol
                 DafnyNameResolver.dafnyTypesNamespace(resourceShape),
                 resourceShape.getId().getName(),
                 SmithyNameResolver.smithyTypesNamespace(
-                      resourceShape,
-                      context.model()
-                    ),
+                  resourceShape,
+                  context.model()
+                ),
                 resourceShape.getId().getName(),
                 extendableResourceWrapperCheck,
                 resourceShape.getId().getName()
@@ -1039,8 +1035,11 @@ public class DafnyLocalServiceTypeConversionProtocol
       }
     } else {
       outputType =
-        GoCodegenUtils.getType(context.symbolProvider().toSymbol(shape), true,
-          context.model());
+        GoCodegenUtils.getType(
+          context.symbolProvider().toSymbol(shape),
+          true,
+          context.model()
+        );
     }
     writerDelegator.useFileWriter(
       "%s/%s".formatted(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/DafnyLocalServiceTypeConversionProtocol.java
@@ -120,7 +120,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                   SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                     input.toShapeId().getNamespace()
                   ),
-                  SmithyNameResolver.smithyTypesNamespace(input)
+                  SmithyNameResolver.smithyTypesNamespace(input, model)
                 );
                 writer.write(
                   """
@@ -128,7 +128,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                       ${C|}
                   }""",
                   inputToDafnyMethodName,
-                  SmithyNameResolver.getSmithyType(input, inputSymbol),
+                  SmithyNameResolver.getSmithyType(input, inputSymbol, model),
                   outputType,
                   writer.consumer(w ->
                     generateRequestSerializer(
@@ -179,7 +179,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                     SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                       output.toShapeId().getNamespace()
                     ),
-                    SmithyNameResolver.smithyTypesNamespace(output)
+                    SmithyNameResolver.smithyTypesNamespace(output, model)
                   );
                   writer.write(
                     """
@@ -187,7 +187,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                         ${C|}
                     }""",
                     outputToDafnyMethodName,
-                    SmithyNameResolver.getSmithyType(output, outputSymbol),
+                    SmithyNameResolver.getSmithyType(output, outputSymbol, model),
                     DafnyNameResolver.getDafnyType(output, outputSymbol),
                     writer.consumer(w ->
                       generateResponseSerializer(
@@ -281,7 +281,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                       SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                         input.toShapeId().getNamespace()
                       ),
-                      SmithyNameResolver.smithyTypesNamespace(input)
+                      SmithyNameResolver.smithyTypesNamespace(input, model)
                     );
                     writer.write(
                       """
@@ -289,7 +289,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                           ${C|}
                       }""",
                       inputToDafnyMethodName,
-                      SmithyNameResolver.getSmithyType(input, inputSymbol),
+                      SmithyNameResolver.getSmithyType(input, inputSymbol, model),
                       outputType,
                       writer.consumer(w ->
                         generateRequestSerializer(
@@ -344,7 +344,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                         SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                           output.toShapeId().getNamespace()
                         ),
-                        SmithyNameResolver.smithyTypesNamespace(output)
+                        SmithyNameResolver.smithyTypesNamespace(output, model)
                       );
                       writer.write(
                         """
@@ -352,7 +352,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                             ${C|}
                         }""",
                         outputToDafnyMethodName,
-                        SmithyNameResolver.getSmithyType(output, outputSymbol),
+                        SmithyNameResolver.getSmithyType(output, outputSymbol, model),
                         DafnyNameResolver.getDafnyType(output, outputSymbol),
                         writer.consumer(w ->
                           generateResponseSerializer(
@@ -407,7 +407,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                     }
                     """,
                     resourceShape.getId().getName(),
-                    SmithyNameResolver.smithyTypesNamespace(resourceShape),
+                    SmithyNameResolver.smithyTypesNamespace(resourceShape, model),
                     resourceShape.getId().getName(),
                     DafnyNameResolver.dafnyTypesNamespace(resourceShape),
                     resourceShape.getId().getName(),
@@ -485,7 +485,8 @@ public class DafnyLocalServiceTypeConversionProtocol
           GoCodegenUtils.getType(
             context.symbolProvider().toSymbol(resourceOrService),
             resourceOrService,
-            true
+            true,
+            context.model()
           );
       } else {
         outputType =
@@ -497,7 +498,7 @@ public class DafnyLocalServiceTypeConversionProtocol
             .concat(context.symbolProvider().toSymbol(serviceShape).getName());
       }
     } else {
-      inputType = GoCodegenUtils.getType(curSymbol, shape, true);
+      inputType = GoCodegenUtils.getType(curSymbol, shape, true, context.model());
       outputType = DafnyNameResolver.getDafnyType(shape, curSymbol);
     }
     writerDelegator.useFileWriter(
@@ -511,7 +512,7 @@ public class DafnyLocalServiceTypeConversionProtocol
           SmithyNameResolver.getGoModuleNameForSmithyNamespace(
             shape.toShapeId().getNamespace()
           ),
-          SmithyNameResolver.smithyTypesNamespace(shape)
+          SmithyNameResolver.smithyTypesNamespace(shape, context.model())
         );
         writer.write(
           """
@@ -614,7 +615,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                   SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                     input.toShapeId().getNamespace()
                   ),
-                  SmithyNameResolver.smithyTypesNamespace(input)
+                  SmithyNameResolver.smithyTypesNamespace(input, context.model())
                 );
 
                 writer.write(
@@ -624,7 +625,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                   }""",
                   inputFromDafnyMethodName,
                   inputType,
-                  SmithyNameResolver.getSmithyType(input, inputSymbol),
+                  SmithyNameResolver.getSmithyType(input, inputSymbol, context.model()),
                   writer.consumer(w ->
                     generateRequestDeserializer(
                       context,
@@ -679,7 +680,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                     SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                       output.toShapeId().getNamespace()
                     ),
-                    SmithyNameResolver.smithyTypesNamespace(output)
+                    SmithyNameResolver.smithyTypesNamespace(output, context.model())
                   );
 
                   writer.write(
@@ -689,7 +690,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                     }""",
                     outputFromDafnyMethodName,
                     DafnyNameResolver.getDafnyType(output, outputSymbol),
-                    SmithyNameResolver.getSmithyType(output, outputSymbol),
+                    SmithyNameResolver.getSmithyType(output, outputSymbol, context.model()),
                     writer.consumer(w ->
                       generateResponseDeserializer(
                         context,
@@ -787,7 +788,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                       SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                         input.toShapeId().getNamespace()
                       ),
-                      SmithyNameResolver.smithyTypesNamespace(input)
+                      SmithyNameResolver.smithyTypesNamespace(input, context.model())
                     );
 
                     writer.write(
@@ -797,7 +798,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                       }""",
                       inputFromDafnyMethodName,
                       inputType,
-                      SmithyNameResolver.getSmithyType(input, inputSymbol),
+                      SmithyNameResolver.getSmithyType(input, inputSymbol, context.model()),
                       writer.consumer(w ->
                         generateRequestDeserializer(
                           context,
@@ -854,7 +855,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                         SmithyNameResolver.getGoModuleNameForSmithyNamespace(
                           output.toShapeId().getNamespace()
                         ),
-                        SmithyNameResolver.smithyTypesNamespace(output)
+                        SmithyNameResolver.smithyTypesNamespace(output, context.model())
                       );
 
                       writer.write(
@@ -864,7 +865,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                         }""",
                         outputFromDafnyMethodName,
                         DafnyNameResolver.getDafnyType(output, outputSymbol),
-                        SmithyNameResolver.getSmithyType(output, outputSymbol),
+                        SmithyNameResolver.getSmithyType(output, outputSymbol, context.model()),
                         writer.consumer(w ->
                           generateResponseDeserializer(
                             context,
@@ -913,7 +914,7 @@ public class DafnyLocalServiceTypeConversionProtocol
                     resourceShape.getId().getName(),
                     DafnyNameResolver.dafnyTypesNamespace(resourceShape),
                     resourceShape.getId().getName(),
-                    SmithyNameResolver.smithyTypesNamespace(resourceShape),
+                    SmithyNameResolver.smithyTypesNamespace(resourceShape, context.model()),
                     resourceShape.getId().getName(),
                     extendableResourceWrapperCheck,
                     resourceShape.getId().getName()
@@ -995,7 +996,8 @@ public class DafnyLocalServiceTypeConversionProtocol
         GoCodegenUtils.getType(
           context.symbolProvider().toSymbol(shape),
           shape,
-          true
+          true,
+          context.model()
         );
     }
     writerDelegator.useFileWriter(
@@ -1009,7 +1011,7 @@ public class DafnyLocalServiceTypeConversionProtocol
           SmithyNameResolver.getGoModuleNameForSmithyNamespace(
             shape.toShapeId().getNamespace()
           ),
-          SmithyNameResolver.smithyTypesNamespace(shape)
+          SmithyNameResolver.smithyTypesNamespace(shape, context.model())
         );
         writer.write(
           """
@@ -1190,7 +1192,8 @@ public class DafnyLocalServiceTypeConversionProtocol
             getInputToDafnyMethodName,
             SmithyNameResolver.getSmithyType(
               configShape,
-              context.symbolProvider().toSymbol(configShape)
+              context.symbolProvider().toSymbol(configShape),
+              context.model()
             ),
             DafnyNameResolver.getDafnyType(
               configShape,
@@ -1262,7 +1265,8 @@ public class DafnyLocalServiceTypeConversionProtocol
                 getInputToDafnyMethodName,
                 SmithyNameResolver.getSmithyType(
                   errorShape,
-                  context.symbolProvider().toSymbol(errorShape)
+                  context.symbolProvider().toSymbol(errorShape),
+                  context.model()
                 ),
                 DafnyNameResolver.getDafnyBaseErrorType(errorShape),
                 writer.consumer(w -> {
@@ -1311,10 +1315,10 @@ public class DafnyLocalServiceTypeConversionProtocol
             func OpaqueError_Input_ToDafny(nativeInput $L.OpaqueError)($L.Error) {
             	return $L.Companion_Error_.Create_Opaque_(nativeInput.ErrObject)
             }""",
-            SmithyNameResolver.smithyTypesNamespace(serviceShape),
+            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape),
+            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape)
           );
@@ -1380,7 +1384,8 @@ public class DafnyLocalServiceTypeConversionProtocol
                     context.model().expectShape(error),
                     context
                       .symbolProvider()
-                      .toSymbol(context.model().expectShape(error))
+                      .toSymbol(context.model().expectShape(error)),
+                      context.model()
                   ),
                   SmithyNameResolver.getToDafnyMethodName(
                     serviceShape,
@@ -1391,7 +1396,8 @@ public class DafnyLocalServiceTypeConversionProtocol
                     context.model().expectShape(error),
                     context
                       .symbolProvider()
-                      .toSymbol(context.model().expectShape(error))
+                      .toSymbol(context.model().expectShape(error)),
+                      context.model()
                   )
                 );
               }
@@ -1408,9 +1414,9 @@ public class DafnyLocalServiceTypeConversionProtocol
                 handleDepErrorSerializer(context, w, dependencies);
               }
             }),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape)
+            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
+            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
+            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model())
           );
         }
       );
@@ -1487,7 +1493,7 @@ public class DafnyLocalServiceTypeConversionProtocol
           SmithyNameResolver.getGoModuleNameForSmithyNamespace(
             depShape.toShapeId().getNamespace()
           ),
-          SmithyNameResolver.smithyTypesNamespace(depShape)
+          SmithyNameResolver.smithyTypesNamespace(depShape, context.model())
         );
         w.addImportFromModule(
           SmithyNameResolver.getGoModuleNameForSmithyNamespace(
@@ -1500,7 +1506,7 @@ public class DafnyLocalServiceTypeConversionProtocol
           case $L.$LBaseException:
               return $L.Create_$L_($L.Error_ToDafny(err))
           """,
-          SmithyNameResolver.smithyTypesNamespace(depShape),
+          SmithyNameResolver.smithyTypesNamespace(depShape, context.model()),
           dep.getName(),
           DafnyNameResolver.getDafnyErrorCompanion(serviceShape),
           DafnyNameResolver.dafnyDependentErrorName(depShape),
@@ -1555,7 +1561,7 @@ public class DafnyLocalServiceTypeConversionProtocol
             SmithyNameResolver.getGoModuleNameForSmithyNamespace(
               configShape.toShapeId().getNamespace()
             ),
-            SmithyNameResolver.smithyTypesNamespace(configShape)
+            SmithyNameResolver.smithyTypesNamespace(configShape, context.model())
           );
           writer.write(
             """
@@ -1569,7 +1575,8 @@ public class DafnyLocalServiceTypeConversionProtocol
             ),
             SmithyNameResolver.getSmithyType(
               configShape,
-              context.symbolProvider().toSymbol(configShape)
+              context.symbolProvider().toSymbol(configShape),
+              context.model()
             ),
             writer.consumer(w -> {
               final String output = configShape.accept(
@@ -1638,7 +1645,8 @@ public class DafnyLocalServiceTypeConversionProtocol
                 DafnyNameResolver.getDafnyBaseErrorType(errorShape),
                 SmithyNameResolver.getSmithyType(
                   errorShape,
-                  context.symbolProvider().toSymbol(errorShape)
+                  context.symbolProvider().toSymbol(errorShape),
+                  context.model()
                 ),
                 writer.consumer(w -> {
                   final String output = errorShape.accept(
@@ -1709,12 +1717,12 @@ public class DafnyLocalServiceTypeConversionProtocol
                 }
             }""",
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape),
+            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
+            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
             DafnyNameResolver.dafnyTypesNamespace(serviceShape),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape),
-            SmithyNameResolver.smithyTypesNamespace(serviceShape)
+            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model()),
+            SmithyNameResolver.smithyTypesNamespace(serviceShape, context.model())
           );
         }
       );
@@ -1859,8 +1867,22 @@ public class DafnyLocalServiceTypeConversionProtocol
             GoCodegenUtils.getType(
               context.symbolProvider().toSymbol(visitingShape),
               visitingShape,
-              true
+              true,
+              context.model()
             );
+          if (
+            model
+              .shapes(OperationShape.class)
+              .anyMatch(op ->
+                op
+                  .getInput()
+                  .filter(visitingShape.getId()::equals)
+                  .isPresent() ||
+                op.getOutput().filter(visitingShape.getId()::equals).isPresent()
+              )
+          ) {
+            System.out.println(visitingShape);
+          }
           Boolean isPointable = context
             .symbolProvider()
             .toSymbol(visitingMemberShape)
@@ -1892,7 +1914,8 @@ public class DafnyLocalServiceTypeConversionProtocol
                   GoCodegenUtils.getType(
                     context.symbolProvider().toSymbol(resourceOrService),
                     resourceOrService,
-                    true
+                    true,
+                    context.model()
                   );
               } else {
                 outputType =
@@ -1963,7 +1986,8 @@ public class DafnyLocalServiceTypeConversionProtocol
           var outputType = GoCodegenUtils.getType(
             context.symbolProvider().toSymbol(visitingShape),
             visitingShape,
-            true
+            true,
+            context.model()
           );
           Boolean isPointable = context
             .symbolProvider()

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/nameresolver/SmithyNameResolver.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/nameresolver/SmithyNameResolver.java
@@ -86,11 +86,11 @@ public class SmithyNameResolver {
       return isTopLevelShape ? sdkName : sdkName.concat("types");
     }
     return shape
-    .toShapeId()
-    .getNamespace()
-    .replace(DOT, BLANK)
-    .toLowerCase()
-    .concat("smithygeneratedtypes");
+      .toShapeId()
+      .getNamespace()
+      .replace(DOT, BLANK)
+      .toLowerCase()
+      .concat("smithygeneratedtypes");
   }
 
   public static String getGoModuleNameForSdkNamespace(
@@ -109,7 +109,11 @@ public class SmithyNameResolver {
     return serviceTrait.getSdkId().toLowerCase();
   }
 
-  public static String getSmithyType(final Shape shape, final Symbol symbol, final Model model) {
+  public static String getSmithyType(
+    final Shape shape,
+    final Symbol symbol,
+    final Model model
+  ) {
     if (
       symbol.getNamespace().contains("smithy.") ||
       symbol.getNamespace().equals("smithyapitypes") ||

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/nameresolver/SmithyNameResolver.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/nameresolver/SmithyNameResolver.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import software.amazon.smithy.aws.traits.ServiceTrait;
-import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/nameresolver/SmithyNameResolver.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/nameresolver/SmithyNameResolver.java
@@ -64,20 +64,6 @@ public class SmithyNameResolver {
       .concat("smithygenerated");
   }
 
-  public static String smithyTypesNamespace(final Shape shape) {
-    if (isShapeFromAWSSDK(shape)) {
-      throw new CodegenException(
-        "Unsupported function used for namespace resolution of AWS SDK shapes. Use smithyTypesNamespace(shape, model) instead."
-      );
-    }
-    return shape
-      .toShapeId()
-      .getNamespace()
-      .replace(DOT, BLANK)
-      .toLowerCase()
-      .concat("smithygeneratedtypes");
-  }
-
   public static String smithyTypesNamespace(
     final Shape shape,
     final Model model
@@ -99,7 +85,12 @@ public class SmithyNameResolver {
         );
       return isTopLevelShape ? sdkName : sdkName.concat("types");
     }
-    return smithyTypesNamespace(shape);
+    return shape
+    .toShapeId()
+    .getNamespace()
+    .replace(DOT, BLANK)
+    .toLowerCase()
+    .concat("smithygeneratedtypes");
   }
 
   public static String getGoModuleNameForSdkNamespace(
@@ -118,7 +109,7 @@ public class SmithyNameResolver {
     return serviceTrait.getSdkId().toLowerCase();
   }
 
-  public static String getSmithyType(final Shape shape, final Symbol symbol) {
+  public static String getSmithyType(final Shape shape, final Symbol symbol, final Model model) {
     if (
       symbol.getNamespace().contains("smithy.") ||
       symbol.getNamespace().equals("smithyapitypes") ||
@@ -128,7 +119,7 @@ public class SmithyNameResolver {
     }
     if (shape.isResourceShape()) {
       return SmithyNameResolver
-        .smithyTypesNamespace(shape)
+        .smithyTypesNamespace(shape, model)
         .concat(DOT)
         .concat("I")
         .concat(shape.toShapeId().getName());
@@ -138,14 +129,14 @@ public class SmithyNameResolver {
       return "time".concat(DOT).concat(symbol.getName());
     }
     return SmithyNameResolver
-      .smithyTypesNamespace(shape)
+      .smithyTypesNamespace(shape, model)
       .concat(DOT)
       .concat(symbol.getName());
   }
 
-  public static String getSmithyType(final Shape shape) {
+  public static String getSmithyType(final Shape shape, Model model) {
     return SmithyNameResolver
-      .smithyTypesNamespace(shape)
+      .smithyTypesNamespace(shape, model)
       .concat(DOT)
       .concat(shape.toShapeId().getName());
   }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/nameresolver/SmithyNameResolver.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/nameresolver/SmithyNameResolver.java
@@ -9,10 +9,10 @@ import java.util.Map;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.Model;
 
 public class SmithyNameResolver {
 
@@ -70,13 +70,18 @@ public class SmithyNameResolver {
         "Unsupported function used for namespace resolution of AWS SDK shapes. Use smithyTypesNamespace(shape, model) instead."
       );
     }
-    return shape.toShapeId().getNamespace()
+    return shape
+      .toShapeId()
+      .getNamespace()
       .replace(DOT, BLANK)
       .toLowerCase()
       .concat("smithygeneratedtypes");
   }
 
-  public static String smithyTypesNamespace(final Shape shape, final Model model) {
+  public static String smithyTypesNamespace(
+    final Shape shape,
+    final Model model
+  ) {
     final String shapeNameSpace = shape.toShapeId().getNamespace();
     if (isShapeFromAWSSDK(shape)) {
       final String sdkName = shapeNameSpace
@@ -86,9 +91,12 @@ public class SmithyNameResolver {
         return sdkName;
       }
       // Boolean to hold if shape is input or output of any operation
-      boolean isTopLevelShape = model.shapes(OperationShape.class)
-      .anyMatch( op -> op.getInput().filter(shape.getId()::equals).isPresent() ||
-                        op.getOutput().filter(shape.getId()::equals).isPresent());
+      boolean isTopLevelShape = model
+        .shapes(OperationShape.class)
+        .anyMatch(op ->
+          op.getInput().filter(shape.getId()::equals).isPresent() ||
+          op.getOutput().filter(shape.getId()::equals).isPresent()
+        );
       return isTopLevelShape ? sdkName : sdkName.concat("types");
     }
     return smithyTypesNamespace(shape);

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
@@ -235,7 +235,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
         SmithyNameResolver.getGoModuleNameForSmithyNamespace(
           resourceOrService.toShapeId().getNamespace()
         ),
-        SmithyNameResolver.smithyTypesNamespace(resourceShape)
+        SmithyNameResolver.smithyTypesNamespace(resourceShape, context.model())
       );
       namespace =
         SmithyNameResolver.shapeNamespace(resourceOrService).concat(".");
@@ -253,7 +253,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
         }
         return %s
     }()""".formatted(
-        SmithyNameResolver.smithyTypesNamespace(resourceShape),
+        SmithyNameResolver.smithyTypesNamespace(resourceShape, context.model()),
         resourceShape.getId().getName(),
         dataSource,
         "%s_FromDafny(%s.(%s.I%s))".formatted(
@@ -285,7 +285,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
           shape.getId().getNamespace()
         ),
         "types",
-        SmithyNameResolver.smithyTypesNamespace(shape)
+        SmithyNameResolver.smithyTypesNamespace(shape, context.model())
       );
     }
     writer.addImportFromModule(DAFNY_RUNTIME_GO_LIBRARY_MODULE, "dafny");
@@ -315,7 +315,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
           shape.getId().getNamespace()
         ),
         "types",
-        SmithyNameResolver.smithyTypesNamespace(shape)
+        SmithyNameResolver.smithyTypesNamespace(shape, context.model())
       );
     }
     if (shape.hasTrait(ReferenceTrait.class)) {
@@ -350,7 +350,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
       "return %1$s%2$s{".formatted(
           referenceType,
           SmithyNameResolver
-            .smithyTypesNamespace(shape)
+            .smithyTypesNamespace(shape, context.model())
             .concat(".")
             .concat(shape.getId().getName())
         )
@@ -430,7 +430,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
           shape.getId().getNamespace()
         ),
         "types",
-        SmithyNameResolver.smithyTypesNamespace(shape)
+        SmithyNameResolver.smithyTypesNamespace(shape, context.model())
       );
     }
     final StringBuilder typeConversionMethodBuilder = new StringBuilder();
@@ -459,7 +459,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
       	}
       	fieldValue = append(fieldValue, %s)}
       	""".formatted(
-          GoCodegenUtils.getType(symbol, shape, true),
+          GoCodegenUtils.getType(symbol, shape, true, context.model()),
           dataSource,
           ShapeVisitorHelper.toNativeShapeVisitorWriter(
             memberShape,
@@ -485,7 +485,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
           shape.getId().getNamespace()
         ),
         "types",
-        SmithyNameResolver.smithyTypesNamespace(shape)
+        SmithyNameResolver.smithyTypesNamespace(shape, context.model())
       );
     }
     final StringBuilder typeConversionMethodBuilder = new StringBuilder();
@@ -496,7 +496,8 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
       .expectShape(valueMemberShape.getTarget());
     final var type = SmithyNameResolver.getSmithyType(
       valueTargetShape,
-      context.symbolProvider().toSymbol(valueTargetShape)
+      context.symbolProvider().toSymbol(valueTargetShape), 
+      context.model()
     );
     final String valueDataSource = "(*val.(dafny.Tuple).IndexInt(1))";
     typeConversionMethodBuilder.append(
@@ -550,7 +551,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
           shape.getId().getNamespace()
         ),
         "types",
-        SmithyNameResolver.smithyTypesNamespace(shape)
+        SmithyNameResolver.smithyTypesNamespace(shape, context.model())
       );
     }
     if (this.isOptional) {
@@ -584,7 +585,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
           shape.getId().getNamespace()
         ),
         "types",
-        SmithyNameResolver.smithyTypesNamespace(shape)
+        SmithyNameResolver.smithyTypesNamespace(shape, context.model())
       );
     }
     if (shape.hasTrait(EnumTrait.class)) {
@@ -622,9 +623,9 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
 
         	return &u.Values()[index]
         }()""".formatted(
-            SmithyNameResolver.smithyTypesNamespace(shape),
+            SmithyNameResolver.smithyTypesNamespace(shape, context.model()),
             context.symbolProvider().toSymbol(shape).getName(),
-            SmithyNameResolver.smithyTypesNamespace(shape),
+            SmithyNameResolver.smithyTypesNamespace(shape, context.model()),
             context.symbolProvider().toSymbol(shape).getName(),
             dataSource,
             dataSource,
@@ -659,9 +660,9 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
 
         	return u.Values()[index]
         }()""".formatted(
-            SmithyNameResolver.smithyTypesNamespace(shape),
+            SmithyNameResolver.smithyTypesNamespace(shape, context.model()),
             context.symbolProvider().toSymbol(shape).getName(),
-            SmithyNameResolver.smithyTypesNamespace(shape),
+            SmithyNameResolver.smithyTypesNamespace(shape, context.model()),
             context.symbolProvider().toSymbol(shape).getName(),
             dataSource,
             DafnyNameResolver.getDafnyType(
@@ -738,7 +739,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
           shape.getId().getNamespace()
         ),
         "types",
-        SmithyNameResolver.smithyTypesNamespace(shape)
+        SmithyNameResolver.smithyTypesNamespace(shape, context.model())
       );
     }
     if (isOptional) {
@@ -771,7 +772,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
           shape.getId().getNamespace()
         ),
         "types",
-        SmithyNameResolver.smithyTypesNamespace(shape)
+        SmithyNameResolver.smithyTypesNamespace(shape, context.model())
       );
     }
     if (isOptional) {
@@ -805,7 +806,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
           shape.getId().getNamespace()
         ),
         "types",
-        SmithyNameResolver.smithyTypesNamespace(shape)
+        SmithyNameResolver.smithyTypesNamespace(shape, context.model())
       );
     }
     writer.addUseImports(SmithyGoDependency.MATH);
@@ -850,7 +851,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
           shape.getId().getNamespace()
         ),
         "types",
-        SmithyNameResolver.smithyTypesNamespace(shape)
+        SmithyNameResolver.smithyTypesNamespace(shape, context.model())
       );
     }
 
@@ -923,7 +924,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
         """.formatted(
             isMemberCheck,
             wrappedDataSource,
-            SmithyNameResolver.smithyTypesNamespace(shape),
+            SmithyNameResolver.smithyTypesNamespace(shape, context.model()),
             memberName,
             pointerForPointableShape,
             ShapeVisitorHelper.toNativeShapeVisitorWriter(

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/DafnyToSmithyShapeVisitor.java
@@ -496,7 +496,7 @@ public class DafnyToSmithyShapeVisitor extends ShapeVisitor.Default<String> {
       .expectShape(valueMemberShape.getTarget());
     final var type = SmithyNameResolver.getSmithyType(
       valueTargetShape,
-      context.symbolProvider().toSymbol(valueTargetShape), 
+      context.symbolProvider().toSymbol(valueTargetShape),
       context.model()
     );
     final String valueDataSource = "(*val.(dafny.Tuple).IndexInt(1))";

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/SmithyToDafnyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/SmithyToDafnyShapeVisitor.java
@@ -752,14 +752,14 @@ public class SmithyToDafnyShapeVisitor extends ShapeVisitor.Default<String> {
             var inputToConversion = %s
             return %s
         """.formatted(
-            SmithyNameResolver.smithyTypesNamespace(shape),
+            SmithyNameResolver.smithyTypesNamespace(shape, context.model()),
             context.symbolProvider().toMemberName(member),
             ShapeVisitorHelper.toDafnyShapeVisitorWriter(
               member,
               context,
               dataSource +
               ".(*" +
-              SmithyNameResolver.smithyTypesNamespace(shape) +
+              SmithyNameResolver.smithyTypesNamespace(shape, context.model()) +
               "." +
               context.symbolProvider().toMemberName(member) +
               ").Value",

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/utils/GoCodegenUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/utils/GoCodegenUtils.java
@@ -55,19 +55,21 @@ public class GoCodegenUtils {
   public static String getType(
     final Symbol symbol,
     final Shape shape,
-    final Boolean includeNamespace
+    final Boolean includeNamespace,
+    final Model model
   ) {
     if (
       symbol.getProperty(SymbolUtils.GO_ELEMENT_TYPE, Symbol.class).isEmpty()
     ) {
       return includeNamespace
-        ? SmithyNameResolver.getSmithyType(shape, symbol)
+        ? SmithyNameResolver.getSmithyType(shape, symbol, model)
         : symbol.getName();
     }
     var type = getType(
       symbol.expectProperty(SymbolUtils.GO_ELEMENT_TYPE, Symbol.class),
       shape,
-      includeNamespace
+      includeNamespace,
+      model
     );
     if (symbol.getProperty(SymbolUtils.GO_MAP).isPresent()) {
       type = "map[string]" + type;
@@ -179,7 +181,8 @@ public class GoCodegenUtils {
       return (
         SmithyNameResolver.getSmithyType(
           curShape,
-          symbolProvider.toSymbol(curShape)
+          symbolProvider.toSymbol(curShape),
+          model
         )
       );
     } else {

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/utils/GoCodegenUtils.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/utils/GoCodegenUtils.java
@@ -61,7 +61,11 @@ public class GoCodegenUtils {
       symbol.getProperty(SymbolUtils.GO_ELEMENT_TYPE, Symbol.class).isEmpty()
     ) {
       return includeNamespace
-        ? SmithyNameResolver.getSmithyType(symbol.expectProperty(SymbolUtils.SHAPE, Shape.class), symbol, model)
+        ? SmithyNameResolver.getSmithyType(
+          symbol.expectProperty(SymbolUtils.SHAPE, Shape.class),
+          symbol,
+          model
+        )
         : symbol.getName();
     }
     var type = getType(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Short description:
- return `<serviceName>` if shape in aws sdk models is inside input and output of operation
- add new parameter `model` to the smithyTypeNamespace function 

Long description:
All the shape which is input and output of operation is inside `github.com/aws/aws-sdk-go-v2/service/dynamodb` and all other inside those are in `github.com/aws/aws-sdk-go-v2/service/dynamodb/types`. However, in current `main-1.x`, smithyNameResolver return `<serviceName>types` (example: `dynamodbtypes` and `kmstypes`) in every scenario which is wrong. Updates from this PR loops in the model's operation shape and if the shape belong to input/output of the operation shape and uses either <serviceName>types or <serviceName> module for the shapes.

Note: We alias service/types module to  <serviceName>types. For example: `github.com/aws/aws-sdk-go-v2/service/dynamodb/types` is aliased into `dynamodbtypes` and `github.com/aws/aws-sdk-go-v2/service/kms/types` into `kmstypes` so that there won't be name collision.

Test PR in MPL after bumping smithy-dafny to this branch: https://github.com/aws/aws-cryptographic-material-providers-library/pull/1243
(No polymorph changes expected in MPL because none of the model in MPL depends on shape that are inside input and output of operation shape.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
