### PR TITLE
fix(java): empty nullable lists convert to optional empty lists

### DIFF
--- a/TestModels/Aggregate/runtimes/java/build.gradle.kts
+++ b/TestModels/Aggregate/runtimes/java/build.gradle.kts
@@ -1,0 +1,73 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
+
+tasks.wrapper {
+    gradleVersion = "7.6"
+}
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+var dafnyVersion = props.getProperty("dafnyVersion")
+
+group = "simple"
+version = "1.0-SNAPSHOT"
+description = "Constraints"
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(8))
+    sourceSets["main"].java {
+        srcDir("src/main/java")
+        srcDir("src/main/dafny-generated")
+        srcDir("src/main/smithy-generated")
+    }
+    sourceSets["test"].java {
+        srcDir("src/test/java")
+        srcDir("src/test/dafny-generated")
+        srcDir("src/test/smithy-generated")
+    }
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+dependencies {
+    implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
+    implementation("software.amazon.smithy.dafny:conversion:0.1.1")
+    implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
+    testImplementation("org.testng:testng:7.5")
+}
+
+publishing {
+    publications.create<MavenPublication>("maven") {
+        groupId = "simple"
+        artifactId = "Constraints"
+        from(components["java"])
+    }
+    repositories { mavenLocal() }
+}
+
+tasks.withType<JavaCompile>() {
+    options.encoding = "UTF-8"
+}
+
+tasks {
+    register("runTests", JavaExec::class.java) {
+        mainClass.set("TestsFromDafny")
+        classpath = sourceSets["test"].runtimeClasspath
+    }
+}
+
+tasks.named<Test>("test") {
+    useTestNG()
+}

--- a/TestModels/Aggregate/runtimes/java/src/main/java/simple/aggregate/internaldafny/__default.java
+++ b/TestModels/Aggregate/runtimes/java/src/main/java/simple/aggregate/internaldafny/__default.java
@@ -1,0 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package simple.aggregate.internaldafny;
+
+public class __default extends _ExternBase___default {}

--- a/TestModels/Aggregate/runtimes/java/src/main/java/simple/aggregate/internaldafny/types/__default.java
+++ b/TestModels/Aggregate/runtimes/java/src/main/java/simple/aggregate/internaldafny/types/__default.java
@@ -1,0 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package simple.aggregate.internaldafny.types;
+
+public class __default extends _ExternBase___default {}

--- a/TestModels/Aggregate/runtimes/java/src/test/java/simple/aggregate/internaldafny/wrapped/__default.java
+++ b/TestModels/Aggregate/runtimes/java/src/test/java/simple/aggregate/internaldafny/wrapped/__default.java
@@ -1,0 +1,33 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package simple.aggregate.internaldafny.wrapped;
+
+import Wrappers_Compile.Result;
+import simple.aggregate.SimpleAggregate;
+import simple.aggregate.ToNative;
+import simple.aggregate.internaldafny.types.Error;
+import simple.aggregate.internaldafny.types.ISimpleAggregateClient;
+import simple.aggregate.internaldafny.types.SimpleAggregateConfig;
+import simple.aggregate.wrapped.TestSimpleAggregate;
+
+public class __default extends _ExternBase___default {
+
+  public static Result<
+    ISimpleAggregateClient,
+    Error
+  > WrappedSimpleAggregate(SimpleAggregateConfig config) {
+    simple.aggregate.model.SimpleAggregateConfig wrappedConfig =
+      ToNative.SimpleAggregateConfig(config);
+    simple.aggregate.SimpleAggregate impl = SimpleAggregate
+      .builder()
+      .SimpleAggregateConfig(wrappedConfig)
+      .build();
+    TestSimpleAggregate wrappedClient = TestSimpleAggregate
+      .builder()
+      .impl(impl)
+      .build();
+    return simple.aggregate.internaldafny.__default.CreateSuccessOfClient(
+      wrappedClient
+    );
+  }
+}

