### PR TITLE
fix: Nightly build

### DIFF
--- a/.github/workflows/test_models_rust_tests.yml
+++ b/.github/workflows/test_models_rust_tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: "1.82.0"
+          toolchain: "1.85.0"
           rustflags: ""
           components: rustfmt
 


### PR DESCRIPTION
*Description of changes:*

Newer versions of the AWS SDK require a newer version of the Rust toolchain.

Dry run of nightly: https://github.com/smithy-lang/smithy-dafny/actions/runs/16130316330

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
