### PR TITLE
chore: add polymorph_net as an alias for polymorph_dotnet

### DIFF
--- a/.github/workflows/test_models_rust_tests.yml
+++ b/.github/workflows/test_models_rust_tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: "1.82.0"
+          toolchain: "1.88.0"
           rustflags: ""
           components: rustfmt
 

--- a/SmithyDafnyMakefile.mk
+++ b/SmithyDafnyMakefile.mk
@@ -392,6 +392,9 @@ _polymorph_dafny: _polymorph
 dafny: polymorph_dafny verify
 
 # Generates dotnet code for all namespaces in this project
+.PHONY: polymorph_net
+polymorph_net: polymorph_dotnet
+
 .PHONY: polymorph_dotnet
 polymorph_dotnet: POLYMORPH_LANGUAGE_TARGET=dotnet
 polymorph_dotnet: _polymorph_dependencies


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In every other context, we say `_net` let's make polymorph the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
