### PR TITLE
[Python] Fix #816: Handle Dafny 4.11's escaping of reserved names

### DIFF
--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithypython/common/nameresolver/DafnyNameResolver.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithypython/common/nameresolver/DafnyNameResolver.java
@@ -72,7 +72,27 @@ public class DafnyNameResolver {
       "try",
       "while",
       "with",
-      "yield"
+      "yield",
+      // Built-in functions (https://docs.python.org/3/library/functions.html)
+      "abs", "aiter", "all", "anext", "any", "ascii",
+      "bin", "bool", "breakpoint", "bytearray", "bytes"
+      "callable", "chr", "classmethod", "compile", "complex",
+      "delattr", "dict", "dir", "divmod",
+      "enumerate", "eval", "exec",
+      "filter", "float", "format", "frozenset",
+      "getattr", "globals",
+      "hasattr", "hash", "help", "hex",
+      "id", "input", "int", "isinstance", "issubclass", "iter",
+      "len", "list", "locals",
+      "map", "max", "memoryview", "min",
+      "next",
+      "object", "oct", "open", "ord",
+      "pow", "print", "property",
+      "range", "repr", "reversed", "round",
+      "set", "setattr", "slice", "sorted", "staticmethod", "str", "sum", "super",
+      "tuple", "type",
+      "vars",
+      "zip"
     )
   );
 

--- a/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithypython/common/nameresolver/DafnyNameResolver.java
+++ b/codegen/smithy-dafny-codegen/src/main/java/software/amazon/polymorph/smithypython/common/nameresolver/DafnyNameResolver.java
@@ -75,7 +75,7 @@ public class DafnyNameResolver {
       "yield",
       // Built-in functions (https://docs.python.org/3/library/functions.html)
       "abs", "aiter", "all", "anext", "any", "ascii",
-      "bin", "bool", "breakpoint", "bytearray", "bytes"
+      "bin", "bool", "breakpoint", "bytearray", "bytes",
       "callable", "chr", "classmethod", "compile", "complex",
       "delattr", "dict", "dir", "divmod",
       "enumerate", "eval", "exec",


### PR DESCRIPTION
*Issue #, if available:* #816 

*Description of changes:* `dafnyReservedNames` in `DafnyNameResolver.java` now includes all Python built-in functions as described [here](https://docs.python.org/3/library/functions.html).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
