### PR TITLE
refactor(go): Use dafny.SeqOfBytes for to dafny byte conversion

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/SmithyToDafnyShapeVisitor.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithygo/localservice/shapevisitor/SmithyToDafnyShapeVisitor.java
@@ -224,20 +224,16 @@ public class SmithyToDafnyShapeVisitor extends ShapeVisitor.Default<String> {
       someWrapIfRequired = "Wrappers.Companion_Option_.Create_Some_(%s)";
       returnType = "Wrappers.Option";
     }
+    String bytesToDafnySequence = "dafny.SeqOfBytes(%s)".formatted(dataSource);
     return """
     func () %s {
-        v := make([]interface{}, 0, len(input))
         if %s == nil {return %s}
-        for _, e := range %s {
-        	v = append(v, e)
-        }
         return %s;
     }()""".formatted(
         returnType,
         dataSource,
         nilWrapIfRequired,
-        dataSource,
-        someWrapIfRequired.formatted("dafny.SeqFromArray(v, false)")
+        someWrapIfRequired.formatted(bytesToDafnySequence)
       );
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Directly uses `dafny.SeqOfBytes` for to dafny byte conversion. This PR just reduces duplication as the to dafny implementation was a copy of `dafny.SeqOfBytes`. There is no memory optimization. 

Profiling data:
before:
```
ROUTINE ======================== github.com/aws/aws-encryption-sdk/releases/go/encryption-sdk/awscryptographyencryptionsdksmithygenerated.Aws_cryptography_encryptionSdk_DecryptInput_ciphertext_ToDafny in /Users/rishavkj/Documents/Storage/Team-Repos/private-aws-encryption-sdk-dafny-staging/encryption-sdk/awscryptographyencryptionsdksmithygenerated/to_dafny.go
         0   806.27MB (flat, cum) 59.51% of Total
         .          .    160:func Aws_cryptography_encryptionSdk_DecryptInput_ciphertext_ToDafny(input []byte) dafny.Sequence {
         .          .    161:   return func() dafny.Sequence {
         .          .    162:           v := make([]interface{}, 0, len(input))
         .          .    163:           if input == nil {
         .          .    164:                   return nil
         .          .    165:           }
         .          .    166:           for _, e := range input {
         .          .    167:                   v = append(v, e)
         .          .    168:           }
         .          .    169:           return dafny.SeqFromArray(v, false)
         .   806.27MB    170:   }()
         .          .    171:}
         .          .    172:
         .          .    173:func Aws_cryptography_encryptionSdk_DecryptInput_encryptionContext_ToDafny(input map[string]string) Wrappers.Option {
         .          .    174:   return func() Wrappers.Option {
         .          .    175:           fieldValue := dafny.NewMapBuilder()
ROUTINE ======================== github.com/aws/aws-encryption-sdk/releases/go/encryption-sdk/awscryptographyencryptionsdksmithygenerated.Aws_cryptography_encryptionSdk_DecryptInput_ciphertext_ToDafny.func1 in /Users/rishavkj/Documents/Storage/Team-Repos/private-aws-encryption-sdk-dafny-staging/encryption-sdk/awscryptographyencryptionsdksmithygenerated/to_dafny.go
  806.27MB   806.27MB (flat, cum) 59.51% of Total
         .          .    161:   return func() dafny.Sequence {
  806.27MB   806.27MB    162:           v := make([]interface{}, 0, len(input))
         .          .    163:           if input == nil {
         .          .    164:                   return nil
         .          .    165:           }
         .          .    166:           for _, e := range input {
         .          .    167:                   v = append(v, e)
```
after (no changes):
```
ROUTINE ======================== github.com/aws/aws-encryption-sdk/releases/go/encryption-sdk/awscryptographyencryptionsdksmithygenerated.Aws_cryptography_encryptionSdk_DecryptInput_ciphertext_ToDafny in /Users/rishavkj/Documents/Storage/Team-Repos/private-aws-encryption-sdk-dafny-staging/encryption-sdk/awscryptographyencryptionsdksmithygenerated/to_dafny.go
         0   806.27MB (flat, cum) 86.82% of Total
         .          .    160:func Aws_cryptography_encryptionSdk_DecryptInput_ciphertext_ToDafny(input []byte) dafny.Sequence {
         .          .    161:   if input == nil {
         .          .    162:           return nil
         .          .    163:   }
         .   806.27MB    164:   return dafny.SeqOfBytes(input)
         .          .    165:}
         .          .    166:
         .          .    167:func Aws_cryptography_encryptionSdk_DecryptInput_encryptionContext_ToDafny(input map[string]string) Wrappers.Option {
         .          .    168:   return func() Wrappers.Option {
         .          .    169:           fieldValue := dafny.NewMapBuilder()
```

Test bump in MPL: https://github.com/aws/aws-cryptographic-material-providers-library/pull/1706

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
