### PR TITLE
Optimize DafnySequence<Character> to String

### DIFF
--- a/smithy-dafny-conversion/src/main/java/software/amazon/smithy/dafny/conversion/ToNative.java
+++ b/smithy-dafny-conversion/src/main/java/software/amazon/smithy/dafny/conversion/ToNative.java
@@ -64,7 +64,7 @@ public class ToNative {
     ) {
       StringBuilder sb = new StringBuilder();
       for (char c : dafnySequence) {
-          sb.append(c);
+        sb.append(c);
       }
       return sb.toString();
     }

--- a/smithy-dafny-conversion/src/main/java/software/amazon/smithy/dafny/conversion/ToNative.java
+++ b/smithy-dafny-conversion/src/main/java/software/amazon/smithy/dafny/conversion/ToNative.java
@@ -62,11 +62,11 @@ public class ToNative {
     public static String String(
       DafnySequence<? extends Character> dafnySequence
     ) {
-      Stream<? extends Character> chars = StreamSupport.stream(
-        dafnySequence.spliterator(),
-        false
-      );
-      return chars.map(Object::toString).collect(Collectors.joining());
+      StringBuilder sb = new StringBuilder();
+      for (char c : dafnySequence) {
+          sb.append(c);
+      }
+      return sb.toString();
     }
 
     /**


### PR DESCRIPTION
Optimize performance of `ToNative$Simple.String`. I saw in an allocation profile of my application that this code is creating a lot of garbage, principally from calling `Character.toString` on every element, which creates a whole `String` object and backing `byte[]`. The `Stream` is wasteful too.

Move to a `StringBuilder` and for loop. A very rough benchmark shows about 80% reduction in allocations and total time taken.

Small string (4 chars):
| | Time | Allocation |
|---------|------|-------|
| Baseline | 159 ns/op | 608 bytes/op |
| Optimized | 37 ns/op | 96 bytes/op |

Larger string (88 chars):
| | Time | Allocation |
|---------|------|-------|
| Baseline | 2079 ns/op | 5360 bytes/op |
| Optimized | 419 ns/op | 816 bytes/op |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
