### PR TITLE
fix: Dafny standard libraries .doo building fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,5 @@
 	url = https://github.com/smithy-lang/smithy-rs.git
 [submodule "TestModels/dafny-dependencies/dafny"]
 	path = TestModels/dafny-dependencies/dafny
-	url = git@github.com:dafny-lang/dafny.git
+	url = https://github.com/dafny-lang/dafny.git
 	branch = actions-and-streaming-stdlibs

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -248,7 +248,7 @@ transpile_test:
 		$(DAFNY_OPTIONS) \
 		$(DAFNY_OTHER_FILES) \
 		$(if $(strip $(STD_LIBRARY)) , --library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy, ) \
-		$(if $(USE_DAFNY_STANDARD_LIBRARIES) , --library:$(PROJECT_ROOT)/$(STD_LIBRARY)/bin/DafnyStandardLibraries-smithy-dafny-subset.doo, ) \
+		$(if $(USE_DAFNY_STANDARD_LIBRARIES) , $(if $(strip $(STD_LIBRARY)) , --library:$(PROJECT_ROOT)/$(STD_LIBRARY)/bin/DafnyStandardLibraries-smithy-dafny-subset.doo, ), ) \
 		$(TRANSLATION_RECORD) \
 		$(SOURCE_TRANSLATION_RECORD) \
 		$(TRANSPILE_MODULE_NAME) \

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -209,7 +209,7 @@ transpile_implementation:
 		$(DAFNY_OTHER_FILES) \
 		$(TRANSPILE_MODULE_NAME) \
 		$(if $(strip $(STD_LIBRARY)) , --library:$(PROJECT_ROOT)/$(STD_LIBRARY)/src/Index.dfy, ) \
-		$(if $(USE_DAFNY_STANDARD_LIBRARIES) , --library:$(PROJECT_ROOT)/$(STD_LIBRARY)/bin/DafnyStandardLibraries-smithy-dafny-subset.doo, ) \
+		$(if $(USE_DAFNY_STANDARD_LIBRARIES) , $(if $(strip $(STD_LIBRARY)) , --library:$(PROJECT_ROOT)/$(STD_LIBRARY)/bin/DafnyStandardLibraries-smithy-dafny-subset.doo, ), ) \
 		$(TRANSLATION_RECORD) \
 		$(TRANSPILE_DEPENDENCIES)
 

--- a/TestModels/dafny-dependencies/StandardLibrary/Makefile
+++ b/TestModels/dafny-dependencies/StandardLibrary/Makefile
@@ -107,7 +107,7 @@ transpile_implementation:
 		--unicode-char:false \
 		--function-syntax:3 \
 		--output $(OUT) \
-		$(if $(USE_DAFNY_STANDARD_LIBRARIES), bin/DafnyStandardLibraries-smithy-dafny-subset.doo, ) \
+		$(if $(USE_DAFNY_STANDARD_LIBRARIES), ./bin/DafnyStandardLibraries-smithy-dafny-subset.doo, ) \
 		$(DAFNY_OPTIONS) \
 		$(DAFNY_OTHER_FILES) \
 		$(TRANSPILE_MODULE_NAME)

--- a/TestModels/dafny-dependencies/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/extern/streams.py
+++ b/TestModels/dafny-dependencies/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/extern/streams.py
@@ -17,8 +17,10 @@ class DafnyByteStreamAsByteStream(ByteStream):
     self.dafny_byte_stream = dafny_byte_stream
 
   def read(self, size: int = -1) -> bytes:
-    # TODO: assert size is -1, buffer, 
-    # or define a more specialized Action<int, bytes> type for streams.
+    # We could define a more specialized Action<int, bytes> type for streams
+    # if we wanted to support this level of control in all languages.
+    if size != -1:
+      raise ValueError(f"A read size other than -1 is not supported: {size}")
     next = self.dafny_byte_stream.Next()
     while next.is_Some and len(next.value) == 0:
       next = self.dafny_byte_stream.Next()


### PR DESCRIPTION
Fixes necessary to use this in the MPL as well: https://github.com/aws/aws-cryptographic-material-providers-library/pull/1321

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