--- a/TestModels/Aggregate/test/SimpleAggregateImplTest.dfy
+++ b/TestModels/Aggregate/test/SimpleAggregateImplTest.dfy
@@ -7,9 +7,19 @@ module SimpleAggregateImplTest {
     import opened SimpleAggregateTypes
     import opened Wrappers
     method{:test} GetAggregate(){
-        var client :- expect SimpleAggregate.SimpleAggregate();
-        TestGetAggregate(client);
-        TestGetAggregateKnownValue(client);
+      var client :- expect SimpleAggregate.SimpleAggregate();
+      TestAggregate(client);
+    }
+
+    method TestAggregate(client: ISimpleAggregateClient)
+      requires client.ValidState()
+      modifies client.Modifies
+      ensures client.ValidState()
+    {
+      TestGetAggregate(client);
+      TestGetAggregateKnownValue(client);
+      TestEmptyAggregate(client);
+      TestNoneAggregate(client);
     }
 
     method TestGetAggregate(client: ISimpleAggregateClient)
@@ -37,7 +47,7 @@ module SimpleAggregateImplTest {
     }
 
     method TestGetAggregateKnownValue(client: ISimpleAggregateClient)
-    requires client.ValidState()
+      requires client.ValidState()
       modifies client.Modifies
       ensures client.ValidState()
       {
@@ -57,6 +67,52 @@ module SimpleAggregateImplTest {
         expect ret.simpleStringMap.UnwrapOr(map[]) == simpleStringMap;
         expect ret.simpleIntegerMap.UnwrapOr(map[]) == simpleIntegerMap;
         expect ret.nestedStructure.UnwrapOr(NestedStructure(stringStructure := Some(StringStructure(value := Some(""))))) == nestedStructure;
+        print ret;
+    }
+
+    method TestEmptyAggregate(client: ISimpleAggregateClient)
+      requires client.ValidState()
+      modifies client.Modifies
+      ensures client.ValidState()
+      {
+        var stringList := [];
+        var simpleStringMap := map[];
+        var structureList :=[];
+        var simpleIntegerMap := map[];
+        var nestedStructure := NestedStructure(stringStructure := Some(StringStructure(value := Some("Nested"))));
+        var ret :- expect client.GetAggregate(GetAggregateInput(simpleIntegerMap := Some(simpleIntegerMap),
+                                                                simpleStringMap := Some(simpleStringMap),
+                                                                simpleStringList := Some(stringList),
+                                                                structureList := Some(structureList),
+                                                                nestedStructure := Some(nestedStructure))
+                                                                );
+        expect ret.simpleStringList == Some(stringList);
+        expect ret.structureList == Some(structureList);
+        expect ret.simpleStringMap == Some(simpleStringMap);
+        expect ret.simpleIntegerMap == Some(simpleIntegerMap);
+        expect ret.nestedStructure.UnwrapOr(NestedStructure(stringStructure := Some(StringStructure(value := Some(""))))) == nestedStructure;
+        print ret;
+    }
+
+    method TestNoneAggregate(client: ISimpleAggregateClient)
+      requires client.ValidState()
+      modifies client.Modifies
+      ensures client.ValidState()
+      {
+
+        var ret :- expect client.GetAggregate(
+          GetAggregateInput(
+            simpleIntegerMap := None,
+            simpleStringMap := None,
+            simpleStringList := None,
+            structureList := None,
+            nestedStructure := None)
+          );
+        expect ret.simpleStringList == None;
+        expect ret.structureList == None;
+        expect ret.simpleStringMap == None;
+        expect ret.simpleIntegerMap == None;
+        expect ret.nestedStructure == None;
         print ret;
     }
 }

--- a/TestModels/Aggregate/test/WrappedSimpleAggregateImplTest.dfy
+++ b/TestModels/Aggregate/test/WrappedSimpleAggregateImplTest.dfy
@@ -9,7 +9,6 @@ module WrappedSimpleTypesStringTest {
     import opened Wrappers
     method{:test} GetAggregate() {
         var client :- expect WrappedSimpleAggregateService.WrappedSimpleAggregate();
-        SimpleAggregateImplTest.TestGetAggregate(client);
-        SimpleAggregateImplTest.TestGetAggregateKnownValue(client);
+        SimpleAggregateImplTest.TestAggregate(client);
     }
 }

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/ToDafny.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithyjava/generator/ToDafny.java
@@ -263,7 +263,10 @@ public abstract class ToDafny extends Generator {
     );
     CodeBlock isSetCheck = isNullCheck;
     Shape targetShape = subject.model.expectShape(memberShape.getTarget());
-    if (Constants.LIST_MAP_SET_SHAPE_TYPES.contains(targetShape.getType())) {
+    if (
+      Constants.LIST_MAP_SET_SHAPE_TYPES.contains(targetShape.getType())
+      && AwsSdkNameResolverHelpers.isInAwsSdkNamespace(memberShape.getTarget())
+    ) {
       isSetCheck = CodeBlock.of("($L && $L.size() > 0)", isNullCheck, inputVar);
     }
     CodeBlock typeDescriptor = subject.dafnyNameResolver.typeDescriptor(


### PR DESCRIPTION
`null` and `.isPresent()` of empty are not the same.

The AWS SKD has a specific way it handles these cases, and we are not adjusting that.

This converts java `null` => `None`, and `[]` => `Some([])`.

This means that for smithy-dafny
Java <=> Dafny conversions are lossless.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
