### PR TITLE
fix: smithy-python `OpaqueWithText`

### DIFF
--- a/.github/workflows/test_models_dafny_verification.yml
+++ b/.github/workflows/test_models_dafny_verification.yml
@@ -47,6 +47,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup .NET Core SDK 6.0
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1.7.0
         with:

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithypython/localservice/DafnyPythonLocalServiceProtocolGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithypython/localservice/DafnyPythonLocalServiceProtocolGenerator.java
@@ -450,6 +450,7 @@ public abstract class DafnyPythonLocalServiceProtocolGenerator
         );
         writer.addImport(".errors", "ServiceError");
         writer.addImport(".errors", "OpaqueError");
+        writer.addImport(".errors", "OpaqueWithTextError");
         writer.addImport(".errors", "CollectionOfErrors");
         writer.addStdlibImport("_dafny");
         writer.openBlock(
@@ -461,7 +462,7 @@ public abstract class DafnyPythonLocalServiceProtocolGenerator
               if error.is_Opaque:
                   return OpaqueError(obj=error.obj)
               elif error.is_OpaqueWithText:
-                  return OpaqueErrorWithText(obj=error.obj, obj_message=error.objMessage)
+                  return OpaqueWithTextError(obj=error.obj, obj_message=_dafny.string_of(error.objMessage))
               elif error.is_CollectionOfErrors:
                   return CollectionOfErrors(
                       message=_dafny.string_of(error.message),
@@ -679,7 +680,13 @@ public abstract class DafnyPythonLocalServiceProtocolGenerator
         writer.write(
           """
           elif error.is_$L:
-              return $L(message=_dafny.string_of(error.$L.message))""",
+              if hasattr(error.$L, "objMessage"):
+                  return $L(message=_dafny.string_of(error.$L.objMessage))
+              else:
+                  return $L(message=_dafny.string_of(error.$L.message))""",
+          code,
+          code,
+          code,
           code,
           code,
           code

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithypython/localservice/DafnyPythonLocalServiceProtocolGenerator.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithypython/localservice/DafnyPythonLocalServiceProtocolGenerator.java
@@ -682,8 +682,13 @@ public abstract class DafnyPythonLocalServiceProtocolGenerator
           elif error.is_$L:
               if hasattr(error.$L, "objMessage"):
                   return $L(message=_dafny.string_of(error.$L.objMessage))
+              elif hasattr(error.$L, "Message"):
+                  return $L(message=_dafny.string_of(error.$L.Message))
               else:
                   return $L(message=_dafny.string_of(error.$L.message))""",
+          code,
+          code,
+          code,
           code,
           code,
           code,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Nested errors for SDK dependencies properly handle the `OpaqueWithText`
- see MPL PR for codegen diff and tests
https://github.com/aws/aws-cryptographic-material-providers-library/pull/1656

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
