### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,6 +4,9 @@ name: Java Format Check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check-java:
     runs-on: ubuntu-22.04

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   manual-ci-verification:
     uses: ./.github/workflows/test_models_dafny_verification.yml

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -10,6 +10,9 @@ on:
     # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
     - cron: "30 16 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   dafny-nightly-verification:
     # Don't run the cron builds on forks

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -4,6 +4,9 @@ name: PR CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pr-populate-dafny-versions:
     runs-on: ubuntu-22.04

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main-1.x
 
+permissions:
+  contents: read
+
 jobs:
   pr-populate-dafny-versions:
     runs-on: ubuntu-22.04

--- a/.github/workflows/smithy-dafny-conversion.yml
+++ b/.github/workflows/smithy-dafny-conversion.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main-1.x
 
+permissions:
+  contents: read
+
 jobs:
   gradle-build-smithy-dafny-conversion:
     runs-on: ubuntu-22.04

--- a/.github/workflows/smithy-polymorph.yml
+++ b/.github/workflows/smithy-polymorph.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main-1.x
 
+permissions:
+  contents: read
+
 jobs:
   gradle-build-smithy-dafny:
     strategy:

--- a/.github/workflows/test_models_dafny_verification.yml
+++ b/.github/workflows/test_models_dafny_verification.yml
@@ -13,6 +13,9 @@ on:
         type: number
         default: 10
 
+permissions:
+  contents: read
+
 jobs:
   populate-matrix-dimensions:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.