### PR TITLE
fix(go): current shape namespace to hold targetShape's namespace

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/ValidationGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/codegen/ValidationGenerator.java
@@ -507,7 +507,7 @@ public class ValidationGenerator {
           context.settings().getService(model)
         );
         final var currShapeNamespace = SmithyNameResolver.shapeNamespace(
-          memberShape
+          model.expectShape(memberShape.getTarget())
         );
         final Boolean isExternalShape = !currServiceShapeNamespace.equals(
           currShapeNamespace
@@ -604,7 +604,7 @@ public class ValidationGenerator {
           context.settings().getService(model)
         );
         final var currShapeNamespace = SmithyNameResolver.shapeNamespace(
-          memberShape
+          model.expectShape(memberShape.getTarget())
         );
         final Boolean isExternalShape = !currServiceShapeNamespace.equals(
           currShapeNamespace
@@ -676,7 +676,7 @@ public class ValidationGenerator {
         context.settings().getService(model)
       );
     final var currShapeNamespace = SmithyNameResolver.smithyTypesNamespace(
-      memberShape
+      model.expectShape(memberShape.getTarget())
     );
     if (!funcInput.isEmpty()) {
       final Boolean isExternalShape =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This changed `currShapeNamespace` variable is used to see if the shape is an external shape but if we put memberShape namespace this shapes will always be internal shapes. The PR fixes it by using targetShape instead of memberShape. 

Example:
```
namespace aws.cryptography.dbEncryptionSdk.dynamoDb
use com.amazonaws.dynamodb#AttributeMap
union GetEncryptedDataKeyDescriptionUnion {
  header: Blob,
  item: AttributeMap,
}
```
item's memberShape namespace is `aws.cryptography.dbEncryptionSdk.dynamoDb`
But it's targetShape namespace would be `com.amazonaws.dynamodb`

No changes expected in MPL: https://github.com/aws/aws-cryptographic-material-providers-library/pull/1251


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
